### PR TITLE
fix: Cloud Run startup failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,20 +5,21 @@ COPY package*.json ./
 RUN npm ci
 
 COPY . .
-RUN npm run build
+RUN npx vite build
 
 FROM node:22-slim AS runner
 
 WORKDIR /app
 COPY package*.json ./
-RUN npm ci --omit=dev
+RUN npm ci
 
 COPY --from=builder /app/dist ./dist
-COPY --from=builder /app/dist-server ./dist-server
+COPY server ./server
+COPY types.ts ./types.ts
 
 ENV NODE_ENV=production
 ENV USE_VERTEX_AI=true
 ENV PORT=8080
 
 EXPOSE 8080
-CMD ["node", "dist-server/server/index.js"]
+CMD ["npx", "tsx", "server/index.ts"]

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "tsx server/index.ts",
-    "build": "vite build && tsc -p tsconfig.server.json",
-    "start": "node dist-server/server/index.js",
+    "build": "vite build",
+    "start": "tsx server/index.ts",
     "lint": "tsc --noEmit",
     "preview": "vite preview"
   },

--- a/server/index.ts
+++ b/server/index.ts
@@ -43,7 +43,7 @@ async function startServer() {
     } else {
         const distPath = path.join(process.cwd(), 'dist');
         app.use(express.static(distPath));
-        app.get('*', (_req, res) => {
+        app.get('/{*path}', (_req, res) => {
             res.sendFile(path.join(distPath, 'index.html'));
         });
     }


### PR DESCRIPTION
## Summary
- tsx使用でESMモジュール解決問題を回避
- Express 5のワイルドカードルート構文を修正（`*` → `/{*path}`）

## Test plan
- [x] `npm run lint` パス
- [x] ローカル `NODE_ENV=production PORT=8080` で `/health` 応答確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)