### PR TITLE
chore(ci): bump GH Actions to Node 24 versions (M3 prep)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,15 +18,15 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - id: auth
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: projects/446321146441/locations/global/workloadIdentityPools/github-pool/providers/github-provider
           service_account: github-deploy@novel-writer-dev.iam.gserviceaccount.com
 
-      - uses: google-github-actions/setup-gcloud@v2
+      - uses: google-github-actions/setup-gcloud@v3
 
       - name: Configure Docker
         run: gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev --quiet
@@ -40,11 +40,13 @@ jobs:
           docker push "$IMAGE"
 
       - id: deploy
-        uses: google-github-actions/deploy-cloudrun@v2
+        uses: google-github-actions/deploy-cloudrun@v3
         with:
           service: ${{ env.SERVICE }}
           region: ${{ env.REGION }}
           image: ${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/${{ env.SERVICE }}:${{ github.sha }}
+          # v3 で wait のデフォルトが false に変更されたため、Output URL step が steps.deploy.outputs.url を参照する都合上、明示的に true を指定
+          wait: true
           flags: >-
             --service-account=novel-writer-run@novel-writer-dev.iam.gserviceaccount.com
             --memory=512Mi

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,8 +45,6 @@ jobs:
           service: ${{ env.SERVICE }}
           region: ${{ env.REGION }}
           image: ${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/${{ env.SERVICE }}:${{ github.sha }}
-          # v3 で wait のデフォルトが false に変更されたため、Output URL step が steps.deploy.outputs.url を参照する都合上、明示的に true を指定
-          wait: true
           flags: >-
             --service-account=novel-writer-run@novel-writer-dev.iam.gserviceaccount.com
             --memory=512Mi


### PR DESCRIPTION
## Summary
- Node 20 deprecation (2026-06-02 強制、[GitHub blog 2025-09-19](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)) に対応するため、`.github/workflows/deploy.yml` の actions を Node 24 ベースに引き上げる
- `actions/checkout@v4→v5`、`google-github-actions/{auth,setup-gcloud,deploy-cloudrun}@v2→v3`

## Why now
- M3 着手前に独立 PR として済ませる方針（ハンドオフ §3）
- Cloud Run デプロイログでも Node 20 deprecation 警告が出ている

## Compatibility
| action | 現状 → 新 | 削除 input | 影響 |
|---|---|---|---|
| actions/checkout | v4 → v5 | — | Node 24 |
| google-github-actions/auth | v2 → v3 | `retries`, `backoff`, `backoff_limit` | 現 workflow で未使用 → 影響なし |
| google-github-actions/setup-gcloud | v2 → v3 | `skip_tool_cache` | 現 workflow で未使用 → 影響なし |
| google-github-actions/deploy-cloudrun | v2 → v3 | `env_vars_file` | 現 workflow で未使用 → 影響なし |

WIF 設定（`workload_identity_provider` / `service_account`）と `outputs.url` は不変。

### `wait` input について
当初の commit `0974f86` で `wait: true` を明示追加していたが、後続 commit `6a3e243` で revert。経緯:

- 一次ソース ([v2](https://raw.githubusercontent.com/google-github-actions/deploy-cloudrun/v2/action.yml) / [v3](https://raw.githubusercontent.com/google-github-actions/deploy-cloudrun/v3.0.0/action.yml)) で確認した結果、`wait` の default は **v2: `'false'` / v3: `'true'`**（当初調査と逆）
- `wait` input の説明は **"This option only applies to jobs."** — Cloud Run **Jobs** にのみ適用され、本 workflow がデプロイする Cloud Run **Service** には影響しない
- したがって明示指定は冗長 → 純粋な version bump に戻す

## Test plan
- [x] YAML syntax 検証 (`python3 -c "import yaml; yaml.safe_load(...)"` PASS)
- [x] `npm run lint` (tsc --noEmit) PASS
- [ ] merge 後、GitHub Actions の deploy run のログを確認:
  - `actions/checkout@v5` 等の Node 24 actions で実行されること（Node 20 deprecation 警告が消えること）
  - Cloud Run デプロイ成功 (`Output URL` step で URL が出力されること)
  - Cloud Run service の health 維持

## Out of scope
- `actions/checkout` は v6.0.2 (2026-01-09) も release 済だが、ハンドオフ指示に合わせ保守的に v5 採用。v6 への bump は次回メンテで再評価
- M3 持越項目 (5 件) はハンドオフ `docs/handoff/LATEST.md` 参照

🤖 Generated with [Claude Code](https://claude.com/claude-code)