### PR TITLE
docs(handoff): record M2 PR-B + PR-Bx merge state for next session

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ Browser → fetch(/api/ai/*) → server/routes/ → server/services/ → Vertex 
 
 ### 状態管理（Zustand slices pattern）
 
-`store/index.ts` で9スライスを結合（`persist` ミドルウェアは未使用、メモリのみ）。永続化は `syncSlice` 経由で Firestore へ書き込み（2秒 debounce + `beforeunload`/`visibilitychange` で flush、`hooks/useFirestoreSync.ts`）。
+`store/index.ts` で 10 スライス（M2 PR-B で `authSlice` 追加）を結合（`persist` ミドルウェアは未使用、メモリのみ）。永続化は `syncSlice` 経由で IndexedDB（Dexie.js）へ書き込み（2 秒 debounce + `beforeunload`/`visibilitychange` で flush、`hooks/useLocalSync.ts`）。
 
 | スライス | 責務 |
 |---------|------|
@@ -58,11 +58,12 @@ Browser → fetch(/api/ai/*) → server/routes/ → server/services/ → Vertex 
 | uiSlice | モーダル、サイドバー、タブ、トースト等のUI状態 |
 | dataSlice | 小説本文、設定、ナレッジ、プロット、タイムラインの変更 |
 | aiSlice | AI呼び出し、生成モード、複数候補管理 |
-| historySlice | ツリー構造の undo/redo（最大10ノード、メモリのみ・Firestore に書かない） |
-| syncSlice | Firestore 同期（2秒 debounce → `flushSave` → `PUT /api/projects/:id`） |
-| tutorialSlice | 5種チュートリアルの進捗 |
-| analysisHistorySlice | テキストインポート分析の履歴 |
+| historySlice | ツリー構造の undo/redo（最大10ノード、メモリのみ・IndexedDB にも書かない） |
+| syncSlice | IndexedDB 同期（2 秒 debounce → `flushSave` → `putProject` via `db/projectRepository.ts`、M2 PR-A で Firestore から移行） |
+| tutorialSlice | 5種チュートリアルの進捗（IndexedDB の `tutorialState` ストア） |
+| analysisHistorySlice | テキストインポート分析の履歴（IndexedDB の `analysisHistory` ストア） |
 | formSlice | フォーム状態 |
+| authSlice | Firebase Auth 状態（`currentUser` / `authStatus: 'initializing' \| 'unauthenticated' \| 'authenticated'` / `authError`、IndexedDB は uid に紐付けない設計、M2 PR-B で導入） |
 
 ### 型定義
 

--- a/docs/adr/0001-local-first-architecture.md
+++ b/docs/adr/0001-local-first-architecture.md
@@ -85,7 +85,7 @@
 |---|---|---|
 | M0 | 緊急対応（Cloud Run 非公開化、max-instances 制限、予算アラート） | ✅ 完了（2026-04-25） |
 | M1 | 基盤整備（IaC 化、防御層、Firebase 準備） | ✅ 完了（2026-04-26） |
-| M2 | 認証 + IndexedDB 移行 | 🚧 進行中（PR-A IndexedDB 移行 ✅ 2026-04-26 PR #24 / PR-B Auth FE ⏳ / PR-C 旧ルート退役 ⏳） |
+| M2 | 認証 + IndexedDB 移行 | 🚧 進行中（PR-A IndexedDB 移行 ✅ 2026-04-26 PR #24 / PR-Bx useLocalSync hardening ✅ 2026-04-27 PR #31 / PR-B Auth FE ✅ 2026-04-27 PR #29 / PR-C 旧ルート退役 ⏳） |
 | M3 | AI 認証ゲート + クォータ | ⏳ |
 | M4 | Export/Import + バックアップ警告 UI | ⏳ |
 | M5 | Stripe Subscription + Webhook + 法務 | ⏳ |

--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -1,113 +1,133 @@
-# Handoff: PR-Bx (useLocalSync hardening) 全品質ゲート完了 + PR #29/#31 実機検証待ち
+# Handoff: M2 PR-B + PR-Bx merge 完了 / Issue #27 #28 自動 close / 残 PR-C のみ
 
 - Session Date: 2026-04-27
 - Owner: yasushi-honda
-- Status: ✅ 再開可能（PR #29 + PR #31 が open、両者ともユーザー側手動 AC 検証待ち）
+- Status: ✅ 再開可能（M2 マイルストーン: PR-A ✅ / PR-Bx ✅ / PR-B ✅ / PR-C ⏳）
 
 ## 今セッションの完了内容
 
 | 区分 | 完了事項 | 成果物 |
 |---|---|---|
-| マージ | 前セッションの handoff docs を merge、main 同期 | PR #30 (279aedb) |
-| Triage | Issue #27 / #28 に triage 結論コメント追加（P1/P2 相当、修正方針、PR-Bx でバンドル方針を明記） | issue-comment 4322936841 / 4322938467 |
-| 実装 | PR-Bx: useLocalSync hardening (Issue #27 + #28 バンドル修正) を 7 ファイルで実装 | feature ブランチ `feature/m2-uselocalsync-hardening` (2 commits / 7 files / +94 / -19) |
-| 主要変更 | `db/dexie.ts` lazy init pattern (`getDb()`)、`db/projectRepository.ts:getProject` に `validateAndSanitizeProjectData` 適用、`utils.ts` に `ProjectValidationError` クラス導入、`hooks/useLocalSync.ts` に corrupted record handling + activeProjectId stale 検証 + validation/infrastructure error 分類 | 同上 |
-| 品質ゲート | `npm run lint` PASS / `/simplify` 3-agent (HIGH 0) / `/codex plan` セカンドオピニオン / `/safe-refactor` (全 0) / `/evaluator` (HIGH FAIL 検出 → validation on read 適用で修正 → PASS) / `/review-pr` 6-agent (Critical 0、Important #1 修正反映) | 5 ゲート全 PASS |
-| PR 作成 | https://github.com/Yukina1116/novel-writer/pull/31 — Test plan に TC-EX-IDB-001〜005 + Out of scope 4 件 + AC-X1〜X6 を明記 | PR #31 |
-| Review iteration | `/review-pr` silent-failure-hunter Important #1 (validation/infrastructure 誤分類) を 2nd commit (9e39473) で修正、PR コメントで適用状況を documenter | comment 4323013261 |
+| AC 検証 | PR #31 (PR-Bx useLocalSync hardening) を Playwright MCP で AC 検証完了 (TC-EX-IDB-001/002/003/004 PASS、005 は AC-X4 同様 UNTESTABLE 扱い) | PR #31 |
+| 追加修正 | PR #31 内に commit `941e187` (`App.tsx` 早期 return path に `<Toast />` マウント、AC-X2 真の充足) | commit 941e187 |
+| マージ | PR #31 squash merge → commit `c1e43a0` on main、Issue #27 / #28 自動クローズ | PR #31 → c1e43a0 |
+| Firebase 設定 | `firebase apps:create WEB` で `novel-writer-dev-web` (App ID `1:446321146441:web:285a9e0bbd4146e15b1d98`) を CLI 登録、SDK config 取得、`.env.local` 作成、Google プロバイダ有効化（ユーザー操作） | Firebase Console |
+| AC 検証 | PR #29 (PR-B Firebase Auth FE) を Playwright MCP + Firebase Auth Emulator で AC 検証完了（Pre-flight + B1〜B8 + B3-err1/B3-err2、合計 11 項目 PASS） | PR #29 |
+| 追加修正 | PR #29 内に commit `83157f4` (server/index.ts CSP 拡張: `cdn.tailwindcss.com` `aistudiocdn.com` `fonts.googleapis.com` `fonts.gstatic.com` 追加 + `cors` の origin function を「同一ホスト自動許可」に拡張) | commit 83157f4 |
+| 主要設計判断 | `authStatus = 'initializing' → unauthenticated/authenticated` の遷移が Firebase の `onAuthStateChanged` で 200ms 以内に完了することを実機確認、 `useRequiresAuth` フック経由で 7 ファイル / 17 箇所の AI ボタンが Tier 0 disable + tooltip 化、IDB レコードが uid 切替で完全保持されることを実証 (`idbCountStableAcrossAccountSwitch=true` + `idbIdsIdenticalAcrossSwitch=true`) | 同上 |
+| マージ | PR #29 squash merge → commit `e68079a` on main、Cloud Run 自動デプロイ ✅ success (run 24972945015) | PR #29 → e68079a |
+| ドキュメント | `docs/spec/m2/tasks.md` PR-B AC を全 [x] 化、Pre-flight + B3-err1/B3-err2 を AC セクションに追加記録、検証中の追加修正（CSP 拡張、cors 同一ホスト自動許可）を tasks.md に記録 | tasks.md |
+| ドキュメント | 本 handoff PR で ADR-0001 ロードマップ表 M2 を「PR-A ✅ / PR-Bx ✅ / PR-B ✅ / PR-C ⏳」に更新、CLAUDE.md "状態管理" セクションを Firestore→IndexedDB 反映に修正 + `authSlice` 追記 | 本 PR |
 
 ## 次セッション開始時の状態
 
-- ブランチ: `main` clean、origin/main と同期済み (commit 279aedb)
-- 進行中の feature ブランチ:
-  - `feature/m2-firebase-auth-fe` — PR #29 open、Firebase Console 設定 + AC 検証待ち（前セッションから継続）
-  - `feature/m2-uselocalsync-hardening` — PR #31 open、コード変更完了 (2 commits)、AC 検証待ち
-  - `docs/handoff-pr-bx` — 本ハンドオフ用ブランチ
-- Open Issue: 2 件 (#27 / #28、両方とも PR #31 マージで `Closes` により自動クローズ予定)
-- Open PR: 3 件 (#29, #31, 本セッションで作る handoff PR)
+- ブランチ: `main` clean、origin/main と同期済み (commit e68079a)
+- 進行中の feature ブランチ: `docs/handoff-pr-b-bx-merged` — 本ハンドオフ用
+- Open Issue: 0 件
+- Open PR: 1 件（本セッションで作る handoff PR）
 - グローバル `~/.claude/` への変更なし (プロジェクト CLAUDE.md §1 遵守)
 - main 直 push なし、feature ブランチ + PR 運用維持 (プロジェクト CLAUDE.md §2 遵守)
 
 ## 次のアクション (推奨順)
 
-### 1. PR #31 (PR-Bx useLocalSync hardening) 実機 AC 検証 → merge
-- Pre-flight: `npm run dev` 起動（リポジトリ root から）
-- `tests/例外系テスト.md` の TC-EX-IDB-001〜005 を順次実行（DevTools > Application > IndexedDB の手動操作）
-  - TC-EX-IDB-001: corrupted record 1 件混在 → toast 「破損データを除外しました」表示、activeProjectId healthy 選択
-  - TC-EX-IDB-002: 全 corrupted → null + toast、空のプロジェクト一覧画面
-  - TC-EX-IDB-003: 健全 IDB → PR-A AC A1〜A10 退行なし
-  - TC-EX-IDB-004: stale activeProjectId → healthy fallback
-  - TC-EX-IDB-005: プライベートモードで IDB 利用不可 → toast 表示、white screen 回避
-- 全 PASS 後 → `gh pr merge 31 --squash --delete-branch`（明示認可必須）
-- merge 後、Issue #27 / #28 が自動クローズされることを確認
+### 1. 本ハンドオフ PR をレビュー → merge
+- `gh pr view <本 PR>` で内容確認
+- ユーザー明示認可後 `gh pr merge <PR#> --squash --delete-branch`
 
-### 2. PR #29 (M2 PR-B Firebase Auth FE) Firebase Console 設定 + AC 検証 → merge
-- 詳細手順: 前セッション handoff (commit 279aedb の `docs/handoff/LATEST.md` を `git show 279aedb:docs/handoff/LATEST.md` で参照)
-- Firebase Console → `novel-writer-dev` Web アプリ登録 → SDK config 取得 → `.env.local` 作成
-- AC B1〜B8 + B3-err1/err2 + Pre-flight (`.env.local` fail-fast) を順次検証
-- 全 PASS 後 → `docs/spec/m2/tasks.md` PR-B AC を `[x]` 化 → `gh pr merge 29 --squash --delete-branch`
+### 2. PR-C 着手（M2 最終 PR、`/api/projects` `/api/data` 退役 + Firestore メタ縮小 + ID Token 検証ミドルウェア）
+- `git checkout main && git fetch && git reset --hard origin/main`
+- `git checkout -b feature/m2-server-retirement`
+- `/impl-plan` 起動（中規模・クロスレイヤー変更のため必須）
+- ベース資料: `docs/spec/m2/tasks.md` PR-C C.1〜C.5 + AC C1〜C7 + リスク R12〜R15
+- 実装内容（spec 抜粋）:
+  - **C.1**: `server/routes/projects.ts` / `server/routes/data.ts` / `server/services/projectService.ts` / `server/firestoreClient.ts` / `projectApi.ts` (FE) 削除、`server/index.ts` の mount 行削除、firestore を `firebase-admin/firestore` の `getFirestore(getFirebaseAdminApp())` 経由に統合
+  - **C.2**: `server/middleware/verifyIdToken.ts` 新規作成（Bearer ID Token 検証）
+  - **C.3**: `server/routes/users.ts` 新規（`POST /api/users/init` で Firestore `users/{uid}` 初期化、`verifyIdToken` ミドルウェア適用）
+  - **C.4**: route 側 keys allowlist + enum 検証（admin SDK rules bypass の防御）
+  - **C.5**: CLAUDE.md "AI API層" 表更新（`/api/projects` 削除 + `/api/users/init` 追加）
+  - **firestore.rules 初版**（M3 で正式運用、本 PR では `users/{uid}` の uid 一致書込みのみ許可）
+- 同 PR で更新するドキュメント:
+  - `CLAUDE.md` "AI API層" 表（`/api/projects` 行削除 + `/api/users/init` 行追加）
+  - ADR-0001 ロードマップ表（M2 を ✅ 完了に更新、PR-C の merge 時点で）
+  - `docs/spec/m2/tasks.md` PR-C AC を順次 [x] 化、最後に M2 完了の定義 4 項目を [x] 化
 
-### 3. PR-C 着手準備（PR #29 / #31 両方 merge 後）
-- `git checkout main && git pull --rebase`
-- `docs/spec/m2/tasks.md` PR-B / PR-Bx AC を `[x]` 化（マージ前に完了していなければ）
-- ADR-0001 ロードマップ表で M2 を「PR-B ✅ / PR-Bx ✅」に更新
-- PR-C (`/api/projects` `/api/data` 退役 + Firestore メタ縮小 + ID Token 検証ミドルウェア) 着手:
-  - ブランチ `feature/m2-server-retirement`
-  - `/impl-plan` 起動
-  - tasks.md PR-C C.1〜C.5 + AC C1〜C7 + リスク R12〜R15 を計画ベースに
+### 3. M2 完了振り返り（PR-C merge 後）
+- `docs/spec/m2/tasks.md` 末尾「M2 完了の定義」全 [x] 化
+- ADR-0001 末尾に M2 振り返り追記（M1 と同流儀）
+- ADR-0001 ロードマップ表 M2 を ✅ 完了に最終更新
 
-### 4. (Optional) PR #31 への follow-up
-PR #31 description の "Out of scope" に記載済の 4 件を必要に応じて Issue 化:
-- `setActiveProjectId` 経由の `historyTree` 初期化欠落（pre-existing in main、useLocalSync `setState` 直叩き）
-- `listProjects` IO 失敗時の error message 誤誘導（generic "プライベートモードや容量不足で…" を non-IDB error にも表示）
-- 自動テスト基盤導入（Vitest + Firebase Auth emulator + Dexie mock の検討、AC-X4 limitation 解消にも寄与）
-- React strict mode で toast 二重発火（dev mode 限定、production 影響なし）
-
-いずれも CLAUDE.md triage 基準（rating ≥7 + confidence ≥80）には届かないため、必要性が出たタイミングで起票検討。
+### 4. (Optional) M2 振り返り後の M3 計画前段
+- M3 = AI 認証ゲート + クォータ。PR-C で導入する `verifyIdToken` ミドルウェアを `/api/ai/*` に適用、FE から `Authorization: Bearer <ID Token>` 付与の仕組みを実装（spec B.5 注記参照）
+- `--allow-unauthenticated` 復活の再評価も M3 の対象
 
 ## 申し送り事項 (重要)
 
-### PR #31 で確定した重要設計判断
-- **`getProject` は read 側で validation を行う**: Dexie は schema 強制せず、corrupted record (id/name 欠落) は raw object として返る。`putProject` 側でしか validation していなかった非対称を解消。`@throws ProjectValidationError` で documentation。
-- **`ProjectValidationError` を導入**: validation 失敗と infrastructure error (Dexie transient, IDB unavailable 等) を `instanceof` で区別。toast 文言を「破損データを除外しました」 vs 「一時的なエラーの可能性があります、リロードで復旧する場合があります」に branch。
-- **`db/dexie.ts` を lazy init に**: `let _db = null; getDb() => _db ??= createDb()` で module 評価時の同期 throw を call site に移動。`useLocalSync` の既存 try/catch で実効的に拾えるようになる。
-- **`activeProjectId` の stale 検証**: 既存値が `allProjectsData` に存在するかチェックし、なければ healthy 先頭か null へ fallback。空 projectList 時も stale id をクリア。
+### PR #29 / PR #31 で確定した重要設計判断
 
-### PR #31 / #29 共通の運用注意
-- **manual AC 検証は user 操作必須**: Claude は dev server 起動・DevTools 操作・実機検証を直接実行できないため、ユーザーがブラウザ操作 + Claude が結果解釈支援。
-- **ハンドオフ間の作業並列性**: PR #29 (Firebase Auth FE) と PR #31 (useLocalSync hardening) は別ファイル変更で **コンフリクトなし**。先にどちらを merge しても問題ない。
-- **AC 検証の優先度**: PR #31 の方が手順がシンプル（Firebase Console 設定不要）なので先行検証推奨。
+**PR #31 (PR-Bx)**:
+- **`getProject` は read 側で validation を行う**: Dexie は schema 強制せず、corrupted record (id/name 欠落) は raw object として返る → `validateAndSanitizeProjectData` を read 経由でも適用
+- **`ProjectValidationError` を導入**: validation 失敗と infrastructure error を `instanceof` で区別、toast 文言を branch
+- **`db/dexie.ts` を lazy init に**: `let _db = null; getDb() => _db ??= createDb()` で module 評価時の同期 throw を call site に移動
+- **`activeProjectId` の stale 検証**: 既存値が `allProjectsData` に存在するかチェック、空 projectList 時も stale id をクリア
+- **`App.tsx` 早期 return path に `<Toast />` マウント**: AC-X2「activeProjectId null + toast」を真に充足するため。ProjectSelectionScreen 内では Toast コンポーネントが render されない構造を AC 検証中に発見、PR #31 内で追加修正
 
-### PR-C 着手時のドキュメント更新ポイント
-- `CLAUDE.md` "AI API層" 表 — `/api/projects` 削除 + `/api/users/init` 追加 (spec C.5)
-- `CLAUDE.md` "状態管理" セクション — `syncSlice` の保存先を IndexedDB に修正 (PR-A 由来)、`authSlice` 追記 (PR-B 由来)
-- ADR-0001 ロードマップ表で M2 を「PR-B ✅ / PR-Bx ✅ / PR-C ⏳」へ進捗記載
+**PR #29 (PR-B)**:
+- **検証中に発見した CSP / cors 修正**:
+  - CSP `scriptSrc` に `https://cdn.tailwindcss.com` `https://aistudiocdn.com` 追加（pre-existing index.html 依存）
+  - CSP `styleSrc` に `https://fonts.googleapis.com`、`fontSrc` に `https://fonts.gstatic.com` 追加
+  - `cors` の origin function を「同一ホストなら自動許可」に拡張: `new URL(origin).host === req.headers.host` のチェックを追加して、同一オリジン静的アセット fetch（`/assets/index-*.{js,css}`）の自己 403 を回避
+- **B6 caveat (記録済み)**: `signInWithPopup` の callback 自動完結は Playwright MCP の chromium 環境で popup auto-close + postMessage callback 経路が block される → 本 PR の AC 検証は `signInWithEmailAndPassword` で代替実証。本物 Chrome では問題ない
+- **B7 で IDB uid 非紐付けを実証**: account A → signOut → account B 切替で IDB レコード件数 + ID 完全一致（spec の重要設計判断「IndexedDB は uid に紐付けない（uid 切替で消えない）」を E2E で確認）
+
+### Firebase 設定の現状（PR-C / M3 で参照）
+
+- Web App ID: `1:446321146441:web:285a9e0bbd4146e15b1d98`（`novel-writer-dev-web`、`novel-writer-dev` プロジェクト）
+- SDK config 6 値は `.env.local`（gitignore）に投入済み、`.env.example` に項目テンプレート
+- Auth Emulator: `firebase emulators:start --only auth` で `127.0.0.1:9099`、`firebase.json` に設定済
+- `npm run dev:emu` で `VITE_USE_AUTH_EMULATOR=true` + vite + emulator 並列起動
+
+### CLAUDE.md / ADR-0001 の更新状況（本 PR で対応）
+
+- ✅ ADR-0001 ロードマップ表 M2 を「PR-Bx ✅ / PR-B ✅」に更新
+- ✅ CLAUDE.md "状態管理" syncSlice 行を IndexedDB 経由に修正（PR-A merge 時点で嘘記載になっていたため遅延訂正）+ `authSlice` 追記（PR-B 由来）
+- ⏳ CLAUDE.md "AI API層" 表 — PR-C 着手時に更新（`/api/projects` 削除 + `/api/users/init` 追加）
+
+### Out of scope / フォローアップ候補（Issue 化は triage 基準を満たした時点で）
+
+PR #29 / PR #31 description の "Out of scope" に詳細記載済。CLAUDE.md triage 基準（rating ≥ 7 + confidence ≥ 80 / 実害あり / 再現バグ / CI 破壊 / ユーザー明示指示）を満たさないため現時点で Issue 化せず:
+
+- **silent-failure-hunter C-1**: `firebaseClient.ts` module-level throw は ErrorBoundary に届かず white screen（Issue #28 の Dexie 同型問題は PR #31 で `getDb()` lazy init 化により解決済、firebase 側は未対応）
+- **silent-failure-hunter H-1**: Firebase 503 outage で `unauthenticated` に demote → `authStatus='error'` + sticky banner が望ましい
+- **type-design-analyzer Important×3**: `createAuthSlice` の `(set, get)` パラメータ型付け / `RequiresAuthState` 判別共用体化 / `REQUIRED_KEYS` を `RequiredFirebaseEnv` 型から派生
+- **pr-test-analyzer S1〜S4**: Strict Mode 二重 subscribe / cross-tab sync / 連打 race / Auth Emulator フロー差分（M3 で vitest + Firebase Auth emulator 自動テスト基盤導入後に機械化）
+- **Pre-existing 課題**: `index.html` の `cdn.tailwindcss.com` runtime → 本来 PostCSS plugin 化、`aistudiocdn.com` の importmap → bundle 化推奨。Console warning が prod 起動時に出る（CSP allowlist で迂回中）
+- **PR #31 Out of scope 4 件**: `setActiveProjectId` 経由の `historyTree` 初期化欠落 / `listProjects` IO 失敗時のメッセージ誤誘導 / 自動テスト基盤 / `lastModified` を欠く record 不可視
 
 ### 環境状況
+
 - `.envrc` 設定済 (GH_TOKEN 自動取得 + GCP `novel-writer-dev`)
 - `cd ~/Projects/学校/yamashita/novel-writer && claude` で起動すれば direnv 経由で正しいアカウントが有効化される
-- 残留 Node プロセスなし（cleanup-node.sh 確認済）
+- 残留 Node プロセスなし
 
 ## Issue Net 変化
 
-- Close 数: 0 件
+- Close 数: 2 件 (#27, #28、PR #31 マージで `Closes` 自動クローズ)
 - 起票数: 0 件
-- コメント追加: 2 件（#27 / #28 triage 結論記録）
-- Net: ±0
-- **進捗の質**: Net = 0 だが、本セッションの主要進捗は `[PR #30 merge + Issue #27/#28 triage 結論記録 + PR #31 (PR-Bx) 全品質ゲート通過状態で open]` で M2 マイルストーンの追加進捗。PR #31 merge 後に Net = -2 になる予定（`Closes #27` `Closes #28`）。Issue 起票はゼロ（既存 issue の triage と PR 作成のみ、新規問題は未発見）。
+- Net: -2 件 ✅
+- **進捗の質**: Net = -2 で Issue 削減成功。両 issue とも PR-A の `/review-pr` で発見された未対処事項 (corrupted record swallow + Dexie module-level throw) を PR-Bx でバンドル修正、AC 検証で App.tsx Toast マウント漏れも併せて修正。本セッションの主要進捗は `[PR #31 (PR-Bx) merge + Issue #27/#28 close + PR #29 (PR-B) merge]` で M2 マイルストーン PR-A/PR-Bx/PR-B 全て完了、残 PR-C のみ。
 
 ## ドキュメント整合性
 
 | 項目 | 状態 | 備考 |
 |---|---|---|
 | `docs/spec/m2/tasks.md` PR-A セクション | AC `[x]` 全 9 項目 + 品質ゲート | PR #24 マージ前に更新済 |
-| `docs/spec/m2/tasks.md` PR-B セクション | AC `[ ]` のまま | PR #29 実機検証後に `[x]` 化する運用 |
-| `docs/spec/m2/tasks.md` PR-C | `⏳` のまま | PR-B / PR-Bx 後に着手 |
-| ADR-0001 ロードマップ表 | M2 「進行中 (PR-A ✅ / PR-B ⏳ / PR-C ⏳)」 | PR-Bx (Issue #27/#28 follow-up) は M2 内の bug fix 扱いで roadmap への明示行追加は不要 |
-| `CLAUDE.md` "AI API層" 表 | 未更新 | PR-C 着手時に更新 |
-| `CLAUDE.md` "状態管理" セクション | 未更新 | PR-C 着手時に `syncSlice` 修正 + `authSlice` 追記 |
+| `docs/spec/m2/tasks.md` PR-B セクション | AC `[x]` 全 8 項目 + Pre-flight + B3-err1/B3-err2 + 検証中追加修正記録 | PR #29 検証完了で本セッション更新 |
+| `docs/spec/m2/tasks.md` PR-C | `⏳` のまま | PR-C 着手時に進捗反映 |
+| ADR-0001 ロードマップ表 | M2 「進行中 (PR-A ✅ / PR-Bx ✅ / PR-B ✅ / PR-C ⏳)」 | 本 PR で更新 |
+| `CLAUDE.md` "AI API層" 表 | 未更新 | PR-C 着手時に更新（`/api/projects` 削除 + `/api/users/init` 追加） |
+| `CLAUDE.md` "状態管理" セクション | 更新済 | 本 PR で IndexedDB 反映 + `authSlice` 追記 |
 | `tests/例外系テスト.md` ローカル永続化セクション | TC-EX-IDB-001〜005 + AC-X4 検証制限事項 追記済 | PR #31 で追加 |
 
 ## 残留プロセス
 
-✅ なし (cleanup-node.sh 確認済)
+✅ なし


### PR DESCRIPTION
## Summary
- 今セッションで PR #31 (PR-Bx useLocalSync hardening) と PR #29 (PR-B Firebase Auth FE) を AC 検証完了 → squash merge。
- Issue #27 / #28 は PR #31 の `Closes` で自動クローズ。
- M2 マイルストーン進捗: PR-A ✅ / PR-Bx ✅ / PR-B ✅ → 残 **PR-C のみ**。
- 検証中に発見した修正を同 PR にバンドル: PR #31 で `App.tsx` Toast マウント (commit 941e187)、PR #29 で CSP 拡張 + cors 同一ホスト自動許可 (commit 83157f4)。

## Changes (3 files)
- `docs/handoff/LATEST.md`: 全面更新（次セッションは PR-C `/impl-plan` 起動から開始）
- `docs/adr/0001-local-first-architecture.md`: ロードマップ表 M2 を「PR-A ✅ / PR-Bx ✅ 2026-04-27 PR #31 / PR-B ✅ 2026-04-27 PR #29 / PR-C ⏳」に更新
- `CLAUDE.md`: "状態管理" セクションを修正 — `syncSlice` を Firestore→IndexedDB 経由に書換（PR-A merge 時の更新漏れの遅延訂正）、`authSlice` (M2 PR-B 由来) 追記、tutorialSlice/analysisHistorySlice の保存先も IndexedDB に明記

## Issue Net 変化
- Close 数: 2 件 (#27, #28、PR #31 マージで自動クローズ)
- 起票数: 0 件
- Net: **-2 件 ✅**

## Test plan
- [x] `cat docs/handoff/LATEST.md` で記載内容確認
- [x] ADR-0001 ロードマップ表で M2 行を確認 (line 88)
- [x] CLAUDE.md "状態管理" セクション (line 51-) で IndexedDB 反映 + authSlice 追記を確認
- [x] 次セッションが本ハンドオフを読んで PR-C `/impl-plan` 着手できる状態であることを確認
- [x] `npm run lint` PASS（コード変更なしのドキュメントのみ PR、参考確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)