### PR TITLE
chore: add .envrc to .gitignore & fix TS error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Environment
+.envrc

--- a/store/analysisHistorySlice.ts
+++ b/store/analysisHistorySlice.ts
@@ -7,7 +7,7 @@ export interface AnalysisHistorySlice {
     saveAnalysisHistory: (newResult: AnalysisResult) => Promise<void>;
 }
 
-export const createAnalysisHistorySlice: StateCreator<AnalysisHistorySlice> = (set, get) => ({
+export const createAnalysisHistorySlice = (set, get): AnalysisHistorySlice => ({
     analysisHistory: [],
     loadAnalysisHistory: async () => {
         try {


### PR DESCRIPTION
## Summary
- `.envrc`（GCP direnv設定）を`.gitignore`に追加
- `analysisHistorySlice`の既存TypeScriptエラー（TS2554）を修正

## Test plan
- [x] `npm run lint`（tsc --noEmit）パス確認済み
- [ ] `npm run build` でビルド確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)