### PR TITLE
docs(handoff): record M2 PR-A state for next session

### DIFF
--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -1,77 +1,102 @@
-# Handoff: M2 Spec 確定 → PR-A 着手準備
+# Handoff: M2 PR-A 実装 + 全品質ゲート完了 → 実機検証待ち
 
 - Session Date: 2026-04-26
 - Owner: yasushi-honda
-- Status: ✅ 再開可能
+- Status: ✅ 再開可能（PR #24 open、ユーザー側手動 AC 検証待ち）
 
 ## 今セッションの完了内容
 
-| 区分 | 完了事項 | コミット / PR |
+| 区分 | 完了事項 | 成果物 |
 |---|---|---|
-| 環境設定 | `.envrc` に GH_TOKEN 自動取得行を追加（`gh auth switch --user yasushi-honda` + `export GH_TOKEN=$(gh auth token)`）、`direnv allow .` 完了 | (commit 対象外、`.envrc` は `.gitignore:34` で除外済の端末ローカル運用ファイル。機密ハードコードなし) |
-| ADR 訂正 | ADR-0001 の `historyTree` を IndexedDB 列挙から外し「永続化対象外、メモリのみ、最大10ノード」と統一。M2 spec PR の Codex plan threadId 追記 | PR #22 内 |
-| M2 spec 起草 | `docs/spec/m2/tasks.md` 新規作成。逐次 PR-A → PR-B → PR-C 構成。ADR-0001 ロードマップ M2 と完全整合 | PR #22 (`891b7e9`) マージ済 |
-| レビュー反映 | `/review-pr` (code-reviewer) + `/codex plan` (threadId `019dc8b9-72d8-7813-94c4-fd1333be10d7`) 並列実行。Critical 5 + Medium 8 を全反映 | PR #22 内 (`697f4cb`、squash merge 後 main からは到達不能。確認は `gh pr view 22 --json commits` または GitHub PR タイムライン) |
-| CI 確認 | Cloud Run デプロイ成功（2m6s, run id 24951790278） | - |
+| 実装 | M2 PR-A の A.0〜A.9 全タスク。永続化レイヤーを Firestore（`/api/projects`/`/api/data`/`/api/tutorial`/`/api/analysis-history`）から ブラウザ IndexedDB（Dexie 4.4.2）に切替 | feature ブランチ `feature/m2-indexeddb-migration`（8 commits / 16 files / +304 / -156） |
+| 新規モジュール | `db/dexie.ts`（schema v1, 3 stores）、`db/projectRepository.ts`（whitelist + recursive `_*` strip + 型 tripwire）、`db/tutorialRepository.ts`、`db/analysisHistoryRepository.ts`、`hooks/useLocalSync.ts` | - |
+| 既存改修 | `App.tsx` import 切替、`components/Header.tsx` Export 経路置換、`store/{projectSlice,syncSlice,tutorialSlice,analysisHistorySlice}.ts` の永続化先置換、`store/uiSlice.ts` showToast の error 通知強制、`store/syncSlice.ts` `_pendingFlush` 経路 + 5秒再試行 | - |
+| 削除 | `projectApi.ts`（FE ラッパー）、`hooks/useFirestoreSync.ts`（rename 統合） | - |
+| 品質ゲート | `npm run lint` PASS / `/simplify` 3エージェント / `/safe-refactor` / `evaluator`（HIGH 3 / MEDIUM 3 修正）/ `/codex review`（Critical 1 / Major 1 修正）/ `/review-pr` 6エージェント並列（Critical 4 / Important 5 → A〜E 採用、F〜H 別 Issue 化に振分） | PR #24 |
+| PR 作成 | https://github.com/Yukina1116/novel-writer/pull/24 | Test plan に AC A1〜A10 + AR1〜AR5 を明記、Out of scope セクションに deferred 11 件を列挙 |
 
 ## 次セッション開始時の状態
 
-- ブランチ: `main` clean、origin/main と同期済み（PR #22 マージ済）
-- M2 spec (`docs/spec/m2/tasks.md`) が確定し、PR-A から逐次着手可能
-- 進行中タスクなし、未マージ PR は本ハンドオフ PR のみ（マージ判断はユーザー）
-- Open Issue: 0 件
+- ブランチ: `main` clean、origin/main と同期済み
+- 進行中の feature ブランチ:
+  - `feature/m2-indexeddb-migration` — PR #24 open、コード変更完了
+  - `feature/m2-pra-handoff` — 本ハンドオフ用ブランチ（このコミットを含む）
+- Open Issue: 0 件（前回 #23 ハンドオフから変動なし）
+- グローバル `~/.claude/` への変更なし（プロジェクト CLAUDE.md §1 遵守）
+- main 直 push なし、feature ブランチ + PR 運用維持（プロジェクト CLAUDE.md §2 遵守）
 
 ## 次のアクション（推奨順）
 
-### 1. PR-A: IndexedDB（Dexie.js）導入 + 永続化レイヤー切替
-- ブランチ: `feature/m2-indexeddb-migration`
-- 規模: 大（5〜7 時間）
-- 影響: `db/dexie.ts`・`db/projectRepository.ts`・`db/tutorialRepository.ts`・`db/analysisHistoryRepository.ts` 新規、`store/projectSlice.ts`・`store/syncSlice.ts`・`store/tutorialSlice.ts`・`store/analysisHistorySlice.ts`・`App.tsx` 改修、`hooks/useFirestoreSync.ts` → `hooks/useLocalSync.ts` にリネーム（spec `docs/spec/m2/tasks.md` PR-A タスク A.2 末尾参照）
-- **着手前の必須準備**:
-  - 開発端末の手元プロジェクトを Export で JSON 退避（spec の「PR-A 切替手順」参照）
-  - `grep -rn "/api/data" .` で `/api/data` 全呼出元を一覧化（PR-A スコープ確定用）
-  - `grep -rn "fetch.*'/api/" .` で全 API 呼出元の網羅
-- **品質ゲート**: spec の PR-A 品質ゲートに従い `npm run lint` / `/simplify` / `evaluator` agent / `/codex review` を実施
-- **ROI 注意**: 規模が大きいため `/impl-plan` で PR-A 単体の詳細設計（タスク分解 + AC 詳細化）を先に行う
+### 1. PR #24 の状態確認（最優先）
+- `gh pr view 24` で マージ済 / レビューコメント / open のいずれかを確認
+- 本ハンドオフ PR は `gh pr list --state open` で別途確認
 
-### 2. PR-B: Firebase Auth FE 導入
-- ブランチ: `feature/m2-firebase-auth-fe`
-- 規模: 中（2〜3 時間）、PR-A マージ後に着手
+### 2A. PR #24 が未マージ かつ 検証未完了 → 手動 AC 検証セッション
+- ユーザーがブラウザ操作、Claude が結果解釈・tasks.md 更新支援
+- **最優先**: AR1（`_pendingFlush` 経路 DevTools 検証、codex Critical 修正の妥当性）/ AR2（save-failure 5秒再試行、silent-failure-hunter CRIT-1 修正の妥当性）/ AR3（大型データ往復、spec R8）
+- spec PR-A 切替手順：手元プロジェクトを Export → ブランチ切替 → Import 復元 → AC 確認
 
-### 3. PR-C: サーバー退役 + Firestore メタ縮小
-- ブランチ: `feature/m2-server-retirement`
-- 規模: 中（2〜3 時間）、PR-B マージ後に着手
+### 2B. PR #24 が未マージ かつ 検証完了 PASS → tasks.md 更新コミット
+- `docs/spec/m2/tasks.md` PR-A セクション AC A1〜A9 を `[x]` に更新
+- 本 PR と同じブランチに追加コミット → push → マージ
+
+### 2C. PR #24 がマージ済 → main 同期 + PR-B 着手準備
+- `git checkout main && git pull --rebase`
+- `docs/spec/m2/tasks.md` の PR-A AC を `[x]` 更新（マージ前にやれていなければ）
+- ADR-0001 ロードマップ表で M2 を ⏳ → 部分完了マーク
+- PR-B（Firebase Auth FE）着手: ブランチ `feature/m2-firebase-auth-fe`、impl-plan 起動、grep `firebase` `auth` で現状確認
+
+### 3. /review-pr deferred の triage（マージ後に着手可能）
+- PR #24 description「Out of scope」に列挙した 11 件のうち、CLAUDE.md triage 基準（rating ≥ 7、実バグ、CI 破壊、ユーザー明示指示）を満たすものを `gh issue create`
+- **起票候補（rating ≥ 7 相当）**:
+  - silent-failure-hunter CRIT-2: validation throw vs DB I/O error 区別不能（typed error class hierarchy）
+  - silent-failure-hunter HIGH-1: `getProject(p.id).catch(() => null)` で個別 corrupted record が握りつぶされ、`activeProjectId` が壊れた project を選ぶ可能性
+  - silent-failure-hunter HIGH-2: Dexie module-level construction throw が `useLocalSync` の try/catch に届かない（Dexie の lazy open に依存）
+- **起票しない**（PR description 記録で十分）:
+  - silent-failure-hunter MED-1〜3、type-design-analyzer Important×2 / Suggestion×3、pr-test-analyzer Important（refactor 規模 / 設計判断系）
+  - LOW pre-existing bugs（`App.tsx:163` typo、`importProject` の `reader.onerror` 欠如、Export の `historyTree` 残存）
 
 ## 申し送り事項（注意点）
 
-### M1 振り返りからの引き継ぎ
-- **GitHub Actions Node 20 廃止対応**: PR-A〜C のレビュー待ち時間に公式 [GitHub blog 2025-09-19](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) で再確認 → `actions/checkout@v5`、`google-github-actions/auth@v3`、`setup-gcloud@v3`、`deploy-cloudrun@v3` の major 追従を独立 PR で実施
-- **M1 PR-C admin SDK スタブの 4 項目**（applicationDefault 失敗時 logError、prod の projectId fail-fast、test スクリプトの Anonymous プロバイダ未許可エラー化、`__resetFirebaseAdminAppForTesting()` 露出検討）→ M2 PR-C で `verifyIdToken` ミドルウェア導入時に併せて実装
+### 本セッションで実機検証は未実施
+- ユーザーのブラウザ操作（Chrome DevTools 含む）が必要なため、本セッションでは検証していない
+- AC A1〜A10 + AR1〜AR5（合計 15 項目）の DevTools 操作手順は PR #24 description に詳細記載
+- マージ前に必ず実機検証を完了させる（プロジェクト CLAUDE.md MUST「Test plan に記載した項目は全てマージ前に実行」）
 
-### M2 spec で確定した重要設計判断（出典: `docs/spec/m2/tasks.md`）
-- **IndexedDB は uid に紐付けない**（ログイン/ログアウトでデータ保持・切替なし） — spec 冒頭「ログイン切替時のローカルデータ境界」セクション
-- **`historyTree` は永続化しない**（メモリのみ、最大10ノード、リロードでリセット） — spec PR-A タスク A.1（`db/dexie.ts` 仕様）+ ADR-0001 アーキテクチャ概要
-- **`users/{uid}` 冪等 init は transaction 必須**（`merge: true` 単独不可、`createdAt` 保護） — spec PR-C タスク C.3
-- **Admin SDK は Firestore rules を bypass する**ため route 側でも同等の schema validation が必須 — spec PR-C タスク C.4 末尾 + リスク R15
-- **prod Cloud Run へのブラウザアクセスは M2 中は不能**（IAM 非公開、M3 で `--allow-unauthenticated` 復活を再検討） — spec 補足「Cloud Run 認証の扱い」+ AC B3
+### M2 spec で確定した重要設計判断（PR-A 実装で具現化）
+- **IndexedDB は uid に紐付けない** — login/logout でデータ保持。`db/dexie.ts` の DB 名は固定 `novelWriterDb`、uid セグメントなし
+- **`historyTree` は永続化しない** — `db/projectRepository.ts` の `PERSISTABLE_KEYS` から除外、`_coverageCheck` 型 tripwire で意図を compile-time に固定
+- **未知フィールド除去**: top-level whitelist + recursive `_*` strip の二段防御（codex Major 修正）。AC A6 の根本対策
+- **保存中編集の再 flush**: `_pendingFlush` flag + flushSave catch の 5秒再試行（codex Critical / silent-failure-hunter CRIT-1 の合算修正）
+- **error toast の必達性**: `showToastNotifications=false` でも `type='error'` は表示（silent-failure-hunter HIGH-3）
+
+### M1 から踏襲の既知問題（PR-A スコープ外、follow-up issue 化推奨）
+- `tutorialSlice` / `analysisHistorySlice` の `console.error` のみ catch — IndexedDB 移行で意味が変質（ローカル DB 失敗 = 通知すべき）
+- `App.tsx:163` cleanup typo（`addEventListener` を `removeEventListener` に修正すべき）
+- `importProject` の `reader.onerror` 未定義
+- Export 時の `historyTree` 残存（ファイルサイズ）
 
 ### 環境状況
 - `.envrc` 設定済（GH_TOKEN 自動取得 + GCP `novel-writer-dev`）
 - `cd ~/Projects/学校/yamashita/novel-writer && claude` で起動すれば direnv 経由で正しいアカウントが有効化される
 - 残留 Node プロセスなし
 
-## Issue Net 変化（計測タイミング: PR #22 マージ完了直後、本ハンドオフ PR #23 マージ前後で変動なし）
+## Issue Net 変化
 
 - Close 数: 0 件
 - 起票数: 0 件
 - Net: 0 件
-- **進捗の質**: PR #22 マージ（M2 spec 確定）を達成。Issue 化対象（実害バグ / CI 破壊 / rating ≥ 7 提案 / ユーザー明示指示）は今セッション中に発生せず、Net 0 は規範通り（review agent の rating 5-6 提案は本 spec PR の修正で取り込み済み、起票していない）
+- **進捗の質**: コードベースで M2 PR-A の実装と全品質ゲートを完了。PR #24 が open（コード完成、検証待ち）。Issue Net = 0 だが、PR-A は M2 の最大規模タスクであり、次セッションで検証通過 → マージ → PR-B 着手の準備が整った状態。/review-pr deferred 11 件のうち triage 基準を満たすもの（推定 3 件）は次セッションで起票予定で、その時点で Net が変動する
 
 ## ドキュメント整合性
 
-- ADR-0001 ロードマップ表: M2 ⏳ → PR #22 マージで spec 確定。完了マークは M2 全 PR 完了時に更新
-- `docs/spec/m1/tasks.md` ✅ Completed と本ハンドオフが整合
-- CLAUDE.md の "AI API層" 表 / "状態管理" セクションは PR-C 着手時に更新（spec C.5 で明記済）
+| 項目 | 状態 | 備考 |
+|---|---|---|
+| `docs/spec/m2/tasks.md` PR-A セクション | AC `[ ]` のまま | 実機検証後に `[x]` 化する運用（CLAUDE.md MUST と整合） |
+| `docs/spec/m2/tasks.md` PR-B / PR-C | `⏳` のまま | PR-A 後に着手 |
+| ADR-0001 ロードマップ表 | M2 `⏳` のまま | M2 全 PR 完了時に更新 |
+| `CLAUDE.md` "AI API層" 表 | 未更新 | PR-C 着手時に `/api/projects` 削除 + `/api/users/init` 追加（spec C.5） |
+| `CLAUDE.md` "状態管理" セクション | 未更新 | PR-C 着手時に `syncSlice` の保存先を IndexedDB に修正、`authSlice` 追記 |
 
 ## 残留プロセス
 


### PR DESCRIPTION
## Summary
- Updates \`docs/handoff/LATEST.md\` with the M2 PR-A implementation + quality-gate completion state
- Companion to PR #24 (feature/m2-indexeddb-migration), which is open and code-complete but pending manual AC verification

## Refs
- PR #24: M2 PR-A IndexedDB migration (open)
- Spec: \`docs/spec/m2/tasks.md\` PR-A
- ADR: \`docs/adr/0001-local-first-architecture.md\`

## Test plan
- [ ] \`docs/handoff/LATEST.md\` rendered on GitHub is readable, under 500 lines, all section anchors resolve
- [ ] No code changes introduced by this PR (verify \`git diff main...HEAD\` shows only the handoff file)
- [ ] Next-session entry instructions cover all three states of PR #24 (未マージ未検証 / 未マージ検証完了 / マージ済)

🤖 Generated with [Claude Code](https://claude.com/claude-code)