### PR TITLE
feat: Firestore移行（localStorage → Firestore）

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -17,11 +17,13 @@ import { ProjectSelectionScreen } from './components/ProjectSelectionScreen';
 import { Toast } from './components/Toast';
 import { TutorialModeSelectionModal } from './components/TutorialModeSelectionModal';
 import AppMobile from './App.mobile';
+import { useFirestoreSync } from './hooks/useFirestoreSync';
 
 import { useShallow } from 'zustand/react/shallow';
 import { EMPTY_ARRAY } from './constants';
 
 export default function App() {
+    const { isInitializing, error: syncError } = useFirestoreSync();
     // --- Zustand Store Selectors ---
     const activeProjectId = useStore(state => state.activeProjectId);
     const allProjectsData = useStore(state => state.allProjectsData);
@@ -181,6 +183,12 @@ export default function App() {
         link.click();
         URL.revokeObjectURL(link.href);
     };
+
+    if (isInitializing) {
+        return <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100vh', fontFamily: 'sans-serif' }}>
+            <p>読み込み中...</p>
+        </div>;
+    }
 
     if (!activeProjectId || !activeProjectData) {
         return <ProjectSelectionScreen 

--- a/hooks/useFirestoreSync.ts
+++ b/hooks/useFirestoreSync.ts
@@ -1,0 +1,81 @@
+import { useEffect, useState } from 'react';
+import { useStore } from '../store/index';
+import { listProjects, getProject, createProjectApi } from '../projectApi';
+
+export const useFirestoreSync = () => {
+    const [isInitializing, setIsInitializing] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const activeProjectId = useStore(state => state.activeProjectId);
+    const flushSave = useStore(state => state.flushSave);
+
+    // Initial load: migrate localStorage then fetch from Firestore
+    useEffect(() => {
+        const init = async () => {
+            try {
+                // Step 1: Migrate localStorage data if it exists
+                const stored = localStorage.getItem('NOVEL_WRITER_storage');
+                if (stored) {
+                    try {
+                        const parsed = JSON.parse(stored);
+                        const state = parsed?.state;
+                        if (state?.allProjectsData) {
+                            const projects = Object.values(state.allProjectsData) as any[];
+                            await Promise.all(projects.map(p => createProjectApi(p)));
+                            localStorage.removeItem('NOVEL_WRITER_storage');
+                            console.log(`Migrated ${projects.length} projects to Firestore`);
+                        }
+                    } catch (e) {
+                        console.error('localStorage migration failed:', e);
+                    }
+                }
+
+                // Step 2: Load project list from Firestore
+                const projectList = await listProjects();
+                if (projectList.length > 0) {
+                    // Fetch all projects
+                    const projects = await Promise.all(
+                        projectList.map(p => getProject(p.id))
+                    );
+                    const allProjectsData: Record<string, any> = {};
+                    for (const p of projects) {
+                        if (p) allProjectsData[p.id] = p;
+                    }
+                    useStore.setState({
+                        allProjectsData,
+                        activeProjectId: useStore.getState().activeProjectId || projectList[0].id,
+                    });
+                }
+            } catch (e: any) {
+                console.error('Firestore init failed:', e);
+                setError(e.message);
+            } finally {
+                setIsInitializing(false);
+            }
+        };
+        init();
+    }, []);
+
+    // Flush on beforeunload and visibilitychange
+    useEffect(() => {
+        const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+            const status = useStore.getState().saveStatus;
+            if (status === 'dirty' || status === 'saving') {
+                flushSave();
+                e.preventDefault();
+            }
+        };
+        const handleVisibilityChange = () => {
+            if (document.visibilityState === 'hidden') {
+                flushSave();
+            }
+        };
+        window.addEventListener('beforeunload', handleBeforeUnload);
+        document.addEventListener('visibilitychange', handleVisibilityChange);
+        return () => {
+            window.removeEventListener('beforeunload', handleBeforeUnload);
+            document.removeEventListener('visibilitychange', handleVisibilityChange);
+        };
+    }, [flushSave]);
+
+    return { isInitializing, error };
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
+        "@google-cloud/firestore": "^8.3.0",
         "@google/genai": "^1.23.0",
         "express": "^5.2.1",
         "fs": "^0.0.1-security",
@@ -811,6 +812,22 @@
         "node": ">=18"
       }
     },
+    "node_modules/@google-cloud/firestore": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-8.3.0.tgz",
+      "integrity": "sha512-OYadXaHxx8J5GQtCwDNjaVu2+O9Ozdst4Iqi+vDTI/WmLTO56XX3QBOXp4T+qh3tyQzl9YzDBrmA7o8n1xTouA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "fast-deep-equal": "^3.1.3",
+        "functional-red-black-tree": "^1.0.1",
+        "google-gax": "^5.0.1",
+        "protobufjs": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@google/genai": {
       "version": "1.44.0",
       "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.44.0.tgz",
@@ -832,6 +849,37 @@
         "@modelcontextprotocol/sdk": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
+      "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.8.0",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.0.tgz",
+      "integrity": "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.3",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -899,6 +947,25 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -1857,6 +1924,93 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -2113,6 +2267,18 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/duplexify": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
+      "integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.2"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -2154,6 +2320,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/entities": {
@@ -2244,7 +2419,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -2322,6 +2496,12 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
     "node_modules/fdir": {
@@ -2462,6 +2642,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
+      "license": "MIT"
+    },
     "node_modules/gaxios": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.3.tgz",
@@ -2499,6 +2685,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -2584,6 +2779,28 @@
         "gcp-metadata": "8.1.2",
         "google-logging-utils": "1.1.3",
         "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-gax": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-5.0.6.tgz",
+      "integrity": "sha512-1kGbqVQBZPAAu4+/R1XxPQKP0ydbNYoLAr4l0ZO2bMV0kLyLW4I1gAk++qBLWt7DPORTzmWRMsCZe86gDjShJA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.12.6",
+        "@grpc/proto-loader": "^0.8.0",
+        "duplexify": "^4.1.3",
+        "google-auth-library": "^10.1.0",
+        "google-logging-utils": "^1.1.1",
+        "node-fetch": "^3.3.2",
+        "object-hash": "^3.0.0",
+        "proto3-json-serializer": "^3.0.0",
+        "protobufjs": "^7.5.3",
+        "retry-request": "^8.0.0",
+        "rimraf": "^5.0.1"
       },
       "engines": {
         "node": ">=18"
@@ -2775,6 +2992,19 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
@@ -2979,6 +3209,12 @@
         "jwa": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
     },
     "node_modules/long": {
       "version": "5.3.2",
@@ -3780,6 +4016,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -3996,6 +4241,18 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/proto3-json-serializer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-3.0.4.tgz",
+      "integrity": "sha512-E1sbAYg3aEbXrq0n1ojJkRHQJGE1kaE/O6GLA94y8rnJBfgvOPTOd1b9hOceQK1FFZI9qMh1vBERCyO2ifubcw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "protobufjs": "^7.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/protobufjs": {
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
@@ -4172,6 +4429,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/remark-parse": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
@@ -4205,6 +4476,15 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -4222,6 +4502,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/retry-request": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-8.0.2.tgz",
+      "integrity": "sha512-JzFPAfklk1kjR1w76f0QOIhoDkNkSqW8wYKT08n9yysTmZfB+RQ2QoXoTAeOi1HD9ZipTyTAZg3c4pM/jeqgSw==",
+      "license": "MIT",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "teeny-request": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/rimraf": {
@@ -4527,6 +4820,30 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/stream-events": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
+      "integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
+      "license": "MIT",
+      "dependencies": {
+        "stubs": "^3.0.0"
+      }
+    },
+    "node_modules/stream-shift": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
+      "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
+      "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/string-width": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
@@ -4637,6 +4954,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/stubs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
+      "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==",
+      "license": "MIT"
+    },
     "node_modules/style-to-js": {
       "version": "1.1.21",
       "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
@@ -4653,6 +4976,21 @@
       "license": "MIT",
       "dependencies": {
         "inline-style-parser": "0.2.7"
+      }
+    },
+    "node_modules/teeny-request": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-10.1.2.tgz",
+      "integrity": "sha512-Xj0ZAQ0CeuQn6UxCDPLbFRlgcSTUEyO3+wiepr2grjIjyL/lMMs1Z4OwXn8kLvn/V1OuaEP0UY7Na6UDNNsYrQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2",
+        "stream-events": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tinyglobby": {
@@ -5381,6 +5719,12 @@
         "inherits": "2.0.3"
       }
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
     "node_modules/uuid": {
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
@@ -5648,12 +5992,89 @@
         }
       }
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/zustand": {
       "version": "5.0.11",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@google-cloud/firestore": "^8.3.0",
     "@google/genai": "^1.23.0",
     "express": "^5.2.1",
     "fs": "^0.0.1-security",

--- a/projectApi.ts
+++ b/projectApi.ts
@@ -1,0 +1,30 @@
+import { Project } from './types';
+
+const BASE = '/api/projects';
+
+async function request<T>(url: string, options?: RequestInit): Promise<T> {
+    const res = await fetch(url, {
+        headers: { 'Content-Type': 'application/json' },
+        ...options,
+    });
+    const json = await res.json();
+    if (!res.ok || json.success === false) {
+        throw new Error(json.error || `HTTP ${res.status}`);
+    }
+    return json.data;
+}
+
+export const listProjects = () =>
+    request<Array<{ id: string; name: string; lastModified: string; isSimpleMode?: boolean }>>(`${BASE}`);
+
+export const getProject = (id: string) =>
+    request<Project>(`${BASE}/${id}`);
+
+export const createProjectApi = (project: Project) =>
+    request<void>(`${BASE}`, { method: 'POST', body: JSON.stringify(project) });
+
+export const updateProjectApi = (id: string, project: Project) =>
+    request<void>(`${BASE}/${id}`, { method: 'PUT', body: JSON.stringify(project) });
+
+export const deleteProjectApi = (id: string) =>
+    request<void>(`${BASE}/${id}`, { method: 'DELETE' });

--- a/server/firestoreClient.ts
+++ b/server/firestoreClient.ts
@@ -1,0 +1,13 @@
+import { Firestore } from '@google-cloud/firestore';
+
+let db: Firestore | null = null;
+
+export const getFirestore = (): Firestore => {
+    if (db) return db;
+    db = new Firestore({
+        projectId: process.env.GCP_PROJECT || 'novel-writer-dev',
+    });
+    return db;
+};
+
+export const projectsCollection = () => getFirestore().collection('projects');

--- a/server/index.ts
+++ b/server/index.ts
@@ -9,6 +9,7 @@ import imageRoutes from './routes/image';
 import utilityRoutes from './routes/utility';
 import analysisRoutes from './routes/analysis';
 import dataRoutes from './routes/data';
+import projectRoutes from './routes/projects';
 
 async function startServer() {
     const app = express();
@@ -28,6 +29,9 @@ async function startServer() {
     app.use('/api/ai/image', imageRoutes);
     app.use('/api/ai/utility', utilityRoutes);
     app.use('/api/ai/analysis', analysisRoutes);
+
+    // Project CRUD routes
+    app.use('/api/projects', projectRoutes);
 
     // Data routes (tutorial, analysis-history)
     app.use('/api', dataRoutes);

--- a/server/routes/projects.ts
+++ b/server/routes/projects.ts
@@ -1,0 +1,61 @@
+import { Router } from 'express';
+import * as projectService from '../services/projectService';
+import { handleApiError } from '../middleware/errorHandler';
+
+const router = Router();
+
+router.get('/', async (_req, res) => {
+    try {
+        const projects = await projectService.listProjects();
+        res.json({ success: true, data: projects });
+    } catch (error) {
+        const { status, message } = handleApiError(error, 'listProjects');
+        res.status(status).json({ success: false, error: message });
+    }
+});
+
+router.get('/:id', async (req, res) => {
+    try {
+        const project = await projectService.getProject(req.params.id);
+        if (!project) {
+            res.status(404).json({ success: false, error: 'Project not found' });
+            return;
+        }
+        res.json({ success: true, data: project });
+    } catch (error) {
+        const { status, message } = handleApiError(error, 'getProject');
+        res.status(status).json({ success: false, error: message });
+    }
+});
+
+router.post('/', async (req, res) => {
+    try {
+        await projectService.createProject(req.body);
+        res.status(201).json({ success: true });
+    } catch (error) {
+        const { status, message } = handleApiError(error, 'createProject');
+        res.status(status).json({ success: false, error: message });
+    }
+});
+
+router.put('/:id', async (req, res) => {
+    try {
+        await projectService.updateProject(req.params.id, req.body);
+        res.json({ success: true });
+    } catch (error) {
+        const { status, message } = handleApiError(error, 'updateProject');
+        res.status(status).json({ success: false, error: message });
+    }
+});
+
+router.delete('/:id', async (req, res) => {
+    try {
+        await projectService.deleteProject(req.params.id);
+        res.json({ success: true });
+    } catch (error) {
+        const { status, message } = handleApiError(error, 'deleteProject');
+        res.status(status).json({ success: false, error: message });
+    }
+});
+
+export default router;

--- a/server/services/projectService.ts
+++ b/server/services/projectService.ts
@@ -1,0 +1,49 @@
+import { projectsCollection } from '../firestoreClient';
+import { Project } from '../../types';
+
+function stripUndefined(obj: any): any {
+    if (obj === null || obj === undefined) return null;
+    if (Array.isArray(obj)) return obj.map(stripUndefined);
+    if (typeof obj === 'object') {
+        const result: any = {};
+        for (const [key, value] of Object.entries(obj)) {
+            if (value !== undefined) {
+                result[key] = stripUndefined(value);
+            }
+        }
+        return result;
+    }
+    return obj;
+}
+
+function stripHistoryTree(project: any): any {
+    const { historyTree, ...rest } = project;
+    return rest;
+}
+
+export const listProjects = async (): Promise<Array<{ id: string; name: string; lastModified: string; isSimpleMode?: boolean }>> => {
+    const snapshot = await projectsCollection()
+        .select('id', 'name', 'lastModified', 'isSimpleMode')
+        .get();
+    return snapshot.docs.map(doc => doc.data() as any);
+};
+
+export const getProject = async (id: string): Promise<Project | null> => {
+    const doc = await projectsCollection().doc(id).get();
+    if (!doc.exists) return null;
+    return doc.data() as Project;
+};
+
+export const createProject = async (project: Project): Promise<void> => {
+    const data = stripUndefined(stripHistoryTree(project));
+    await projectsCollection().doc(project.id).set(data);
+};
+
+export const updateProject = async (id: string, project: Project): Promise<void> => {
+    const data = stripUndefined(stripHistoryTree(project));
+    await projectsCollection().doc(id).set(data);
+};
+
+export const deleteProject = async (id: string): Promise<void> => {
+    await projectsCollection().doc(id).delete();
+};

--- a/store/dataSlice.ts
+++ b/store/dataSlice.ts
@@ -6,12 +6,10 @@ import { FONT_MAP } from '../constants';
 import * as analysisApi from '../analysisApi';
 
 const initialState = {
-    saveStatus: 'synced' as 'synced' | 'saving' | 'dirty',
     lastAnalysisResult: null as AnalysisResult | null,
 };
 
 export interface DataSlice {
-    saveStatus: 'synced' | 'saving' | 'dirty';
     lastAnalysisResult: AnalysisResult | null;
     setActiveProjectData: (updater: (data: Project) => Project, historyLabel?: { type: HistoryType; label: string }, options?: { mode: 'merge' | 'replace' }) => void;
     handleSaveSetting: (newItem: Partial<SettingItem | KnowledgeItem>, type?: 'character' | 'world' | 'knowledge') => void;
@@ -71,6 +69,8 @@ export const createDataSlice = (set, get): DataSlice => ({
         if (historyLabel) {
             addHistory(newProjectData, historyLabel);
         }
+
+        get().markDirty();
     },
     handleSaveSetting: (newItem, type) => {
         const { activeModal } = get();

--- a/store/index.ts
+++ b/store/index.ts
@@ -1,5 +1,4 @@
 import { create } from 'zustand';
-import { persist, createJSONStorage } from 'zustand/middleware';
 import { AppState, AppActions } from '../types';
 import { createProjectSlice, ProjectSlice } from './projectSlice';
 import { createUiSlice, UiSlice } from './uiSlice';
@@ -9,80 +8,19 @@ import { createHistorySlice, HistorySlice } from './historySlice';
 import { createTutorialSlice, TutorialSlice } from './tutorialSlice';
 import { createAnalysisHistorySlice, AnalysisHistorySlice } from './analysisHistorySlice';
 import { createFormSlice, FormSlice } from './formSlice';
+import { createSyncSlice, SyncSlice } from './syncSlice';
 
-// 容量制限エラーに対応するためのカスタムストレージラッパー
-const customStorage = {
-    getItem: (name: string) => localStorage.getItem(name),
-    setItem: (name: string, value: string) => {
-        try {
-            localStorage.setItem(name, value);
-        } catch (e) {
-            if (e instanceof DOMException && (e.name === 'QuotaExceededError' || e.name === 'NS_ERROR_DOM_QUOTA_REACHED')) {
-                console.error('LocalStorage quota exceeded. Reducing history and retrying...');
-                // ここで緊急のデータ削減ロジックを走らせることも可能
-                // ユーザーに警告を表示
-                alert('ブラウザの保存容量がいっぱいです。古いプロジェクトを削除するか、エクスポートして整理してください。');
-            } else {
-                throw e;
-            }
-        }
-    },
-    removeItem: (name: string) => localStorage.removeItem(name),
-};
-
-export const useStore = create<AppState & AppActions & ProjectSlice & UiSlice & DataSlice & AiSlice & HistorySlice & TutorialSlice & AnalysisHistorySlice & FormSlice>()(
-    persist(
-        (set, get, api) => ({
-            ...createProjectSlice(set, get),
-            ...createUiSlice(set, get),
-            ...createDataSlice(set, get),
-            ...createAiSlice(set, get),
-            ...createHistorySlice(set, get),
-            ...createTutorialSlice(set, get),
-            ...createAnalysisHistorySlice(set, get),
-            ...createFormSlice(set, get),
-            loadInitialState: () => {},
-        }),
-        {
-            name: 'NOVEL_WRITER_storage',
-            storage: createJSONStorage(() => customStorage),
-            partialize: (state) => {
-                // 各プロジェクト内の冗長な履歴データを削除してから保存
-                const projects = { ...state.allProjectsData };
-                Object.keys(projects).forEach(id => {
-                    if (projects[id]) {
-                        // プロジェクトオブジェクト内の historyTree はグローバル側にあるため間引く
-                        const { historyTree, ...rest } = projects[id] as any;
-                        // 非アクティブなプロジェクトからは chatHistory と novelContent も間引く
-                        if (id !== state.activeProjectId) {
-                            const { chatHistory, novelContent, ...restWithoutChat } = rest;
-                            projects[id] = restWithoutChat;
-                        } else {
-                            projects[id] = rest;
-                        }
-                    }
-                });
-
-                const dataToPersist = {
-                    allProjectsData: projects,
-                    activeProjectId: state.activeProjectId,
-                    isLeftSidebarOpen: state.isLeftSidebarOpen,
-                    isRightSidebarOpen: state.isRightSidebarOpen,
-                    leftSidebarWidth: state.leftSidebarWidth,
-                    rightSidebarWidth: state.rightSidebarWidth,
-                    isNewChunkInputOpen: state.isNewChunkInputOpen,
-                    userMode: state.userMode,
-                    undoScope: state.undoScope,
-                    historyTree: state.historyTree,
-                    pinnedSettingIds: state.pinnedSettingIds,
-                };
-                return dataToPersist;
-            },
-            onRehydrateStorage: () => (state, error) => {
-                if (error) {
-                    console.error('An error occurred during hydration:', error);
-                }
-            },
-        }
-    )
+export const useStore = create<AppState & AppActions & ProjectSlice & UiSlice & DataSlice & AiSlice & HistorySlice & TutorialSlice & AnalysisHistorySlice & FormSlice & SyncSlice>()(
+    (set, get, api) => ({
+        ...createProjectSlice(set, get),
+        ...createUiSlice(set, get),
+        ...createDataSlice(set, get),
+        ...createAiSlice(set, get),
+        ...createHistorySlice(set, get),
+        ...createTutorialSlice(set, get),
+        ...createAnalysisHistorySlice(set, get),
+        ...createFormSlice(set, get),
+        ...createSyncSlice(set, get),
+        loadInitialState: () => {},
+    })
 );

--- a/store/projectSlice.ts
+++ b/store/projectSlice.ts
@@ -4,6 +4,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { Project, AppState, AppActions, HistoryTree, HistoryNode } from '../types';
 import { defaultAiSettings, defaultDisplaySettings, simpleModeAiSettings, simpleModeDisplaySettings } from '../constants';
 import { validateAndSanitizeProjectData } from '../utils';
+import { createProjectApi, deleteProjectApi } from '../projectApi';
 
 const initialState = {
     allProjectsData: {} as { [key: string]: Project },
@@ -78,11 +79,12 @@ export const createProjectSlice = (set, get): ProjectSlice => ({
         const historyTree = createInitialHistoryTree(newProject);
         newProject.historyTree = historyTree;
         
-        set(state => ({ 
-            allProjectsData: { ...state.allProjectsData, [newId]: newProject }, 
+        set(state => ({
+            allProjectsData: { ...state.allProjectsData, [newId]: newProject },
             activeProjectId: newId,
             historyTree: historyTree,
         }));
+        createProjectApi(newProject).catch(err => console.error('Failed to save new project:', err));
     },
     deleteProject: (projectId) => {
         set(state => {
@@ -93,6 +95,7 @@ export const createProjectSlice = (set, get): ProjectSlice => ({
                 activeProjectId: state.activeProjectId === projectId ? null : state.activeProjectId
             };
         });
+        deleteProjectApi(projectId).catch(err => console.error('Failed to delete project:', err));
     },
     importProject: (event) => {
         const file = event.target.files[0];
@@ -115,6 +118,7 @@ export const createProjectSlice = (set, get): ProjectSlice => ({
                         historyTree: historyTree,
                     };
                 });
+                createProjectApi(projectToLoad).catch(err => console.error('Failed to save imported project:', err));
             } catch (err) {
                 alert(`ファイルの読み込みに失敗しました: ${err.message}`);
                 console.error(err);

--- a/store/syncSlice.ts
+++ b/store/syncSlice.ts
@@ -1,0 +1,44 @@
+import { updateProjectApi } from '../projectApi';
+
+export interface SyncSlice {
+    saveStatus: 'synced' | 'saving' | 'dirty' | 'error';
+    lastSyncError: string | null;
+    _saveTimer: ReturnType<typeof setTimeout> | null;
+    markDirty: () => void;
+    flushSave: () => Promise<void>;
+}
+
+export const createSyncSlice = (set, get): SyncSlice => ({
+    saveStatus: 'synced',
+    lastSyncError: null,
+    _saveTimer: null,
+
+    markDirty: () => {
+        const { _saveTimer } = get();
+        if (_saveTimer) clearTimeout(_saveTimer);
+
+        const timer = setTimeout(() => {
+            get().flushSave();
+        }, 2000);
+
+        set({ saveStatus: 'dirty' as const, _saveTimer: timer });
+    },
+
+    flushSave: async () => {
+        const { activeProjectId, allProjectsData, _saveTimer, saveStatus } = get();
+        if (_saveTimer) clearTimeout(_saveTimer);
+        if (!activeProjectId || !allProjectsData[activeProjectId]) return;
+        if (saveStatus === 'saving') return;
+
+        set({ saveStatus: 'saving' as const, _saveTimer: null });
+
+        try {
+            const project = allProjectsData[activeProjectId];
+            await updateProjectApi(activeProjectId, project);
+            set({ saveStatus: 'synced' as const, lastSyncError: null });
+        } catch (error: any) {
+            console.error('Failed to save project:', error);
+            set({ saveStatus: 'error' as const, lastSyncError: error.message });
+        }
+    },
+});

--- a/types.ts
+++ b/types.ts
@@ -201,7 +201,7 @@ export interface AppState {
     highlightedChunkId: string | null;
     projectTitle: string;
     editingChunkId: string | null;
-    saveStatus: 'synced' | 'saving' | 'dirty';
+    saveStatus: 'synced' | 'saving' | 'dirty' | 'error';
     isImageGenerating: boolean;
     leftPanelTab: LeftPanelTab;
     floatingWindows: FloatingWindow[];


### PR DESCRIPTION
## Summary
- localStorage永続化をFirestore（Cloud Native）に移行
- 2秒デバウンスの自動保存（syncSlice）
- 初回ロード時にlocalStorageからFirestoreへ自動マイグレーション
- プロジェクトCRUD API追加（/api/projects）

## GCP Infrastructure
- [x] Firestore API有効化
- [x] Firestoreデータベース作成（asia-northeast1, Native mode）
- [x] Cloud Run SA に roles/datastore.user 付与

## Test plan
- [x] `npm run lint` パス
- [x] `npm run build` パス
- [ ] ローカル動作確認（プロジェクト作成→リロード→データ残存）
- [ ] Cloud Runデプロイ後の動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)