### PR TITLE
ci: deploy.yml に test job 追加 + pull_request trigger (#41)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,8 @@ name: Deploy to Cloud Run
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
 
 env:
   PROJECT_ID: novel-writer-dev
@@ -11,7 +13,27 @@ env:
   REPOSITORY: novel-writer
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run lint
+
+      - run: npm run test
+
+      - run: npm run test:firestore-rules
+
   deploy:
+    needs: test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

- `.github/workflows/deploy.yml` に test job を新規追加（lint + test + test:firestore-rules）
- deploy job を `needs: test` でガード、test 失敗時に deploy がスキップされる構造に変更
- `pull_request` trigger を追加。PR push 時にも test job が走り、deploy job は `if: github.event_name == 'push' && github.ref == 'refs/heads/main'` で PR 時はスキップ
- Node 22 採用（Dockerfile `node:22-slim` と整合）、npm cache 有効化

## 背景

PR #39 (M3 PR-E) の `/review-pr` で pr-test-analyzer rating 9 として検出。M3 PR-F (usage クォータ) 着手前に CI 側で regression 検知を有効化することで、`mountAiRoutes` から `verifyIdToken` が外れる等の重大 regression を merge 前に阻止する。M3 PR-G の Cloud Run public 化前提（BE 認証必須）を CI で守る。

## Acceptance Criteria

- [x] `.github/workflows/deploy.yml` に test job 追加、`deploy` の `needs:` に登録
- [x] PR push 時にも test job が走るよう trigger を `pull_request` にも拡張
- [x] deploy job が `if: github.event_name == 'push' && github.ref == 'refs/heads/main'` で PR 時にスキップされる（Skipped 表示で目視確認）
- [x] Node version は Dockerfile (`node:22-slim`) と整合の Node 22 を採用
- [ ] (後回し) integration test job — M3 PR-G で usage クォータ込み統合確認時に再検討

## ローカル検証結果

```
$ python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deploy.yml'))" → YAML valid
$ npm run lint → 0 error PASS
$ npm run test → 89/89 PASS
$ npm run test:firestore-rules → 15/15 PASS
```

## Test plan

- [ ] PR push 時に test job が走り、PASS することを GitHub Actions UI で確認
- [ ] PR push 時に deploy job が "Skipped" 表示になることを確認
- [ ] main merge 後に test → deploy の順で実行されることを確認
- [ ] npm cache が有効で 2 回目の `npm ci` が高速化されることを確認

## Out of scope

- 意図的に失敗するテストを push して deploy ブロックを実証する手段（リスク高、PR 内の Skipped 表示で代替）
- `test:integration` job の追加（M3 PR-G で再検討）
- Node 24 への昇格（Dockerfile と同期して別 PR で実施）

## Closes

#41

🤖 Generated with [Claude Code](https://claude.com/claude-code)