### PR TITLE
fix: Firestore 1MB制限超過対応

### DIFF
--- a/server/services/projectService.ts
+++ b/server/services/projectService.ts
@@ -1,4 +1,4 @@
-import { projectsCollection } from '../firestoreClient';
+import { projectsCollection, getFirestore } from '../firestoreClient';
 import { Project } from '../../types';
 
 function stripUndefined(obj: any): any {
@@ -16,9 +16,13 @@ function stripUndefined(obj: any): any {
     return obj;
 }
 
-function stripHistoryTree(project: any): any {
-    const { historyTree, ...rest } = project;
-    return rest;
+function splitProject(project: any) {
+    const { historyTree, novelContent, chatHistory, ...meta } = project;
+    return {
+        meta: stripUndefined(meta),
+        novelContent: (novelContent || []).map(stripUndefined),
+        chatHistory: (chatHistory || []).map(stripUndefined),
+    };
 }
 
 export const listProjects = async (): Promise<Array<{ id: string; name: string; lastModified: string; isSimpleMode?: boolean }>> => {
@@ -29,21 +33,96 @@ export const listProjects = async (): Promise<Array<{ id: string; name: string; 
 };
 
 export const getProject = async (id: string): Promise<Project | null> => {
-    const doc = await projectsCollection().doc(id).get();
+    const docRef = projectsCollection().doc(id);
+    const doc = await docRef.get();
     if (!doc.exists) return null;
-    return doc.data() as Project;
+
+    const meta = doc.data() as any;
+
+    // Read subcollections
+    const [chunksSnap, chatSnap] = await Promise.all([
+        docRef.collection('chunks').orderBy('_order').get(),
+        docRef.collection('chatHistory').orderBy('_order').get(),
+    ]);
+
+    meta.novelContent = chunksSnap.docs.map(d => {
+        const { _order, ...rest } = d.data();
+        return rest;
+    });
+    meta.chatHistory = chatSnap.docs.map(d => {
+        const { _order, ...rest } = d.data();
+        return rest;
+    });
+
+    return meta as Project;
 };
 
 export const createProject = async (project: Project): Promise<void> => {
-    const data = stripUndefined(stripHistoryTree(project));
-    await projectsCollection().doc(project.id).set(data);
+    await saveProject(project);
 };
 
 export const updateProject = async (id: string, project: Project): Promise<void> => {
-    const data = stripUndefined(stripHistoryTree(project));
-    await projectsCollection().doc(id).set(data);
+    await saveProject(project);
 };
 
+async function saveProject(project: Project): Promise<void> {
+    const { meta, novelContent, chatHistory } = splitProject(project);
+    const db = getFirestore();
+    const docRef = projectsCollection().doc(project.id);
+
+    // Write main document (without novelContent/chatHistory)
+    await docRef.set(meta);
+
+    // Write subcollections (delete old, write new)
+    await replaceSubcollection(docRef, 'chunks', novelContent);
+    await replaceSubcollection(docRef, 'chatHistory', chatHistory);
+}
+
+async function replaceSubcollection(
+    docRef: FirebaseFirestore.DocumentReference,
+    name: string,
+    items: any[]
+): Promise<void> {
+    const db = getFirestore();
+    const collRef = docRef.collection(name);
+
+    // Delete existing docs
+    const existing = await collRef.listDocuments();
+    if (existing.length > 0) {
+        const deleteBatch = db.batch();
+        for (const doc of existing) {
+            deleteBatch.delete(doc);
+        }
+        await deleteBatch.commit();
+    }
+
+    // Write new docs in batches of 400 (Firestore limit is 500 per batch)
+    for (let i = 0; i < items.length; i += 400) {
+        const writeBatch = db.batch();
+        const slice = items.slice(i, i + 400);
+        for (let j = 0; j < slice.length; j++) {
+            const docId = String(i + j).padStart(6, '0');
+            writeBatch.set(collRef.doc(docId), { ...slice[j], _order: i + j });
+        }
+        await writeBatch.commit();
+    }
+}
+
 export const deleteProject = async (id: string): Promise<void> => {
-    await projectsCollection().doc(id).delete();
+    const db = getFirestore();
+    const docRef = projectsCollection().doc(id);
+
+    // Delete subcollections first
+    for (const subName of ['chunks', 'chatHistory']) {
+        const docs = await docRef.collection(subName).listDocuments();
+        if (docs.length > 0) {
+            const batch = db.batch();
+            for (const doc of docs) {
+                batch.delete(doc);
+            }
+            await batch.commit();
+        }
+    }
+
+    await docRef.delete();
 };


### PR DESCRIPTION
## Summary
インポートしたプロジェクト(1.75MB)がFirestoreの1MBドキュメント制限を超えて保存失敗していた。

`novelContent`と`chatHistory`をサブコレクションに分離:
- `/projects/{id}/chunks/{order}` 
- `/projects/{id}/chatHistory/{order}`

## Test plan
- [x] `npm run lint` パス
- [ ] 大きなプロジェクトのインポート→保存→リロード確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)