### PR TITLE
docs(handoff): M2 PR-B implementation + quality gates → AC verification待ち

### DIFF
--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -1,103 +1,112 @@
-# Handoff: M2 PR-A 実装 + 全品質ゲート完了 → 実機検証待ち
+# Handoff: M2 PR-B 実装 + 全品質ゲート完了 → Firebase Console 設定 & 実機検証待ち
 
-- Session Date: 2026-04-26
+- Session Date: 2026-04-26 〜 2026-04-27
 - Owner: yasushi-honda
-- Status: ✅ 再開可能（PR #24 open、ユーザー側手動 AC 検証待ち）
+- Status: ✅ 再開可能（PR #29 open、ユーザー側 Firebase Console 設定 + 手動 AC 検証待ち）
 
 ## 今セッションの完了内容
 
 | 区分 | 完了事項 | 成果物 |
 |---|---|---|
-| 実装 | M2 PR-A の A.0〜A.9 全タスク。永続化レイヤーを Firestore（`/api/projects`/`/api/data`/`/api/tutorial`/`/api/analysis-history`）から ブラウザ IndexedDB（Dexie 4.4.2）に切替 | feature ブランチ `feature/m2-indexeddb-migration`（8 commits / 16 files / +304 / -156） |
-| 新規モジュール | `db/dexie.ts`（schema v1, 3 stores）、`db/projectRepository.ts`（whitelist + recursive `_*` strip + 型 tripwire）、`db/tutorialRepository.ts`、`db/analysisHistoryRepository.ts`、`hooks/useLocalSync.ts` | - |
-| 既存改修 | `App.tsx` import 切替、`components/Header.tsx` Export 経路置換、`store/{projectSlice,syncSlice,tutorialSlice,analysisHistorySlice}.ts` の永続化先置換、`store/uiSlice.ts` showToast の error 通知強制、`store/syncSlice.ts` `_pendingFlush` 経路 + 5秒再試行 | - |
-| 削除 | `projectApi.ts`（FE ラッパー）、`hooks/useFirestoreSync.ts`（rename 統合） | - |
-| 品質ゲート | `npm run lint` PASS / `/simplify` 3エージェント / `/safe-refactor` / `evaluator`（HIGH 3 / MEDIUM 3 修正）/ `/codex review`（Critical 1 / Major 1 修正）/ `/review-pr` 6エージェント並列（Critical 4 / Important 5 → A〜E 採用、F〜H 別 Issue 化に振分） | PR #24 |
-| PR 作成 | https://github.com/Yukina1116/novel-writer/pull/24 | Test plan に AC A1〜A10 + AR1〜AR5 を明記、Out of scope セクションに deferred 11 件を列挙 |
+| マージ | M2 PR-A (IndexedDB Dexie 移行) を merge、main 同期 | PR #24 (a57d094) |
+| マージ | ADR-0001 ロードマップを M2 「進行中」に更新 (PR-A ✅ / PR-B ⏳ / PR-C ⏳) | PR #26 (bdfe981) |
+| Issue 起票 | M2 PR-A `/review-pr` deferred の rating ≥ 7 相当 2 件を triage 起票 (Option B 選択) | #27 (corrupted record swallow → activeProjectId)、#28 (Dexie module-level construction throw) |
+| 実装 | M2 PR-B Firebase Auth FE + Tier 0/1 UI 全 7 タスク (B.1〜B.7) | feature ブランチ `feature/m2-firebase-auth-fe` (4 commits / 22 files / +408 / -39) |
+| 新規モジュール | `firebaseClient.ts`、`store/authSlice.ts`、`components/AuthButton.tsx`、`hooks/useRequiresAuth.ts`、`store/authConstants.ts`、`vite-env.d.ts`、`.env.example` | - |
+| 既存改修 | `App.tsx` initAuth 起動、`store/index.ts` AuthSlice 結合、`components/Header.tsx` + `ProjectSelectionScreen.tsx` AuthButton 配置、6 modal の AI ボタン Tier 0 disable + tooltip、`apiClient.ts` defense-in-depth ガード (AUTH_REQUIRED/AUTH_INITIALIZING タグ)、`server/index.ts` prod CSP、`package.json` `dev:emu` env 注入 | - |
+| 品質ゲート | `npm run lint` PASS / `/simplify` 3エージェント / `evaluator` HIGH 2 fix / `/review-pr` 5エージェント並列 (silent-failure / type-design / code / comment / test) Important 4 fix | PR #29 |
+| PR 作成 | https://github.com/Yukina1116/novel-writer/pull/29 — Test plan に B1〜B8 + B3-err1/err2 + Pre-flight (`.env.local` fail-fast 検証含む) + Out of scope deferred 7 件を明記 | - |
 
 ## 次セッション開始時の状態
 
-- ブランチ: `main` clean、origin/main と同期済み
+- ブランチ: `main` clean、origin/main と同期済み (a57d094 → bdfe981 から進行)
 - 進行中の feature ブランチ:
-  - `feature/m2-indexeddb-migration` — PR #24 open、コード変更完了
-  - `feature/m2-pra-handoff` — 本ハンドオフ用ブランチ（このコミットを含む）
-- Open Issue: 0 件（前回 #23 ハンドオフから変動なし）
-- グローバル `~/.claude/` への変更なし（プロジェクト CLAUDE.md §1 遵守）
-- main 直 push なし、feature ブランチ + PR 運用維持（プロジェクト CLAUDE.md §2 遵守）
+  - `feature/m2-firebase-auth-fe` — PR #29 open、コード変更完了 (4 commits)
+  - `docs/handoff-m2-pr-b` — 本ハンドオフ用ブランチ
+- Open Issue: 2 件 (#27 / #28、両方とも PR-A follow-up、本 PR スコープ外)
+- グローバル `~/.claude/` への変更なし (プロジェクト CLAUDE.md §1 遵守)
+- main 直 push なし、feature ブランチ + PR 運用維持 (プロジェクト CLAUDE.md §2 遵守)
 
-## 次のアクション（推奨順）
+## 次のアクション (推奨順)
 
-### 1. PR #24 の状態確認（最優先）
-- `gh pr view 24` で マージ済 / レビューコメント / open のいずれかを確認
-- 本ハンドオフ PR は `gh pr list --state open` で別途確認
+### 1. PR #29 の状態確認 (最優先)
+- `gh pr view 29` で マージ済 / レビューコメント / open のいずれかを確認
 
-### 2A. PR #24 が未マージ かつ 検証未完了 → 手動 AC 検証セッション
-- ユーザーがブラウザ操作、Claude が結果解釈・tasks.md 更新支援
-- **最優先**: AR1（`_pendingFlush` 経路 DevTools 検証、codex Critical 修正の妥当性）/ AR2（save-failure 5秒再試行、silent-failure-hunter CRIT-1 修正の妥当性）/ AR3（大型データ往復、spec R8）
-- spec PR-A 切替手順：手元プロジェクトを Export → ブランチ切替 → Import 復元 → AC 確認
+### 2A. PR #29 が未マージ + Firebase Console 設定 **未** → 設定セッション
+- Firebase Console → Project (`novel-writer-dev`) → Web アプリ登録 → SDK config 取得
+- `.env.local` 作成 + `VITE_FIREBASE_*` 6 値投入
+- Authentication > Sign-in method で Google プロバイダ有効化
+- 完了したら 2B へ
 
-### 2B. PR #24 が未マージ かつ 検証完了 PASS → tasks.md 更新コミット
-- `docs/spec/m2/tasks.md` PR-A セクション AC A1〜A9 を `[x]` に更新
-- 本 PR と同じブランチに追加コミット → push → マージ
+### 2B. PR #29 が未マージ + Firebase Console 設定済 → 実機 AC 検証セッション
+- Pre-flight (`.env.local` fail-fast 動作確認)
+- AC B1〜B8 + B3-err1 (popup blocked) + B3-err2 (popup closed by user) を順次検証
+- ユーザーがブラウザ操作、Claude が結果解釈 + tasks.md 更新支援
+- 検証手順詳細は PR #29 description Test plan セクション参照
+- 検証 PASS 後 → `docs/spec/m2/tasks.md` PR-B AC を `[x]` に更新コミット
 
-### 2C. PR #24 がマージ済 → main 同期 + PR-B 着手準備
+### 2C. PR #29 がマージ済 → main 同期 + PR-C 着手準備
 - `git checkout main && git pull --rebase`
-- `docs/spec/m2/tasks.md` の PR-A AC を `[x]` 更新（マージ前にやれていなければ）
-- ADR-0001 ロードマップ表で M2 を ⏳ → 部分完了マーク
-- PR-B（Firebase Auth FE）着手: ブランチ `feature/m2-firebase-auth-fe`、impl-plan 起動、grep `firebase` `auth` で現状確認
+- `docs/spec/m2/tasks.md` PR-B AC を `[x]` 更新 (マージ前にやれていなければ)
+- ADR-0001 ロードマップ表で M2 を「PR-B ✅」に更新
+- PR-C (`/api/projects` `/api/data` 退役 + Firestore メタ縮小 + ID Token 検証ミドルウェア) 着手:
+  - ブランチ `feature/m2-server-retirement`
+  - `/impl-plan` 起動
+  - tasks.md PR-C C.1〜C.5 + AC C1〜C7 + リスク R12〜R15 を計画ベースに
 
-### 3. /review-pr deferred の triage（マージ後に着手可能）
-- PR #24 description「Out of scope」に列挙した 11 件のうち、CLAUDE.md triage 基準（rating ≥ 7、実バグ、CI 破壊、ユーザー明示指示）を満たすものを `gh issue create`
-- **起票候補（rating ≥ 7 相当）**:
-  - silent-failure-hunter CRIT-2: validation throw vs DB I/O error 区別不能（typed error class hierarchy）
-  - silent-failure-hunter HIGH-1: `getProject(p.id).catch(() => null)` で個別 corrupted record が握りつぶされ、`activeProjectId` が壊れた project を選ぶ可能性
-  - silent-failure-hunter HIGH-2: Dexie module-level construction throw が `useLocalSync` の try/catch に届かない（Dexie の lazy open に依存）
-- **起票しない**（PR description 記録で十分）:
-  - silent-failure-hunter MED-1〜3、type-design-analyzer Important×2 / Suggestion×3、pr-test-analyzer Important（refactor 規模 / 設計判断系）
-  - LOW pre-existing bugs（`App.tsx:163` typo、`importProject` の `reader.onerror` 欠如、Export の `historyTree` 残存）
+### 3. (Optional) PR #29 への `/codex review` セカンドオピニオン
+- 認証は security-sensitive のため CLAUDE.md 推奨 (大規模 PR + 200 行+)
+- 5-agent review でカバー済 (Critical なし、Important 4 fix 済) のため ROI は中程度
 
-## 申し送り事項（注意点）
+## 申し送り事項 (重要)
 
 ### 本セッションで実機検証は未実施
-- ユーザーのブラウザ操作（Chrome DevTools 含む）が必要なため、本セッションでは検証していない
-- AC A1〜A10 + AR1〜AR5（合計 15 項目）の DevTools 操作手順は PR #24 description に詳細記載
-- マージ前に必ず実機検証を完了させる（プロジェクト CLAUDE.md MUST「Test plan に記載した項目は全てマージ前に実行」）
+- ユーザーのブラウザ操作 (Firebase Console 設定 + DevTools 操作) が必要なため未実施
+- AC 11 項目 (B1〜B8 + B3-err1/err2、`.env.local` fail-fast 含む) の手順は PR #29 description に詳細記載
+- マージ前に必ず実機検証を完了させる (プロジェクト CLAUDE.md MUST「Test plan に記載した項目は全てマージ前に実行」)
 
-### M2 spec で確定した重要設計判断（PR-A 実装で具現化）
-- **IndexedDB は uid に紐付けない** — login/logout でデータ保持。`db/dexie.ts` の DB 名は固定 `novelWriterDb`、uid セグメントなし
-- **`historyTree` は永続化しない** — `db/projectRepository.ts` の `PERSISTABLE_KEYS` から除外、`_coverageCheck` 型 tripwire で意図を compile-time に固定
-- **未知フィールド除去**: top-level whitelist + recursive `_*` strip の二段防御（codex Major 修正）。AC A6 の根本対策
-- **保存中編集の再 flush**: `_pendingFlush` flag + flushSave catch の 5秒再試行（codex Critical / silent-failure-hunter CRIT-1 の合算修正）
-- **error toast の必達性**: `showToastNotifications=false` でも `type='error'` は表示（silent-failure-hunter HIGH-3）
+### M2 spec で確定した重要設計判断 (PR-B 実装で具現化)
+- **IndexedDB は uid に紐付けない (uid 切替で消えない)** — `signInWithGoogle` / `signOut` / `initAuth` のいずれも IDB に触らない (コメントで明示)
+- **`useRequiresAuth` フック + `apiClient.ts` の二段防御** — UI ボタン disable + 万一の漏れに備えた API client defense ガード (`code: 'AUTH_REQUIRED' | 'AUTH_INITIALIZING'` タグで `initializing` を区別、誤誘導回避)
+- **`authStatus = 'initializing'` 中の専用メッセージ** — 「認証確認中…」表示で「ログインしてから」誤誘導を防止 (silent-failure-hunter H-2 対応)
+- **popup-closed-by-user / cancelled-popup-request は silent** — user 意図のため toast 抑制 (silent-failure-hunter M-2 対応)、popup-blocked は強化メッセージ
+- **Tier 判定は派生値**として `useRequiresAuth` フックが提供 (`selectTier(state)` 関数は spec 言及だが、フック方式と機能等価で許容)
 
-### M1 から踏襲の既知問題（PR-A スコープ外、follow-up issue 化推奨）
-- `tutorialSlice` / `analysisHistorySlice` の `console.error` のみ catch — IndexedDB 移行で意味が変質（ローカル DB 失敗 = 通知すべき）
-- `App.tsx:163` cleanup typo（`addEventListener` を `removeEventListener` に修正すべき）
-- `importProject` の `reader.onerror` 未定義
-- Export 時の `historyTree` 残存（ファイルサイズ）
+### 次 PR (PR-C) への申し送り
+- BE 認証ゲート (Bearer ID Token 検証ミドルウェア) は **本 PR では入れていない** — M3 で実装予定だが PR-C で `/api/users/init` 用に先行導入する設計 (spec C.2 / C.3)
+- FE 側は `Authorization: Bearer <token>` 付与の仕組みを M3 で導入 (spec B.5 注記)
+- prod Cloud Run はブラウザから IAM 非公開 (M2 範囲外、M3 で `--allow-unauthenticated` 復活を再評価)
+
+### Out of scope (PR #29 description に詳細記載、別 issue / 後続 PR 候補)
+- silent-failure-hunter C-1 (`firebaseClient.ts` module-level throw) — Issue #28 (PR-A の Dexie 同型問題) と統合扱い
+- silent-failure-hunter H-1 (Firebase 503 outage demote to unauthenticated) — `authStatus='error'` + 「再試行」 sticky banner の別 PR
+- evaluator MED (`AuthButton` で `authError` の persistent UI 表示) — popup-blocked メッセージ強化のみで対応、別 PR 候補
+- type-design-analyzer Important×3 (createAuthSlice 型付け / RequiresAuthState 判別共用体 / REQUIRED_KEYS 型派生) — 既存 slice 規約変更を伴うため大規模 refactor
+- pr-test-analyzer S1〜S4 (Strict Mode 二重 subscribe / cross-tab sync / 連打 race / Auth Emulator フロー差分) — M3 自動テスト基盤導入後に vitest + Firebase Auth emulator で機械化
 
 ### 環境状況
-- `.envrc` 設定済（GH_TOKEN 自動取得 + GCP `novel-writer-dev`）
+- `.envrc` 設定済 (GH_TOKEN 自動取得 + GCP `novel-writer-dev`)
 - `cd ~/Projects/学校/yamashita/novel-writer && claude` で起動すれば direnv 経由で正しいアカウントが有効化される
 - 残留 Node プロセスなし
 
 ## Issue Net 変化
 
 - Close 数: 0 件
-- 起票数: 0 件
-- Net: 0 件
-- **進捗の質**: コードベースで M2 PR-A の実装と全品質ゲートを完了。PR #24 が open（コード完成、検証待ち）。Issue Net = 0 だが、PR-A は M2 の最大規模タスクであり、次セッションで検証通過 → マージ → PR-B 着手の準備が整った状態。/review-pr deferred 11 件のうち triage 基準を満たすもの（推定 3 件）は次セッションで起票予定で、その時点で Net が変動する
+- 起票数: 2 件 (#27 / #28、いずれも PR-A `/review-pr` deferred の rating ≥ 7 相当を triage 起票)
+- Net: +2 件
+- **進捗の質**: Net = +2 だが、両 issue とも CLAUDE.md triage 基準 #1 (実害あり) + #4 (rating ≥ 7) を満たし、PR-A `/review-pr` で発見された未対処事項の機械的可視化。本セッションの主要進捗は `[PR-A merge + PR-B 実装 + 全品質ゲート通過]` で M2 マイルストーンの ~67% 完了 (PR-A ✅ / PR-B ⏳実機検証待ち / PR-C ⏳)。Issue 起票 +2 は triage 後の正規化なので進捗ゼロ扱いではない
 
 ## ドキュメント整合性
 
 | 項目 | 状態 | 備考 |
 |---|---|---|
-| `docs/spec/m2/tasks.md` PR-A セクション | AC `[ ]` のまま | 実機検証後に `[x]` 化する運用（CLAUDE.md MUST と整合） |
-| `docs/spec/m2/tasks.md` PR-B / PR-C | `⏳` のまま | PR-A 後に着手 |
-| ADR-0001 ロードマップ表 | M2 `⏳` のまま | M2 全 PR 完了時に更新 |
-| `CLAUDE.md` "AI API層" 表 | 未更新 | PR-C 着手時に `/api/projects` 削除 + `/api/users/init` 追加（spec C.5） |
-| `CLAUDE.md` "状態管理" セクション | 未更新 | PR-C 着手時に `syncSlice` の保存先を IndexedDB に修正、`authSlice` 追記 |
+| `docs/spec/m2/tasks.md` PR-A セクション | AC `[x]` 全 9 項目 + 品質ゲート | PR #24 マージ前に更新済 |
+| `docs/spec/m2/tasks.md` PR-B セクション | AC `[ ]` のまま | 実機検証後に `[x]` 化する運用 (CLAUDE.md MUST と整合) |
+| `docs/spec/m2/tasks.md` PR-C | `⏳` のまま | PR-B 後に着手 |
+| ADR-0001 ロードマップ表 | M2 「進行中 (PR-A ✅ / PR-B ⏳ / PR-C ⏳)」 | PR #26 でマージ済 |
+| `CLAUDE.md` "AI API層" 表 | 未更新 | PR-C 着手時に `/api/projects` 削除 + `/api/users/init` 追加 (spec C.5) |
+| `CLAUDE.md` "状態管理" セクション | 未更新 | PR-C 着手時に `syncSlice` の保存先を IndexedDB に修正 (PR-A 由来)、`authSlice` 追記 (PR-B 由来) |
 
 ## 残留プロセス
 
-✅ なし
+✅ なし (cleanup-node.sh 確認済)


### PR DESCRIPTION
## Summary
- PR #29 (M2 PR-B Firebase Auth FE) の実装 + 4 つの品質ゲート (lint / simplify / evaluator / review-pr 5-agent) 通過状態を記録
- 次セッションで Firebase Console 設定 + 実機 AC 検証から再開できる状態を保存
- 旧 PR-A handoff (PR #25 由来) を上書き

## Test plan
- [x] LATEST.md 単独修正、コードベース影響なし
- [x] 構文確認 (Markdown 表として表示崩れなし)
- [ ] マージ後 main の docs/handoff/LATEST.md が PR-B 状態を反映していることを次セッションで確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)