### PR TITLE
fix(m2): harden useLocalSync against corrupted records & DB throw

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -191,13 +191,18 @@ export default function App() {
     }
 
     if (!activeProjectId || !activeProjectData) {
-        return <ProjectSelectionScreen 
-            projects={Object.values(allProjectsData)} 
-            onCreateProject={createProject} 
-            onDeleteProject={deleteProject} 
-            onImportProject={importProject} 
-            onSelectProject={setActiveProjectId} 
-        />;
+        return (
+            <>
+                <Toast />
+                <ProjectSelectionScreen
+                    projects={Object.values(allProjectsData)}
+                    onCreateProject={createProject}
+                    onDeleteProject={deleteProject}
+                    onImportProject={importProject}
+                    onSelectProject={setActiveProjectId}
+                />
+            </>
+        );
     }
 
     // Mobile View

--- a/db/analysisHistoryRepository.ts
+++ b/db/analysisHistoryRepository.ts
@@ -1,11 +1,11 @@
 import { AnalysisResult } from '../types';
-import { ANALYSIS_HISTORY_KEY, db } from './dexie';
+import { ANALYSIS_HISTORY_KEY, getDb } from './dexie';
 
 export const loadAnalysisHistory = async (): Promise<AnalysisResult[]> => {
-    const record = await db.analysisHistory.get(ANALYSIS_HISTORY_KEY);
+    const record = await getDb().analysisHistory.get(ANALYSIS_HISTORY_KEY);
     return record?.history ?? [];
 };
 
 export const saveAnalysisHistory = async (history: AnalysisResult[]): Promise<void> => {
-    await db.analysisHistory.put({ key: ANALYSIS_HISTORY_KEY, history });
+    await getDb().analysisHistory.put({ key: ANALYSIS_HISTORY_KEY, history });
 };

--- a/db/dexie.ts
+++ b/db/dexie.ts
@@ -43,4 +43,7 @@ const createDb = (): AppDexieDb => {
     return instance;
 };
 
-export const db: AppDexieDb = createDb();
+// Lazy init: defer construction so failures throw at the call site (catchable
+// by useLocalSync) instead of at module evaluation (white-screening the app).
+let _db: AppDexieDb | null = null;
+export const getDb = (): AppDexieDb => (_db ??= createDb());

--- a/db/projectRepository.ts
+++ b/db/projectRepository.ts
@@ -1,6 +1,6 @@
 import { Project } from '../types';
 import { validateAndSanitizeProjectData } from '../utils';
-import { db, ProjectListEntry } from './dexie';
+import { getDb, ProjectListEntry } from './dexie';
 
 // historyTree omitted: memory-only by ADR-0001; persisting would defeat the cap
 // and bloat IndexedDB. Whitelist (not blocklist) so future legacy keys from
@@ -67,7 +67,7 @@ const stripInternalKeys = (value: unknown): unknown => {
 };
 
 export const listProjects = async (): Promise<ProjectListEntry[]> => {
-    const projects = await db.projects.orderBy('lastModified').reverse().toArray();
+    const projects = await getDb().projects.orderBy('lastModified').reverse().toArray();
     return projects.map(p => ({
         id: p.id,
         name: p.name,
@@ -77,16 +77,20 @@ export const listProjects = async (): Promise<ProjectListEntry[]> => {
 };
 
 export const getProject = async (id: string): Promise<Project | null> => {
-    const project = await db.projects.get(id);
-    return project ?? null;
+    const project = await getDb().projects.get(id);
+    if (!project) return null;
+    // Mirror putProject's validation on read: Dexie does NOT enforce schema,
+    // so a record missing required fields (id/name) reaches this point. Throw
+    // here so consumers can treat the row as corrupted and fall back safely.
+    return validateAndSanitizeProjectData(project);
 };
 
 export const putProject = async (project: Project): Promise<void> => {
     const sanitized = validateAndSanitizeProjectData(project);
     const persistable = pickPersistableFields(sanitized);
-    await db.projects.put(stripInternalKeys(persistable) as Project);
+    await getDb().projects.put(stripInternalKeys(persistable) as Project);
 };
 
 export const deleteProject = async (id: string): Promise<void> => {
-    await db.projects.delete(id);
+    await getDb().projects.delete(id);
 };

--- a/db/projectRepository.ts
+++ b/db/projectRepository.ts
@@ -76,12 +76,15 @@ export const listProjects = async (): Promise<ProjectListEntry[]> => {
     }));
 };
 
+/**
+ * Returns the project for `id`, or null if no record exists.
+ * @throws {ProjectValidationError} if the record is found but missing
+ *   required fields. Dexie does not enforce schema on read, so callers
+ *   must treat this as a corrupted-record signal.
+ */
 export const getProject = async (id: string): Promise<Project | null> => {
     const project = await getDb().projects.get(id);
     if (!project) return null;
-    // Mirror putProject's validation on read: Dexie does NOT enforce schema,
-    // so a record missing required fields (id/name) reaches this point. Throw
-    // here so consumers can treat the row as corrupted and fall back safely.
     return validateAndSanitizeProjectData(project);
 };
 

--- a/db/tutorialRepository.ts
+++ b/db/tutorialRepository.ts
@@ -1,14 +1,14 @@
-import { db, TUTORIAL_STATE_VERSION, TutorialStateRecord } from './dexie';
+import { getDb, TUTORIAL_STATE_VERSION, TutorialStateRecord } from './dexie';
 
 export type TutorialFlags = Omit<TutorialStateRecord, 'version'>;
 
 export const loadTutorialState = async (): Promise<TutorialFlags> => {
-    const record = await db.tutorialState.get(TUTORIAL_STATE_VERSION);
+    const record = await getDb().tutorialState.get(TUTORIAL_STATE_VERSION);
     if (!record) return {};
     const { version: _omitted, ...flags } = record;
     return flags;
 };
 
 export const saveTutorialState = async (flags: TutorialFlags): Promise<void> => {
-    await db.tutorialState.put({ version: TUTORIAL_STATE_VERSION, ...flags });
+    await getDb().tutorialState.put({ version: TUTORIAL_STATE_VERSION, ...flags });
 };

--- a/hooks/useLocalSync.ts
+++ b/hooks/useLocalSync.ts
@@ -14,19 +14,50 @@ export const useLocalSync = () => {
         const init = async () => {
             try {
                 const projectList = await listProjects();
-                if (projectList.length === 0) return;
+                if (projectList.length === 0) {
+                    if (useStore.getState().activeProjectId) {
+                        useStore.setState({ activeProjectId: null });
+                    }
+                    return;
+                }
 
                 const projects = await Promise.all(
-                    projectList.map(p => getProject(p.id).catch(() => null)),
+                    projectList.map(p =>
+                        getProject(p.id).catch((err: unknown) => {
+                            console.error(`Failed to load project ${p.id}:`, err);
+                            return null;
+                        }),
+                    ),
                 );
                 const allProjectsData: Record<string, Project> = {};
                 for (const p of projects) {
                     if (p) allProjectsData[p.id] = p;
                 }
+
+                // Preserve projectList ordering (lastModified DESC) but filter to
+                // entries that loaded successfully — this is the only safe pool
+                // for activeProjectId (allProjectsData keyspace).
+                const healthyProjects = projectList.filter(p => allProjectsData[p.id]);
+                const corruptedCount = projectList.length - healthyProjects.length;
+
+                // Reuse pre-existing activeProjectId only if its record loaded
+                // successfully (dangling-id guard for stale cross-session state).
+                const existingId = useStore.getState().activeProjectId;
+                const validExistingId =
+                    existingId && allProjectsData[existingId] ? existingId : null;
+                const fallbackId = healthyProjects[0]?.id ?? null;
+
                 useStore.setState({
                     allProjectsData,
-                    activeProjectId: useStore.getState().activeProjectId || projectList[0].id,
+                    activeProjectId: validExistingId ?? fallbackId,
                 });
+
+                if (corruptedCount > 0) {
+                    useStore.getState().showToast(
+                        `プロジェクト ${corruptedCount} 件の読み込みに失敗しました（破損データを除外しました）`,
+                        'error',
+                    );
+                }
             } catch (e: unknown) {
                 console.error('Local persistence init failed:', e);
                 const detail = e instanceof Error ? e.message : String(e);

--- a/hooks/useLocalSync.ts
+++ b/hooks/useLocalSync.ts
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { useStore } from '../store/index';
 import { Project } from '../types';
 import { getProject, listProjects } from '../db/projectRepository';
+import { ProjectValidationError } from '../utils';
 
 const LOCAL_DB_INIT_FAILED_MESSAGE =
     'ローカルデータの読み込みに失敗しました。プライベートモードや容量不足で IndexedDB が利用できない場合、データはメモリ上のみ保持され、リロードで失われます。';
@@ -15,16 +16,21 @@ export const useLocalSync = () => {
             try {
                 const projectList = await listProjects();
                 if (projectList.length === 0) {
-                    if (useStore.getState().activeProjectId) {
-                        useStore.setState({ activeProjectId: null });
-                    }
+                    useStore.setState({ activeProjectId: null });
                     return;
                 }
 
+                let validationFailures = 0;
+                let infrastructureFailures = 0;
                 const projects = await Promise.all(
                     projectList.map(p =>
                         getProject(p.id).catch((err: unknown) => {
                             console.error(`Failed to load project ${p.id}:`, err);
+                            if (err instanceof ProjectValidationError) {
+                                validationFailures++;
+                            } else {
+                                infrastructureFailures++;
+                            }
                             return null;
                         }),
                     ),
@@ -34,14 +40,12 @@ export const useLocalSync = () => {
                     if (p) allProjectsData[p.id] = p;
                 }
 
-                // Preserve projectList ordering (lastModified DESC) but filter to
-                // entries that loaded successfully — this is the only safe pool
-                // for activeProjectId (allProjectsData keyspace).
+                // Filter while preserving listProjects' lastModified-DESC order
+                // so the fallback below picks the most recent healthy project.
                 const healthyProjects = projectList.filter(p => allProjectsData[p.id]);
-                const corruptedCount = projectList.length - healthyProjects.length;
 
-                // Reuse pre-existing activeProjectId only if its record loaded
-                // successfully (dangling-id guard for stale cross-session state).
+                // Dangling-id guard: a persisted activeProjectId may point at a
+                // project that is now missing or corrupted across sessions.
                 const existingId = useStore.getState().activeProjectId;
                 const validExistingId =
                     existingId && allProjectsData[existingId] ? existingId : null;
@@ -52,9 +56,13 @@ export const useLocalSync = () => {
                     activeProjectId: validExistingId ?? fallbackId,
                 });
 
-                if (corruptedCount > 0) {
+                const failureCount = validationFailures + infrastructureFailures;
+                if (failureCount > 0) {
+                    const detail = infrastructureFailures > 0
+                        ? '一時的なエラーの可能性があります。リロードで復旧する場合があります'
+                        : '破損データを除外しました';
                     useStore.getState().showToast(
-                        `プロジェクト ${corruptedCount} 件の読み込みに失敗しました（破損データを除外しました）`,
+                        `プロジェクト ${failureCount} 件の読み込みに失敗しました（${detail}）`,
                         'error',
                     );
                 }

--- a/tests/例外系テスト.md
+++ b/tests/例外系テスト.md
@@ -61,7 +61,7 @@
 
 ### ローカル永続化（IndexedDB / Dexie）
 
-PR-Bx (Issue #27, #28) で追加された useLocalSync hardening の検証項目。
+useLocalSync hardening の検証項目。
 
 | テストケースID | 対象機能 | 操作手順 | 期待結果 | AC |
 | :--- | :--- | :--- | :--- | :--- |
@@ -73,6 +73,6 @@ PR-Bx (Issue #27, #28) で追加された useLocalSync hardening の検証項目
 
 #### AC-X4 検証の制限事項
 
-**TC-EX-IDB-005 は IDB 利用不可シナリオの runtime 検証として機能するが、Dexie の `new Dexie()` / `version().stores()` 自体が module 評価時に同期 throw するシナリオは現行 Dexie 4.4.2 では発生しない**（lazy open 仕様）。将来の Dexie major upgrade で同期 throw 化が起きた場合の保護は、`db/dexie.ts` の lazy init pattern (`getDb()`) によりコード構造で保証している。本リポジトリは自動テスト基盤未導入（CLAUDE.md 規定）のため、module-level throw を mock した runtime 検証は scope 外。
+**TC-EX-IDB-005 は IDB 利用不可シナリオの runtime 検証として機能するが、Dexie の `new Dexie()` / `version().stores()` 自体が module 評価時に同期 throw するシナリオは現行 Dexie 4.x（lazy-open 仕様、`package.json` で固定中のバージョンを参照）では発生しない**。将来の Dexie major upgrade で同期 throw 化が起きた場合の保護は、`db/dexie.ts` の lazy init pattern (`getDb()`) によりコード構造で保証している。本リポジトリは自動テスト基盤未導入（CLAUDE.md 規定）のため、module-level throw を mock した runtime 検証は scope 外。
 
 ---

--- a/tests/例外系テスト.md
+++ b/tests/例外系テスト.md
@@ -59,4 +59,20 @@
 | **TC-EX-API-003** | APIキー無効 | （もし可能なら）意図的に無効なAPIキーを設定してAIに指示を送信する | 「APIキーが無効です」というエラーメッセージが表示される。 |
 | **TC-EX-API-004** | クォータ超過 | （もし可能なら）APIの利用上限に達した状態で指示を送信する | 「利用枠の上限に達しました」というエラーメッセージが表示される。 |
 
+### ローカル永続化（IndexedDB / Dexie）
+
+PR-Bx (Issue #27, #28) で追加された useLocalSync hardening の検証項目。
+
+| テストケースID | 対象機能 | 操作手順 | 期待結果 | AC |
+| :--- | :--- | :--- | :--- | :--- |
+| **TC-EX-IDB-001** | corrupted record 1 件混在時の起動 | 1. 健全な project を 2 件以上作成して保存<br>2. DevTools > Application > IndexedDB > novelWriterDb > projects から 1 件を選び、**`name` フィールドのみを削除して保存**（`id` と `lastModified` は残す。`lastModified` を消すと secondary index から消失して `listProjects` が返さないため再現不可）<br>3. ブラウザをリロード | 1. アプリが正常に起動する（white screen にならない）<br>2. error toast 「プロジェクト N 件の読み込みに失敗しました（破損データを除外しました）」が表示される<br>3. activeProjectId は健全な project のいずれか、または null になる<br>4. DevTools Console に `Failed to load project <id>:` と `validateAndSanitizeProjectData` 由来のエラー（例: 「プロジェクト名が無効または存在しません。」）が出力される<br>5. 健全な project の編集が通常通り可能 | AC-X1, X5 |
+| **TC-EX-IDB-002** | 全 project corrupted 時の起動 | 1. project を 1 件のみ作成<br>2. DevTools で唯一のレコードの `name` を削除（`id`/`lastModified` は残す）<br>3. リロード | 1. アプリが起動する<br>2. error toast 表示<br>3. activeProjectId が null、空のプロジェクト一覧画面に遷移 | AC-X2 |
+| **TC-EX-IDB-003** | 健全 IDB の起動（退行確認） | 1. 健全な project を 1〜複数件で起動 | M2 PR-A の AC A1〜A10 が全 PASS。エラー toast は出ず、activeProjectId は前回値 or projectList[0]（healthy）を選択 | AC-X3 |
+| **TC-EX-IDB-004** | stale activeProjectId 復帰時の検証 | 1. project a, b を作成、activeProjectId=a で保存（a を選択した状態でリロード可能にする）<br>2. project a の `name` を DevTools で削除（`id`/`lastModified` は残す）<br>3. リロード | 1. activeProjectId は b（healthy 先頭）になり a を指し続けない<br>2. error toast 表示 | AC-X1 拡張 |
+| **TC-EX-IDB-005** | プライベートモード/容量不足での起動 | 1. ブラウザを「プライベート/シークレット」モードで開く（IndexedDB 利用不可の挙動が出る環境）<br>2. アプリを起動 | 1. アプリが white screen にならず起動する<br>2. error toast 「ローカルデータの読み込みに失敗しました…」表示<br>3. memory-only mode で動作（リロードでデータは失われる旨が toast で示される） | AC-X4 部分検証 |
+
+#### AC-X4 検証の制限事項
+
+**TC-EX-IDB-005 は IDB 利用不可シナリオの runtime 検証として機能するが、Dexie の `new Dexie()` / `version().stores()` 自体が module 評価時に同期 throw するシナリオは現行 Dexie 4.4.2 では発生しない**（lazy open 仕様）。将来の Dexie major upgrade で同期 throw 化が起きた場合の保護は、`db/dexie.ts` の lazy init pattern (`getDb()`) によりコード構造で保証している。本リポジトリは自動テスト基盤未導入（CLAUDE.md 規定）のため、module-level throw を mock した runtime 検証は scope 外。
+
 ---

--- a/utils.ts
+++ b/utils.ts
@@ -294,19 +294,29 @@ const isValidKnowledgeItem = (item: any): item is KnowledgeItem => {
 };
 // Add more specific validators for other types as needed...
 
+// Distinguishable from runtime/IO errors so callers can tell schema-corrupted
+// records apart from transient infrastructure failures (e.g. IDB transaction
+// abort) and message the user accordingly.
+export class ProjectValidationError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'ProjectValidationError';
+    }
+}
+
 export const validateAndSanitizeProjectData = (data: any): Project => {
     if (!isObject(data)) {
-        throw new Error('プロジェクトファイルが有効なオブジェクトではありません。');
+        throw new ProjectValidationError('プロジェクトファイルが有効なオブジェクトではありません。');
     }
 
     const sanitized: Partial<Project> = { ...data };
 
     // --- Validate mandatory fields ---
     if (!isString(sanitized.id) || !sanitized.id) {
-        throw new Error('プロジェクトIDが無効または存在しません。');
+        throw new ProjectValidationError('プロジェクトIDが無効または存在しません。');
     }
     if (!isString(sanitized.name) || !sanitized.name) {
-        throw new Error('プロジェクト名が無効または存在しません。');
+        throw new ProjectValidationError('プロジェクト名が無効または存在しません。');
     }
     if (!isString(sanitized.lastModified) || isNaN(new Date(sanitized.lastModified).getTime())) {
         sanitized.lastModified = new Date().toISOString();


### PR DESCRIPTION
## Summary
- Issue #27: corrupted records (missing required fields) no longer pollute `allProjectsData` or stale-bind `activeProjectId`. Detection via `validateAndSanitizeProjectData` on read.
- Issue #28: Dexie initialization failures are now catchable at the call site (lazy init pattern), preventing white-screen on module-evaluation throw.
- M2 PR-A `/review-pr` で deferred された 2 つの silent-failure-hunter HIGH finding をバンドル修正。
- AC 検証中に `App.tsx` の早期 return path に `<Toast />` が無く AC-X2 が UI に反映されない問題を発見、同 PR 内で修正（commit `941e187`）。

## Changes (7 files, +82 / -23)
- `db/dexie.ts`: `export const db = createDb()` → `export const getDb()` lazy memoize (Issue #28)
- `db/projectRepository.ts`: read 側に `validateAndSanitizeProjectData` 適用 + `getDb()` 採用 (Issue #27 root cause fix)
- `db/tutorialRepository.ts`, `db/analysisHistoryRepository.ts`: `getDb()` 採用
- `hooks/useLocalSync.ts`:
  - 既存 `activeProjectId` を `allProjectsData` で検証（dangling-id guard）
  - フォールバックは `healthyProjects[0]?.id ?? null` に限定
  - 失敗 record 毎の `console.error` + 集約 error toast
  - 空 projectList 時に stale `activeProjectId` をクリア
- `App.tsx`: `!activeProjectId || !activeProjectData` 早期 return ブランチで `<ProjectSelectionScreen />` を `<><Toast />…</>` で囲み、当該分岐でも toast が DOM にマウントされるように修正（AC-X2 を真に充足）
- `tests/例外系テスト.md`: TC-EX-IDB-001〜005 手動シナリオ + AC-X4 検証制限事項を追記

## Quality gates
- [x] `npm run lint` PASS（tsc --noEmit、Toast マウント修正後にも再 PASS）
- [x] `/simplify` 3-agent (reuse / quality / efficiency) — HIGH 0、コメント簡素化のみ反映
- [x] `/codex plan` セカンドオピニオン（lazy init memoize 推奨、Proxy/singleton 不要、AC-X4 limitation 許容）
- [x] `/safe-refactor` — HIGH/MEDIUM/LOW 0
- [x] `/evaluator` — HIGH FAIL（X1/X2 corrupted 検出ロジック gap）検出 → `validateAndSanitizeProjectData` を read 側に適用して修正 → 自己再評価で PASS

## Acceptance Criteria
- AC-X1: corrupted record 1 件混在 → activeProjectId healthy or null + toast → ✅ PASS（**Playwright MCP 自動検証 TC-EX-IDB-001 で実機確認**）
- AC-X2: 全 corrupted → null + toast → ✅ PASS（**当初 toast 非表示で FAIL → App.tsx 修正後 TC-EX-IDB-002 で再検証 PASS**）
- AC-X3: 健全 IDB → PR-A AC A1〜A10 退行なし → ✅ PASS（**TC-EX-IDB-003 で everShownToast=false / Console errors=0 確認**）
- AC-X4: DB 初期化失敗 → white screen 回避（runtime 検証は test framework 未導入のため `tests/例外系テスト.md` で明記）→ UNTESTABLE（仕様）
- AC-X5: console.error に corrupted 詳細出力 → ✅ PASS（**全 TC で `Failed to load project <id>: ProjectValidationError: …` を Console に確認**）
- AC-X6: lint PASS → ✅ PASS

## Test plan (Playwright MCP 自動検証完了 2026-04-27)
検証は `feature/m2-uselocalsync-hardening` ブランチの dev server (`npm run dev`) に対して実施。各 TC で 6 秒間 100ms 間隔の DOM polling を行い、toast 出現タイミング・最終 DOM・Console error を観測。

- [x] **TC-EX-IDB-001** ✅ PASS: 健全 project 2 件作成 → 1 件の `name` のみ削除（`id`/`lastModified` 保持）→ リロード → toast 「プロジェクト 1 件の読み込みに失敗しました（破損データを除外しました）」が t=0〜2425ms 表示 + activeProjectId は healthy（テスト2）+ Console に `Failed to load project 6a466e87-…: ProjectValidationError: プロジェクト名が無効または存在しません。`
- [x] **TC-EX-IDB-002** ✅ PASS（App.tsx Toast マウント修正後）: project 1 件のみ作成 → `name` 削除 → リロード → toast 表示 + activeProjectId null + ProjectSelectionScreen「まだプロジェクトがありません」+ Console validation error
- [x] **TC-EX-IDB-003** ✅ PASS: 健全 project（テスト1）のみで起動 → toast 非表示 + Console errors 0 + Desktop View 直接遷移（`isProjSel: false`、PR-A AC A1〜A10 退行なし）
- [x] **TC-EX-IDB-004** ✅ PASS: project a (テスト1), b (テスト3) 作成、active=テスト3 → テスト3 の `name` 削除 → リロード → activeProjectId は dangling-id guard により healthy なテスト1 にフォールバック + toast 表示 + Console に corrupted record `57dd197c-…` の validation error
- [x] **TC-EX-IDB-005** ⚠️ UNTESTABLE（automated）: playwright-mcp に incognito context 切替コマンドが無く、`indexedDB.open` を永続的に失敗させる手段も PR scope を逸脱するため automated 検証は実施せず。AC-X4 の UNTESTABLE 扱いに準ずる。手動検証はシークレットモードで http://localhost:3000 を開き「ローカルデータの読み込みに失敗しました…」toast 表示と white screen 非発生を確認することで実施可能。
- [x] `npm run lint` PASS

## Out of scope (follow-up)
本 PR では扱わない既知事項。重要度に応じて別 Issue 化推奨:
- `setActiveProjectId` 経由の `historyTree` 初期化欠落（pre-existing in main、useLocalSync が `setState` 直叩きのため。本 PR と独立した behavior gap）
- `listProjects` IO 失敗時の error message 誤誘導（IDB 不可ではない IO エラーで「プライベートモードや容量不足で…」が表示される可能性、低優先度）
- 自動テスト基盤導入（リポジトリポリシー、別 Issue で議論。本 PR の AC-X4 limitation の根本解消にも関連）
- `lastModified` を欠く record は secondary index に現れず `listProjects` から不可視（実害なし、運用上の注意点）
- TC-EX-IDB-005 を Playwright で再現するための incognito context 起動経路（playwright-mcp の capabilities 拡張または DevTools Protocol 経由 storage quota 制御）

Closes #27
Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)
