### PR TITLE
docs(m1): finalize M1 completion (status / retro / final checkboxes)

### DIFF
--- a/docs/adr/0001-local-first-architecture.md
+++ b/docs/adr/0001-local-first-architecture.md
@@ -102,7 +102,7 @@
 
 ## M1 振り返り（2026-04-26）
 
-3 PR (#17 PR-A, #18 PR-B, #19 PR-C) 全て計画通り逐次マージ完了。所要時間は計画値（合計 4 〜 6 時間）に対し実績ほぼ一致。
+3 PR (#17 PR-A, #18 PR-B, #19 PR-C) 全て計画通り逐次マージ完了。実作業時間として計画値（合計 4 〜 6 時間）に対し実績ほぼ一致（カレンダー時間ではなく純粋な作業時間ベースの主観評価）。
 
 **うまくいった点:**
 
@@ -113,5 +113,9 @@
 **課題・M3 以降への申し送り:**
 
 - 自動テスト未整備のため、AC 検証は手動 curl/手動操作中心。M3（認証ゲート本実装）から契約テスト + ルール unit テストの導入を本格検討
-- PR-C の admin SDK スタブには「prod で `applicationDefault()` 失敗時の logError 統合」「prod で projectId env 必須化」「`__resetFirebaseAdminAppForTesting()` 露出検討」を後回しにしている。M3 で routes に組み込むタイミングで一括対応する（PR #19 コメントに引き継ぎ事項として記録済み）
-- GitHub Actions の各 action が Node 20 ベース。2026-06-02 から Node 24 強制、2026-09-16 廃止予定。M2 着手前後で `actions/checkout@v5` 等の major 追従を一括実施する
+- PR-C の admin SDK スタブには次の 4 項目を後回しにしている。M3 で routes に組み込むタイミングで一括対応する（PR #19 コメントに引き継ぎ事項として記録済み）:
+  1. prod で `applicationDefault()` 失敗時の `logError` 統合（errorIds.ts 連携）
+  2. prod で `projectId` env 未設定時の fail-fast（dev fallback の段階的廃止）
+  3. test スクリプトの Anonymous プロバイダ未許可エラー時の具体メッセージ化（`auth/admin-restricted-operation` 検出時）
+  4. テスト用 `__resetFirebaseAdminAppForTesting()` の露出検討（NODE_ENV ガード付き）
+- GitHub Actions の各 action が Node 20 ベース。**廃止予定日は暫定**（公式 [GitHub blog (2025-09-19)](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) は "fall of 2026" と曖昧表現、PR #17 のデプロイログ由来で `2026-06-02` 強制 / `2026-09-16` 廃止と推定）。M2 着手前後で公式状況を再確認のうえ `actions/checkout@v5` 等の major 追従を一括実施する

--- a/docs/adr/0001-local-first-architecture.md
+++ b/docs/adr/0001-local-first-architecture.md
@@ -83,7 +83,7 @@
 | マイルストーン | 内容 | 状態 |
 |---|---|---|
 | M0 | 緊急対応（Cloud Run 非公開化、max-instances 制限、予算アラート） | ✅ 完了（2026-04-25） |
-| M1 | 基盤整備（IaC 化、防御層、Firebase 準備） | 🚧 着手中 |
+| M1 | 基盤整備（IaC 化、防御層、Firebase 準備） | ✅ 完了（2026-04-26） |
 | M2 | 認証 + IndexedDB 移行 | ⏳ |
 | M3 | AI 認証ゲート + クォータ | ⏳ |
 | M4 | Export/Import + バックアップ警告 UI | ⏳ |
@@ -99,3 +99,19 @@
 - Codex security review: 2026-04-25, threadId 019dc4f1-1fbe-7ba1-91d9-d5c049871861
 - アーキテクチャ図: `docs/diagrams/architecture-target.html`
 - 現状アーキテクチャ図: `docs/diagrams/architecture.html`
+
+## M1 振り返り（2026-04-26）
+
+3 PR (#17 PR-A, #18 PR-B, #19 PR-C) 全て計画通り逐次マージ完了。所要時間は計画値（合計 4 〜 6 時間）に対し実績ほぼ一致。
+
+**うまくいった点:**
+
+- ADR + tasks.md でスペックを先に固めたため、各 PR の AC が明確で「完了とは何か」のブレが出なかった
+- PR-B でマルチエージェントレビューが silent failure を 3 件検出（H1 maskError ガード / H2 CORS reject 漏洩 / H3 Vertex AI エラー素通し）→ 同 PR 内で修正でき、後追い PR を発生させずに済んだ
+- PR-C で `_setup-emulator-env.ts` を副作用 import に分離する設計を、レビュー反映の段階で取り入れた（M3 で firebaseAdmin.ts top-level に env 依存が入っても hoisting で壊れない構造）
+
+**課題・M3 以降への申し送り:**
+
+- 自動テスト未整備のため、AC 検証は手動 curl/手動操作中心。M3（認証ゲート本実装）から契約テスト + ルール unit テストの導入を本格検討
+- PR-C の admin SDK スタブには「prod で `applicationDefault()` 失敗時の logError 統合」「prod で projectId env 必須化」「`__resetFirebaseAdminAppForTesting()` 露出検討」を後回しにしている。M3 で routes に組み込むタイミングで一括対応する（PR #19 コメントに引き継ぎ事項として記録済み）
+- GitHub Actions の各 action が Node 20 ベース。2026-06-02 から Node 24 強制、2026-09-16 廃止予定。M2 着手前後で `actions/checkout@v5` 等の major 追従を一括実施する

--- a/docs/spec/m1/tasks.md
+++ b/docs/spec/m1/tasks.md
@@ -1,8 +1,9 @@
 # M1: 基盤整備 タスク表
 
-- Status: 🚧 In Progress
+- Status: ✅ Completed
 - Owner: yasushi-honda
 - Started: 2026-04-25
+- Completed: 2026-04-26
 - Related ADR: [ADR-0001](../../adr/0001-local-first-architecture.md)
 
 ## ゴール
@@ -167,9 +168,9 @@ M3（AI 認証ゲート）の前段階として、Firebase Auth/Admin SDK と Em
 
 - [x] PR-A merged & deployed & AC A1〜A3 全 PASS（2026-04-25 完了、PR #17）
 - [x] PR-B merged & local検証完了 & AC B1〜B7 全 PASS（2026-04-25 完了、PR #18）
-- [x] PR-C local検証完了 & AC C1〜C3 全 PASS（2026-04-26 完了、merge 待ち PR #19）
-- [ ] 本ファイル `docs/spec/m1/tasks.md` の全チェックボックスが `[x]`
-- [ ] M1 振り返りを ADR 末尾に追記（任意）
+- [x] PR-C merged & local検証完了 & AC C1〜C3 全 PASS（2026-04-26 完了、PR #19）
+- [x] 本ファイル `docs/spec/m1/tasks.md` の全チェックボックスが `[x]`
+- [x] M1 振り返りを ADR 末尾に追記（任意）
 
 ## M1 後フォローアップ（M1 完了後に対応、Issue 化はしない）
 


### PR DESCRIPTION
## Summary

PR #19 マージにより M1 完了 (#17 PR-A / #18 PR-B / #19 PR-C 全完了)。
本 PR は最終仕上げのドキュメント更新のみ、コード変更なし。

- `docs/spec/m1/tasks.md`: Status を ✅ Completed、`M1 完了の定義` の残 2 項目を `[x]`
- `docs/adr/0001-local-first-architecture.md`: マイルストーン表の M1 を ✅、末尾に振り返りセクション追記

## Test plan

- [x] `git diff --stat` で `docs/` 以外に変更がないことを確認（コード変更ゼロ）
- [x] tasks.md の全チェックボックスが `[x]` であることを目視確認
- [x] ADR-0001 の振り返りで PR #17/#18/#19 へ正確にリンクしていることを確認

## 振り返り抜粋（ADR-0001 より）

**うまくいった点:**
- ADR + tasks.md でスペックを先に固めたため AC が明確で完了基準のブレなし
- PR-B のマルチエージェントレビューで silent failure 3 件を同 PR 内で修正、後追い PR ゼロ
- PR-C の `_setup-emulator-env.ts` 副作用 import 分離は M3 で env 依存が増えても hoisting で壊れない構造

**M3 以降への申し送り:**
- 自動テスト未整備の段階解消（M3 から契約テスト + ルール unit テスト）
- admin SDK スタブの logError 統合 / prod projectId env 必須化 / テスト reset 露出（PR #19 コメントに引き継ぎ済み）
- GitHub Actions の Node 20 → 24 major 追従を M2 着手前後で一括実施

## Lint / 型

なし（doc 変更のみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)