### PR TITLE
docs(adr): reflect M3 PR-E completion in ADR-0001 roadmap

### DIFF
--- a/docs/adr/0001-local-first-architecture.md
+++ b/docs/adr/0001-local-first-architecture.md
@@ -86,7 +86,7 @@
 | M0 | 緊急対応（Cloud Run 非公開化、max-instances 制限、予算アラート） | ✅ 完了（2026-04-25） |
 | M1 | 基盤整備（IaC 化、防御層、Firebase 準備） | ✅ 完了（2026-04-26） |
 | M2 | 認証 + IndexedDB 移行 | ✅ 完了（PR-A IndexedDB 移行 2026-04-26 PR #24 / PR-Bx useLocalSync hardening 2026-04-27 PR #31 / PR-B Auth FE 2026-04-27 PR #29 / PR-C 旧ルート退役 + verifyIdToken + users/init + firestore.rules 2026-04-27） |
-| M3 | AI 認証ゲート + クォータ | 🚧 進行中（PR-D テスト基盤 + 持越 #1/#4/#5 完了 2026-04-27 PR #37 / PR-E〜G 残） |
+| M3 | AI 認証ゲート + クォータ | 🚧 進行中（PR-D テスト基盤 + 持越 #1/#4/#5 / PR-E AI 認証ゲート + 起動 probe + handleApiError 共通化 + 持越 #3 完了 2026-04-27 PR #37 #39 / PR-F〜G 残） |
 | M4 | Export/Import + バックアップ警告 UI | ⏳ |
 | M5 | Stripe Subscription + Webhook + 法務 | ⏳ |
 | M6 | E2EE 暗号化バックアップ（任意機能、後回し可） | ⏳ |


### PR DESCRIPTION
## Summary

handoff PR #42 で更新漏れだった ADR-0001 ロードマップ表の M3 行を 1 行修正する追補 PR。

## 変更
- `docs/adr/0001-local-first-architecture.md` L89:
  - 旧: 「PR-D テスト基盤 + 持越 #1/#4/#5 完了 2026-04-27 PR #37 / PR-E〜G 残」
  - 新: 「PR-D テスト基盤 + 持越 #1/#4/#5 / PR-E AI 認証ゲート + 起動 probe + handleApiError 共通化 + 持越 #3 完了 2026-04-27 PR #37 #39 / PR-F〜G 残」

## 背景
- PR #39 (M3 PR-E) マージ後、`docs/handoff/LATEST.md` と `docs/spec/m3/tasks.md` は PR-E 完了で更新済だったが、ADR-0001 ロードマップ表だけ古い記述のまま残存
- `/handoff` チェックで整合性ギャップとして発見
- 残る M2 持越項目は #2 (FE needsUserInit retry) のみ、PR-G で消化予定

## Test plan
- [x] 修正対象は ADR ファイル 1 行のみ、コード変更なし
- [x] 他のドキュメント (handoff/LATEST.md, spec/m3/tasks.md) との整合確認済
- [ ] マージ後: 次セッション開始時 `/catchup` で ADR / handoff / tasks の整合性が一貫していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)