### PR TITLE
fix: ヘルプナレッジ削除後の再追加を防止

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -123,8 +123,11 @@ export default function App() {
         
         const { handleSaveSetting } = useStore.getState();
         const existingKnowledge = activeProjectData.knowledgeBase || [];
-        
-        // 追加するヘルプ項目
+
+        // ヘルプ項目は初回（ナレッジが空の場合）のみ自動追加
+        // 削除後に再追加されるのを防ぐため、1件でも存在すればスキップ
+        if (existingKnowledge.length > 0) return;
+
         const helpKnowledgeItems = Object.entries(helpTexts).map(([key, modes]) => {
             const content = Object.entries(modes).map(([mode, content]) => {
                 return `【${mode}モード】\nタイトル: ${content.title}\n説明: ${content.desc}${content.shortcut ? `\nショートカット: ${content.shortcut}` : ''}${content.tech ? `\n技術: ${content.tech}` : ''}\n`;
@@ -136,13 +139,10 @@ export default function App() {
             };
         });
 
-        // すでに存在するかチェックして追加
         helpKnowledgeItems.forEach(item => {
-            if (!existingKnowledge.find(k => k.name === item.name)) {
-                handleSaveSetting(item, 'knowledge');
-            }
+            handleSaveSetting(item, 'knowledge');
         });
-    }, [activeProjectId, activeProjectData]);
+    }, [activeProjectId]);
 
     // Handle knowledge link clicks globally
     useEffect(() => {


### PR DESCRIPTION
## Summary
ヘルプナレッジを削除しても即座に再追加される問題を修正。

原因: `useEffect`が`activeProjectData`変更のたびに発火し、
削除されたヘルプ項目を「存在しない」と判定して再追加していた。

修正: ヘルプ自動追加はナレッジが空（初回作成時）のみ実行。

## Test plan
- [x] `npm run lint` パス
- [ ] ナレッジ「ヘルプ: テキスト解析」を削除→消えたままであること

🤖 Generated with [Claude Code](https://claude.com/claude-code)