### PR TITLE
feat(m3): PR-G FE integration + Cloud Run public 化 + M3 完了

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,7 +72,8 @@ jobs:
             --memory=512Mi
             --timeout=300
             --max-instances=2
-            --set-env-vars=GCP_PROJECT=novel-writer-dev,GCP_LOCATION=asia-northeast1,USE_VERTEX_AI=true
+            --allow-unauthenticated
+            --set-env-vars=GCP_PROJECT=novel-writer-dev,GCP_LOCATION=asia-northeast1,USE_VERTEX_AI=true,NODE_ENV=production
 
       - name: Output URL
         run: echo "Deployed to ${{ steps.deploy.outputs.url }}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,6 +67,12 @@ jobs:
           service: ${{ env.SERVICE }}
           region: ${{ env.REGION }}
           image: ${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/${{ env.SERVICE }}:${{ github.sha }}
+          # --allow-unauthenticated: BE 側で `verifyIdToken` middleware が全
+          # /api/* を保護しており (server/aiRoutes.ts の mountAiRoutes 経由)、
+          # public 化しても無認証 access は構造的に不可能。詳細は
+          # ADR-0001 §M3 振り返り / docs/spec/m3/tasks.md PR-G。
+          # この flag を外すと FE が 403 で詰むため、本番 rollback 時のみ
+          # `gcloud run services update novel-writer --no-allow-unauthenticated` を使う。
           flags: >-
             --service-account=novel-writer-run@novel-writer-dev.iam.gserviceaccount.com
             --memory=512Mi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,21 +38,25 @@ AI駆動の小説執筆支援アプリ（小説らいたーver16）。React + Ty
 Browser → fetch(/api/*) → server/routes/ → server/services/ → Vertex AI (gemini-2.5-flash) / Firestore
 ```
 
-| ルート | サービス / 認証 | 用途 |
+全 `/api/ai/*` route は `mountAiRoutes` で `verifyIdToken` middleware (M3 PR-E) を一括 mount し、各 endpoint は `withUsageQuota` 高階関数 (M3 PR-F) で reserve→handler→commit/cancel の 3 phase ラップ。FE `apiClient.ts` (M3 PR-G) が Bearer 自動付与 + `requestId` 自動生成 + 401/429/503/409 共通分類器を担当。
+
+| ルート | サービス / 認証・クォータ | 用途 |
 |-------|---------|------|
-| `/api/ai/novel/generate` | novelService | 小説続き生成 |
-| `/api/ai/character/{update,reply,image-prompt}` | characterService | キャラクター作成・更新 |
-| `/api/ai/world/{update,reply}` | worldService | 世界観設定 |
-| `/api/ai/image/generate` | imageService | Imagen画像生成 |
-| `/api/ai/utility/{names,knowledge-name,extract-character}` | utilityService | 名前生成、キャラ抽出等 |
-| `/api/ai/analysis/import` | analysisService | テキストインポート分析 |
+| `/api/ai/novel/generate` | novelService + `withUsageQuota('novel/generate', 200 sen)` | 小説続き生成 |
+| `/api/ai/character/{update,reply,image-prompt}` | characterService + `withUsageQuota('character/*', 100 sen)` | キャラクター作成・更新 |
+| `/api/ai/world/{update,reply}` | worldService + `withUsageQuota('world/*', 100 sen)` | 世界観設定 |
+| `/api/ai/image/generate` | imageService + `withUsageQuota('image/generate', 1000 sen)` | Imagen画像生成 |
+| `/api/ai/utility/{names,knowledge-name,extract-character}` | utilityService + `withUsageQuota('utility/*', 50-100 sen)` | 名前生成、キャラ抽出等 |
+| `/api/ai/analysis/import` | analysisService + `withUsageQuota('analysis/import', 200 sen)` | テキストインポート分析 |
 | `/api/users/init` | verifyIdToken middleware → Firestore `users/{uid}` を transaction で冪等初期化（M2 PR-C） | ログイン直後のユーザーメタ初期化 |
 
 - **AIクライアント**: `server/aiClient.ts` — `USE_VERTEX_AI=true`でVertex AI、それ以外はAPIキーモード
 - **プロンプト構築**: `server/services/promptBuilder.ts` — format系ユーティリティ
 - **Firebase Admin**: `server/firebaseAdmin.ts` — `getFirebaseAdminApp()` / `getFirebaseAuth()` / `getFirebaseFirestore()`（M2 PR-C で `firestoreClient.ts` から統合）
-- **認証ミドルウェア**: `server/middleware/verifyIdToken.ts` — `Authorization: Bearer <ID Token>` 検証、transient（503）/permanent（401）分類（M2 PR-C 導入、M3 で `/api/ai/*` にも適用予定）
-- **フロントエンドAPI**: ルート直下の `*Api.ts` はfetchラッパー（`apiClient.ts`経由）。Project の永続化 API（旧 `projectApi.ts`）は M2 PR-A で削除済み
+- **認証ミドルウェア**: `server/middleware/verifyIdToken.ts` — `Authorization: Bearer <ID Token>` 検証、transient（503）/permanent（401）分類（M2 PR-C 導入、M3 PR-E で `/api/ai/*` 全 endpoint に展開）
+- **usage クォータ**: `server/services/usageService.ts` (reserve/commit/cancel + transaction 予約 + requestId 冪等)、`server/middleware/withUsageQuota.ts` (高階関数ラップ)、`server/services/usageConfig.ts` (Tier 1=月 100 円 + route 別 sen)。詳細は `docs/spec/m3/usage-cost-config.md`
+- **エラー分類**: `server/middleware/errorHandler.ts` の `handleApiError(error, fn, context: 'ai' | 'firestore' | 'usage')` で文言と分類戦略を context 別に切替（M3 PR-F で table-driven 化、context 必須）
+- **フロントエンドAPI**: ルート直下の `*Api.ts` はfetchラッパー（`apiClient.ts`経由）。`apiClient.ts` が Bearer 自動付与 + `requestId` 自動生成 + 401/429/503/409 を `AuthGateErrorCode` 列挙でユーザー向け文言に分類（M3 PR-G）。Project の永続化 API（旧 `projectApi.ts`）は M2 PR-A で削除済み
 
 ### 状態管理（Zustand slices pattern）
 
@@ -69,7 +73,7 @@ Browser → fetch(/api/*) → server/routes/ → server/services/ → Vertex AI 
 | tutorialSlice | 5種チュートリアルの進捗（IndexedDB の `tutorialState` ストア） |
 | analysisHistorySlice | テキストインポート分析の履歴（IndexedDB の `analysisHistory` ストア） |
 | formSlice | フォーム状態 |
-| authSlice | Firebase Auth 状態（`currentUser` / `authStatus: 'initializing' \| 'unauthenticated' \| 'authenticated'` / `authError`、IndexedDB は uid に紐付けない設計、M2 PR-B で導入） |
+| authSlice | Firebase Auth 状態（`currentUser` / `authStatus: 'initializing' \| 'unauthenticated' \| 'authenticated'` / `authError` / `needsUserInit` / `retryUserInit()`、IndexedDB は uid に紐付けない設計、M2 PR-B で導入、M3 PR-G で users/init transient retry signal 追加） |
 
 ### 型定義
 

--- a/apiClient.test.ts
+++ b/apiClient.test.ts
@@ -301,4 +301,64 @@ describe('apiCall', () => {
         expect(result.error.code).toBe('NETWORK_ERROR');
         expect(result.error.message).toContain('network down');
     });
+
+    it('classifies AbortError as REQUEST_ABORTED (distinct from NETWORK_ERROR)', async () => {
+        const abortErr = new Error('request aborted by user');
+        abortErr.name = 'AbortError';
+        fetchMock.mockRejectedValueOnce(abortErr);
+        const result = await apiCall('/utility/names', {});
+        assertFailure(result);
+        expect(result.error.code).toBe('REQUEST_ABORTED');
+    });
+
+    it('classifies getIdToken auth/network-request-failed as SERVICE_UNAVAILABLE (not AUTH_EXPIRED)', async () => {
+        const networkErr = Object.assign(new Error('refresh net error'), { code: 'auth/network-request-failed' });
+        getIdTokenMock.mockReset();
+        getIdTokenMock.mockRejectedValueOnce(networkErr);
+        const result = await apiCall('/utility/names', {});
+        assertFailure(result);
+        expect(result.error.code).toBe('SERVICE_UNAVAILABLE');
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('returns SERVER_ERROR when BE returns 200 OK with success:false (logical failure)', async () => {
+        // BE が誤って 200 + success:false を返した場合に classifier が
+        // SERVER_ERROR を返す contract。BE バグの early signal。
+        fetchMock.mockResolvedValueOnce(
+            new Response(JSON.stringify({ success: false, error: 'logical failure' }), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+            }),
+        );
+        const result = await apiCall('/utility/names', {});
+        assertFailure(result);
+        expect(result.error.code).toBe('SERVER_ERROR');
+        expect(result.error.message).toBe('logical failure');
+    });
+
+    it('shares retryUserInit Promise across concurrent apiCall (cross-layer in-flight contract)', async () => {
+        // authSlice の in-flight 共有が apiClient 経由でも効くことを cross-layer で検証。
+        // 並列 N 件の AI 呼出に対し retryUserInit が 1 回しか発火しない。
+        storeStateMock.needsUserInit = true;
+        let resolveRetry: (() => void) | null = null;
+        const sharedPromise = new Promise<void>((resolve) => {
+            resolveRetry = resolve;
+        });
+        storeStateMock.retryUserInit.mockReturnValue(sharedPromise);
+        fetchMock.mockResolvedValue(okResponse('ok'));
+
+        const p1 = apiCall('/utility/names', { keyword: 'a' });
+        const p2 = apiCall('/utility/names', { keyword: 'b' });
+        const p3 = apiCall('/utility/names', { keyword: 'c' });
+
+        await Promise.resolve();
+        resolveRetry!();
+        await Promise.all([p1, p2, p3]);
+
+        // retryUserInit は各 apiCall から呼ばれるが、authSlice の in-flight guard で
+        // 内部 fetch は 1 回に集約される。ここでは mock 側で「同じ Promise が返る」契約。
+        expect(storeStateMock.retryUserInit).toHaveBeenCalledTimes(3);
+        // 全 apiCall が成功する
+        expect(fetchMock).toHaveBeenCalledTimes(3);
+    });
 });

--- a/apiClient.test.ts
+++ b/apiClient.test.ts
@@ -1,0 +1,304 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// useStore.getState() を制御するため module mock。
+// authStatus / needsUserInit / retryUserInit を test ごとに上書きする。
+const storeStateMock = {
+    authStatus: 'authenticated' as 'authenticated' | 'unauthenticated' | 'initializing',
+    needsUserInit: false,
+    retryUserInit: vi.fn(),
+};
+vi.mock('./store/index', () => ({
+    useStore: {
+        getState: () => storeStateMock,
+    },
+}));
+
+// auth.currentUser.getIdToken() を制御。
+const getIdTokenMock = vi.fn();
+const currentUserMock: { getIdToken: typeof getIdTokenMock } | null = { getIdToken: getIdTokenMock };
+const authMock = { currentUser: currentUserMock as { getIdToken: typeof getIdTokenMock } | null };
+vi.mock('./firebaseClient', () => ({
+    auth: authMock,
+}));
+
+const { apiCall, __testing } = await import('./apiClient');
+const { ensureRequestId, classifyHttpError, generateRequestId } = __testing;
+
+// vitest の `expect(result.success).toBe(false)` は型 narrowing を提供しない。
+// assertion function で `result is { success: false; ... }` を表明し、その後の
+// `result.error` 参照を型安全にする。
+type ApiResult<T> = { success: true; data: T } | { success: false; error: import('./apiClient').ApiCallError };
+function assertFailure<T>(r: ApiResult<T>): asserts r is { success: false; error: import('./apiClient').ApiCallError } {
+    if (r.success) throw new Error('expected failure but apiCall succeeded');
+}
+describe('ensureRequestId', () => {
+    it('adds requestId when body has none', () => {
+        const result = ensureRequestId({ foo: 'bar' }) as { requestId: string; foo: string };
+        expect(typeof result.requestId).toBe('string');
+        expect(result.requestId.length).toBeGreaterThanOrEqual(8);
+        expect(result.foo).toBe('bar');
+    });
+
+    it('preserves caller-provided requestId', () => {
+        const result = ensureRequestId({ requestId: 'caller-id-12345', foo: 'bar' });
+        expect(result).toEqual({ requestId: 'caller-id-12345', foo: 'bar' });
+    });
+
+    it('does not modify primitive body (BE will reject as 400)', () => {
+        expect(ensureRequestId('plain-string')).toBe('plain-string');
+        expect(ensureRequestId(42)).toBe(42);
+        expect(ensureRequestId(null)).toBe(null);
+    });
+
+    it('does not wrap arrays', () => {
+        const arr = [1, 2, 3];
+        expect(ensureRequestId(arr)).toBe(arr);
+    });
+});
+
+describe('generateRequestId', () => {
+    it('returns string of valid length (8-128 chars matching BE contract)', () => {
+        const id = generateRequestId();
+        expect(typeof id).toBe('string');
+        expect(id.length).toBeGreaterThanOrEqual(8);
+        expect(id.length).toBeLessThanOrEqual(128);
+    });
+
+    it('produces unique values across calls', () => {
+        const ids = new Set(Array.from({ length: 50 }, () => generateRequestId()));
+        expect(ids.size).toBe(50);
+    });
+});
+
+describe('classifyHttpError', () => {
+    it('401 → AUTH_EXPIRED with login prompt', () => {
+        const err = classifyHttpError(401, { error: 'expired' });
+        expect(err.code).toBe('AUTH_EXPIRED');
+        expect(err.message).toContain('再ログイン');
+        expect(err.status).toBe(401);
+    });
+
+    it('429 + QUOTA_EXCEEDED → quota message', () => {
+        const err = classifyHttpError(429, { code: 'QUOTA_EXCEEDED' });
+        expect(err.code).toBe('QUOTA_EXCEEDED');
+        expect(err.message).toContain('利用枠の上限');
+        expect(err.status).toBe(429);
+    });
+
+    it('503 → SERVICE_UNAVAILABLE', () => {
+        const err = classifyHttpError(503, null);
+        expect(err.code).toBe('SERVICE_UNAVAILABLE');
+        expect(err.message).toContain('時間をおいて');
+        expect(err.status).toBe(503);
+    });
+
+    it('409 + DUPLICATE_REQUEST → 503-equivalent UX, code preserved', () => {
+        const err = classifyHttpError(409, { code: 'DUPLICATE_REQUEST' });
+        expect(err.code).toBe('DUPLICATE_REQUEST');
+        expect(err.message).toContain('時間をおいて');
+        expect(err.status).toBe(409);
+    });
+
+    it('500 with body error → SERVER_ERROR with body.error', () => {
+        const err = classifyHttpError(500, { error: 'internal' });
+        expect(err.code).toBe('SERVER_ERROR');
+        expect(err.message).toBe('internal');
+    });
+
+    it('500 without body → SERVER_ERROR with HTTP status string', () => {
+        const err = classifyHttpError(500, null);
+        expect(err.code).toBe('SERVER_ERROR');
+        expect(err.message).toBe('HTTP 500');
+    });
+
+    it('504 → SERVICE_UNAVAILABLE (gateway timeout treated as transient)', () => {
+        const err = classifyHttpError(504, null);
+        expect(err.code).toBe('SERVICE_UNAVAILABLE');
+        expect(err.status).toBe(504);
+    });
+
+    it('429 without QUOTA_EXCEEDED code → SERVER_ERROR (not silently undefined)', () => {
+        const err = classifyHttpError(429, { error: 'rate limit' });
+        expect(err.code).toBe('SERVER_ERROR');
+        expect(err.message).toBe('rate limit');
+    });
+});
+
+describe('apiCall', () => {
+    let fetchMock: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        storeStateMock.authStatus = 'authenticated';
+        storeStateMock.needsUserInit = false;
+        storeStateMock.retryUserInit = vi.fn();
+        getIdTokenMock.mockReset();
+        getIdTokenMock.mockResolvedValue('mock-id-token');
+        authMock.currentUser = currentUserMock;
+        fetchMock = vi.fn();
+        global.fetch = fetchMock as unknown as typeof fetch;
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    const okResponse = (data: unknown) =>
+        new Response(JSON.stringify({ success: true, data }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+        });
+
+    const errResponse = (status: number, body: object) =>
+        new Response(JSON.stringify(body), {
+            status,
+            headers: { 'Content-Type': 'application/json' },
+        });
+
+    it('attaches Authorization Bearer header from getIdToken()', async () => {
+        fetchMock.mockResolvedValueOnce(okResponse(['name-1']));
+
+        const result = await apiCall('/utility/names', { category: 'human' });
+        expect(result.success).toBe(true);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        const [, init] = fetchMock.mock.calls[0];
+        expect(init.headers.Authorization).toBe('Bearer mock-id-token');
+        expect(init.headers['Content-Type']).toBe('application/json');
+    });
+
+    it('auto-generates requestId when caller did not provide one', async () => {
+        fetchMock.mockResolvedValueOnce(okResponse('ok'));
+        await apiCall('/utility/names', { category: 'human' });
+
+        const [, init] = fetchMock.mock.calls[0];
+        const sentBody = JSON.parse(init.body);
+        expect(typeof sentBody.requestId).toBe('string');
+        expect(sentBody.requestId.length).toBeGreaterThanOrEqual(8);
+        expect(sentBody.category).toBe('human');
+    });
+
+    it('preserves caller-provided requestId (FE retry can re-send same id)', async () => {
+        fetchMock.mockResolvedValueOnce(okResponse('ok'));
+        await apiCall('/utility/names', { requestId: 'caller-id-9999', category: 'human' });
+
+        const [, init] = fetchMock.mock.calls[0];
+        const sentBody = JSON.parse(init.body);
+        expect(sentBody.requestId).toBe('caller-id-9999');
+    });
+
+    it('blocks before BE when authStatus is unauthenticated', async () => {
+        storeStateMock.authStatus = 'unauthenticated';
+        const result = await apiCall('/utility/names', {});
+        assertFailure(result);
+        {
+            expect(result.error.code).toBe('AUTH_REQUIRED');
+        }
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('blocks with AUTH_INITIALIZING during auth bootstrap', async () => {
+        storeStateMock.authStatus = 'initializing';
+        const result = await apiCall('/utility/names', {});
+        assertFailure(result);
+        {
+            expect(result.error.code).toBe('AUTH_INITIALIZING');
+        }
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('classifies 401 → AUTH_EXPIRED', async () => {
+        fetchMock.mockResolvedValueOnce(errResponse(401, { success: false, error: 'expired' }));
+        const result = await apiCall('/utility/names', {});
+        assertFailure(result);
+        {
+            expect(result.error.code).toBe('AUTH_EXPIRED');
+            expect(result.error.message).toContain('再ログイン');
+        }
+    });
+
+    it('classifies 429 QUOTA_EXCEEDED → quota toast', async () => {
+        fetchMock.mockResolvedValueOnce(
+            errResponse(429, {
+                success: false,
+                code: 'QUOTA_EXCEEDED',
+                usage: { used: 9000, reserved: 500, limit: 10000 },
+            }),
+        );
+        const result = await apiCall('/utility/names', {});
+        assertFailure(result);
+        {
+            expect(result.error.code).toBe('QUOTA_EXCEEDED');
+            expect(result.error.message).toContain('利用枠の上限');
+        }
+    });
+
+    it('classifies 503 → SERVICE_UNAVAILABLE', async () => {
+        fetchMock.mockResolvedValueOnce(errResponse(503, { success: false, error: 'transient' }));
+        const result = await apiCall('/utility/names', {});
+        assertFailure(result);
+        {
+            expect(result.error.code).toBe('SERVICE_UNAVAILABLE');
+        }
+    });
+
+    it('classifies 409 DUPLICATE_REQUEST → 503-equivalent UX', async () => {
+        fetchMock.mockResolvedValueOnce(
+            errResponse(409, { success: false, code: 'DUPLICATE_REQUEST' }),
+        );
+        const result = await apiCall('/utility/names', {});
+        assertFailure(result);
+        {
+            expect(result.error.code).toBe('DUPLICATE_REQUEST');
+            expect(result.error.message).toContain('時間をおいて');
+        }
+    });
+
+    it('triggers users/init retry when needsUserInit is true', async () => {
+        storeStateMock.needsUserInit = true;
+        storeStateMock.retryUserInit.mockResolvedValueOnce(undefined);
+        fetchMock.mockResolvedValueOnce(okResponse('ok'));
+
+        const result = await apiCall('/utility/names', {});
+        expect(storeStateMock.retryUserInit).toHaveBeenCalledTimes(1);
+        expect(result.success).toBe(true);
+    });
+
+    it('returns AUTH_REQUIRED when retryUserInit throws (no infinite loop)', async () => {
+        storeStateMock.needsUserInit = true;
+        storeStateMock.retryUserInit.mockRejectedValueOnce(new Error('still failing'));
+
+        const result = await apiCall('/utility/names', {});
+        assertFailure(result);
+        {
+            expect(result.error.code).toBe('AUTH_REQUIRED');
+        }
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('returns AUTH_EXPIRED when getIdToken throws', async () => {
+        getIdTokenMock.mockRejectedValueOnce(new Error('token refresh failed'));
+        const result = await apiCall('/utility/names', {});
+        assertFailure(result);
+        {
+            expect(result.error.code).toBe('AUTH_EXPIRED');
+        }
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('returns AUTH_REQUIRED when auth.currentUser is null (race condition guard)', async () => {
+        authMock.currentUser = null;
+        const result = await apiCall('/utility/names', {});
+        assertFailure(result);
+        {
+            expect(result.error.code).toBe('AUTH_REQUIRED');
+        }
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('handles fetch network error with NETWORK_ERROR code', async () => {
+        fetchMock.mockRejectedValueOnce(new Error('network down'));
+        const result = await apiCall('/utility/names', {});
+        assertFailure(result);
+        expect(result.error.code).toBe('NETWORK_ERROR');
+        expect(result.error.message).toContain('network down');
+    });
+});

--- a/apiClient.ts
+++ b/apiClient.ts
@@ -24,9 +24,12 @@ export type AuthGateErrorCode =
     | 'SERVICE_UNAVAILABLE'
     | 'DUPLICATE_REQUEST'
     | 'NETWORK_ERROR'
+    | 'REQUEST_ABORTED'
     | 'SERVER_ERROR';
 
-export type ApiCallError = Error & { code?: AuthGateErrorCode; status?: number };
+// code は必須。`makeError` 経由で生成された ApiCallError は必ず分類済みで、
+// 呼出元の switch (code) で silent fallthrough が起きない契約。
+export type ApiCallError = Error & { code: AuthGateErrorCode; status?: number };
 
 const makeError = (code: AuthGateErrorCode, message: string, status?: number): ApiCallError => {
     const err = new Error(message) as ApiCallError;
@@ -36,7 +39,7 @@ const makeError = (code: AuthGateErrorCode, message: string, status?: number): A
 };
 
 // 既知の HTTP status と BE 返却 code から FE 共通文言にマップ。
-// BE の `withUsageQuota` が 401/429/503/409 + code field を返す前提。
+// BE が 401/429/503/409 + `{code, error}` envelope を返す前提。
 // 全経路が必ず `AuthGateErrorCode` を持つ ApiCallError を返し、呼出元の
 // switch 文での silent fallthrough を防ぐ。
 const classifyHttpError = (
@@ -138,7 +141,20 @@ export async function apiCall<T>(
         idToken = await user.getIdToken();
     } catch (tokenErr) {
         console.error('getIdToken failed:', tokenErr);
-        return { success: false as const, error: makeError('AUTH_EXPIRED', AUTH_EXPIRED_MESSAGE) };
+        // refresh token revoke (再ログイン必須) と一時的な network 障害 (再試行で復帰可)
+        // を区別する。前者は AUTH_EXPIRED、後者は SERVICE_UNAVAILABLE で UI 文言が
+        // 真逆になるため。
+        const tokenErrCode = (tokenErr as { code?: unknown }).code;
+        const isNetworkErr = typeof tokenErrCode === 'string' && (
+            tokenErrCode === 'auth/network-request-failed' ||
+            tokenErrCode === 'auth/internal-error'
+        );
+        return {
+            success: false as const,
+            error: isNetworkErr
+                ? makeError('SERVICE_UNAVAILABLE', SERVICE_UNAVAILABLE_MESSAGE)
+                : makeError('AUTH_EXPIRED', AUTH_EXPIRED_MESSAGE),
+        };
     }
 
     const bodyWithRequestId = ensureRequestId(body);
@@ -146,7 +162,11 @@ export async function apiCall<T>(
     try {
         return await performFetch<T>(endpoint, bodyWithRequestId, idToken);
     } catch (error: unknown) {
-        // ネットワーク断 / fetch 例外。code を必ず付与して呼出元の switch を安全に。
+        // ユーザー取消 (AbortController) と本物の network 障害を区別する。前者は
+        // debug 時に「ユーザー操作」として識別したいため REQUEST_ABORTED で分離。
+        if (error instanceof Error && error.name === 'AbortError') {
+            return { success: false as const, error: makeError('REQUEST_ABORTED', error.message || 'リクエストが取り消されました。') };
+        }
         const message = error instanceof Error && error.message ? error.message : NETWORK_ERROR_MESSAGE;
         return { success: false as const, error: makeError('NETWORK_ERROR', message) };
     }

--- a/apiClient.ts
+++ b/apiClient.ts
@@ -1,52 +1,156 @@
 import { useStore } from './store/index';
 import { TIER0_API_BLOCK_MESSAGE } from './store/authConstants';
+import { auth } from './firebaseClient';
 
 const API_BASE = '/api/ai';
 
 // FE-side defense-in-depth Tier gate. UI button-disable is the primary
 // surface, but if a code path slips through this prevents the request
-// from reaching the BE. The real authorization check (Bearer token
-// verification) is BE-side work tracked separately; this gate is purely
-// a soft guardrail and surfaces an actionable error toast.
+// from reaching the BE. The real authorization check is BE-side
+// (verifyIdToken middleware), but we still gate here to avoid spurious
+// Vertex calls and to surface actionable error toasts.
 
 const AUTH_INITIALIZING_MESSAGE = '認証確認中です。数秒後にお試しください。';
+const AUTH_EXPIRED_MESSAGE = 'ログイン期限が切れました。再ログインしてください。';
+const QUOTA_EXCEEDED_MESSAGE = '今月の AI 利用枠の上限に達しました。来月の更新をお待ちください。';
+const SERVICE_UNAVAILABLE_MESSAGE = 'サービスが一時的に利用できません。時間をおいて再度お試しください。';
+const NETWORK_ERROR_MESSAGE = '通信エラーが発生しました。';
 
-export type AuthGateErrorCode = 'AUTH_REQUIRED' | 'AUTH_INITIALIZING';
-export type ApiCallError = Error & { code?: AuthGateErrorCode };
+export type AuthGateErrorCode =
+    | 'AUTH_REQUIRED'
+    | 'AUTH_INITIALIZING'
+    | 'AUTH_EXPIRED'
+    | 'QUOTA_EXCEEDED'
+    | 'SERVICE_UNAVAILABLE'
+    | 'DUPLICATE_REQUEST'
+    | 'NETWORK_ERROR'
+    | 'SERVER_ERROR';
 
-const makeAuthGateError = (code: AuthGateErrorCode, message: string): ApiCallError => {
+export type ApiCallError = Error & { code?: AuthGateErrorCode; status?: number };
+
+const makeError = (code: AuthGateErrorCode, message: string, status?: number): ApiCallError => {
     const err = new Error(message) as ApiCallError;
     err.code = code;
+    if (status !== undefined) err.status = status;
     return err;
+};
+
+// 既知の HTTP status と BE 返却 code から FE 共通文言にマップ。
+// BE の `withUsageQuota` が 401/429/503/409 + code field を返す前提。
+// 全経路が必ず `AuthGateErrorCode` を持つ ApiCallError を返し、呼出元の
+// switch 文での silent fallthrough を防ぐ。
+const classifyHttpError = (
+    status: number,
+    body: { error?: string; code?: string } | null,
+): ApiCallError => {
+    if (status === 401) return makeError('AUTH_EXPIRED', AUTH_EXPIRED_MESSAGE, 401);
+    if (status === 429 && body?.code === 'QUOTA_EXCEEDED') {
+        return makeError('QUOTA_EXCEEDED', QUOTA_EXCEEDED_MESSAGE, 429);
+    }
+    if (status === 503 || status === 504) {
+        return makeError('SERVICE_UNAVAILABLE', SERVICE_UNAVAILABLE_MESSAGE, status);
+    }
+    // 409 DUPLICATE_REQUEST: ユーザー視点では 503 と同等扱い、ログには duplicate と残す
+    if (status === 409 && body?.code === 'DUPLICATE_REQUEST') {
+        return makeError('DUPLICATE_REQUEST', SERVICE_UNAVAILABLE_MESSAGE, 409);
+    }
+    // 上記いずれにも該当しない 4xx/5xx は SERVER_ERROR でまとめる。BE が body.error
+    // を持っていればそれを表示文言に採用、なければ HTTP status を表示。
+    const message = body?.error || `HTTP ${status}`;
+    return makeError('SERVER_ERROR', message, status);
+};
+
+const generateRequestId = (): string => {
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+        return crypto.randomUUID();
+    }
+    // jsdom / 古いブラウザ向け fallback。本番モダンブラウザは crypto.randomUUID で 36 chars
+    return `${Date.now()}-${Math.random().toString(36).slice(2, 14)}`;
+};
+
+const ensureRequestId = (body: unknown): unknown => {
+    if (body && typeof body === 'object' && !Array.isArray(body)) {
+        const obj = body as Record<string, unknown>;
+        if (typeof obj.requestId === 'string' && obj.requestId.length > 0) return body;
+        return { ...obj, requestId: generateRequestId() };
+    }
+    // primitive / array body はそのまま（BE は object 前提なので 400 になるが、想定外形を勝手に変えない）
+    return body;
+};
+
+const performFetch = async <T>(
+    endpoint: string,
+    body: unknown,
+    idToken: string,
+): Promise<{ success: true; data: T } | { success: false; error: ApiCallError }> => {
+    const res = await fetch(`${API_BASE}${endpoint}`, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${idToken}`,
+        },
+        body: JSON.stringify(body),
+    });
+
+    const json = await res.json().catch(() => null) as { success?: boolean; data?: T; error?: string; code?: string } | null;
+
+    if (!res.ok) {
+        return { success: false as const, error: classifyHttpError(res.status, json) };
+    }
+    if (!json || json.success === false) {
+        return { success: false as const, error: classifyHttpError(res.status, json) };
+    }
+    return { success: true as const, data: json.data as T };
 };
 
 export async function apiCall<T>(
     endpoint: string,
-    body: unknown
-): Promise<{ success: true; data: T } | { success: false; error: Error }> {
-    const authStatus = useStore.getState().authStatus;
+    body: unknown,
+): Promise<{ success: true; data: T } | { success: false; error: ApiCallError }> {
+    const state = useStore.getState();
+    const authStatus = state.authStatus;
     if (authStatus !== 'authenticated') {
         const error = authStatus === 'initializing'
-            ? makeAuthGateError('AUTH_INITIALIZING', AUTH_INITIALIZING_MESSAGE)
-            : makeAuthGateError('AUTH_REQUIRED', TIER0_API_BLOCK_MESSAGE);
+            ? makeError('AUTH_INITIALIZING', AUTH_INITIALIZING_MESSAGE)
+            : makeError('AUTH_REQUIRED', TIER0_API_BLOCK_MESSAGE);
         return { success: false as const, error };
     }
-    try {
-        const res = await fetch(`${API_BASE}${endpoint}`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(body),
-        });
 
-        const json = await res.json();
-
-        if (!res.ok || json.success === false) {
-            const message = json.error || `HTTP ${res.status}`;
-            return { success: false as const, error: new Error(message) };
+    // users/init が transient 失敗で残っている場合、AI 呼出前に 1 度 retry。
+    // 失敗時は AUTH_REQUIRED で AI 呼出を止め、ユーザーに再ログインを促す
+    // (in-flight guard は authSlice 側で実装済み)。
+    if (state.needsUserInit) {
+        try {
+            await state.retryUserInit();
+        } catch (retryErr) {
+            console.error('retryUserInit failed:', retryErr);
+            return { success: false as const, error: makeError('AUTH_REQUIRED', TIER0_API_BLOCK_MESSAGE) };
         }
+    }
 
-        return { success: true as const, data: json.data };
-    } catch (error: any) {
-        return { success: false as const, error: new Error(error?.message || '通信エラーが発生しました。') };
+    const user = auth.currentUser;
+    if (!user) {
+        return { success: false as const, error: makeError('AUTH_REQUIRED', TIER0_API_BLOCK_MESSAGE) };
+    }
+
+    let idToken: string;
+    try {
+        idToken = await user.getIdToken();
+    } catch (tokenErr) {
+        console.error('getIdToken failed:', tokenErr);
+        return { success: false as const, error: makeError('AUTH_EXPIRED', AUTH_EXPIRED_MESSAGE) };
+    }
+
+    const bodyWithRequestId = ensureRequestId(body);
+
+    try {
+        return await performFetch<T>(endpoint, bodyWithRequestId, idToken);
+    } catch (error: unknown) {
+        // ネットワーク断 / fetch 例外。code を必ず付与して呼出元の switch を安全に。
+        const message = error instanceof Error && error.message ? error.message : NETWORK_ERROR_MESSAGE;
+        return { success: false as const, error: makeError('NETWORK_ERROR', message) };
     }
 }
+
+// テスト用に内部関数を export
+export const __testing = { ensureRequestId, classifyHttpError, generateRequestId };

--- a/docs/adr/0001-local-first-architecture.md
+++ b/docs/adr/0001-local-first-architecture.md
@@ -86,7 +86,7 @@
 | M0 | 緊急対応（Cloud Run 非公開化、max-instances 制限、予算アラート） | ✅ 完了（2026-04-25） |
 | M1 | 基盤整備（IaC 化、防御層、Firebase 準備） | ✅ 完了（2026-04-26） |
 | M2 | 認証 + IndexedDB 移行 | ✅ 完了（PR-A IndexedDB 移行 2026-04-26 PR #24 / PR-Bx useLocalSync hardening 2026-04-27 PR #31 / PR-B Auth FE 2026-04-27 PR #29 / PR-C 旧ルート退役 + verifyIdToken + users/init + firestore.rules 2026-04-27） |
-| M3 | AI 認証ゲート + クォータ | 🚧 進行中（PR-D テスト基盤 + 持越 #1/#4/#5 / PR-E AI 認証ゲート + 起動 probe + handleApiError 共通化 + 持越 #3 完了 2026-04-27 PR #37 #39 / PR-F〜G 残） |
+| M3 | AI 認証ゲート + クォータ | ✅ 完了（PR-D テスト基盤 + 持越 #1/#4/#5 PR #37 / PR-E BE 認証ゲート + 起動 probe + handleApiError 共通化 + 持越 #3 PR #39 / PR-F usage クォータ + 持越 + Issue #40 PR #45 / PR-G FE 統合 + Cloud Run public 化 + 持越 #2 2026-04-27） |
 | M4 | Export/Import + バックアップ警告 UI | ⏳ |
 | M5 | Stripe Subscription + Webhook + 法務 | ⏳ |
 | M6 | E2EE 暗号化バックアップ（任意機能、後回し可） | ⏳ |
@@ -147,3 +147,32 @@
   3. **`applicationDefault()` eager init**: ADC 未設定環境では `getFirebaseAdminApp()` が初回 request 時に同期 throw する。M3 で起動時 probe（`startServer()` 内で `getFirebaseAuth()` 呼出）を追加して fail-fast 化
   4. **型強化（`AuthedRequest` / `sanitizeForUpdate` undefined フリー戻り値）**: type-design-analyzer 指摘の改善案。M3 の AI 経路で `verifyIdToken` 通過後の handler が増えるタイミングで型を引き締める
   5. **`verifyIdToken` の transient エラーコード拡張**: `/codex review` セカンドオピニオン指摘。現状の `TRANSIENT_AUTH_CODES` Set は `auth/internal-error` / `auth/network-request-failed` / `auth/service-unavailable` + `ETIMEDOUT` / `ECONNRESET` / `ENOTFOUND` をカバーするが、`ECONNREFUSED` / `EAI_AGAIN` / `app/network-error` 形式が permanent (401) に落ちる余地あり。M2 では実害トースト誤分類程度なので、M3 で AI 認証ゲート適用前に広げる
+
+
+## M3 振り返り（2026-04-27）
+
+4 PR + 2 補助 PR でマイルストーン完了。同日中に PR-D/E/F/G を逐次マージし、Stripe (M5) を後回しにする戦略の通り「課金保護成立」までを完成させた。
+
+| PR | 内容 | 状態 |
+|---|---|---|
+| #37 PR-D | テスト基盤 (vitest + supertest) + 持越 #1/#4/#5 | ✅ |
+| #39 PR-E | BE 認証ゲート + 起動 probe + handleApiError 共通化 + 持越 #3 | ✅ |
+| #44 PR-CI | Issue #41 deploy.yml に test job 追加 (PR-F 着手前の regression 検知) | ✅ |
+| #45 PR-F | usage クォータ (transaction reserve + requestId 冪等) + Issue #40 + 持越/PR-E 反映 | ✅ |
+| #46 PR-G | FE 統合 (apiCall Bearer + requestId + 共通分類器 + 持越 #2 needsUserInit retry) + Cloud Run public 化 | ✅ |
+
+**うまくいった点:**
+
+- ADR + tasks.md + handoff/LATEST.md の 3 点で「次に何をするか」を毎セッション 30 秒で再開できた。M3 のように 4 PR を逐次走らせるマイルストーンでは、handoff の更新が次セッションの起動コストを最小化した
+- PR-F 着手前に Issue #41 (P0 CI test job) を別 PR で先行マージしたため、PR-F/G のような大規模 PR で merge 時 regression を CI で阻止できる構造ができた。順序判断が効いた
+- PR-F で `withUsageQuota` 高階関数を導入し、AI route 6 ファイルを純粋な service ラップに簡素化。PR-G の FE 改修も `apiClient.ts` 1 ファイルで cross-cutting concern を集約できた。「BE 高階関数 + FE ラッパー」の対称構造が変更影響範囲を最小化した
+- `/review-pr` 6 エージェント並列 + `/codex review` MCP セカンドオピニオンの組み合わせで PR-F の "month boundary silent failure" / "commit 失敗時 reservation 残存" / "extractMessage 連結境界 false positive" 等、self-review では見逃しがちな経路を merge 前に検出
+- `ReservationHandle` で UTC 月境界跨ぎの silent failure を排除する設計は evaluator 指摘で初めて気づいた経路。第三者評価が「実装の前提知識なし」で読むことの価値を再確認
+
+**課題・M4 以降への申し送り:**
+
+- **後送り Issue 候補（rating 5-7、本 PR スコープ外）**: Sen branded type / AiRouteKey ↔ Express path 単一レジストリ化 / ReservationHandle 内部 docId 化 / processedIds sliding window 警告ログ / AC F8 動的検証（route ファイル全件 withUsageQuota ラップ確認）/ AuthedRequest assertion 関数化 / 401 自動 sign-out 実装。次マイルストーン着手前に triage 基準（rating ≥ 7 + confidence ≥ 80）を満たすものは Issue 化、それ以外は M4/M5 の対応 PR で吸収する判断
+- **残量バー UI**: PR-G スコープ外として保留中（usage rules 緩和 + コンポーネント追加が必要）。M4 で Export/Import UI と一緒に実装するか、M5 Stripe 連携時に「枠拡張動線」とセットで実装するかは要検討
+- **actual metadata 精算**: Vertex AI 応答の usage_metadata から token 数を取得して `commit` の actualCost を補正する経路。observability 拡張として M3 完了後に検討。現状は固定 estimatedCost で運用
+- **本番 Firestore へのルールデプロイ**: PR-G merge 後に `firebase deploy --only firestore:rules -P novel-writer-dev` を手動実行が必要。usage コレクション全拒否を本番に反映する DoD
+- **Cloud Run public 化後の curl 検証**: PR-G の DoD として「401 (Authorization なし) を本番 URL で確認」を merge 後に手動実施。401 でなければ即座に `gcloud run services update --no-allow-unauthenticated` で rollback する手順を確立

--- a/store/authSlice.test.ts
+++ b/store/authSlice.test.ts
@@ -61,9 +61,9 @@ describe('retryUserInit', () => {
     });
 
     it('clears needsUserInit even when retry throws (no permanent retry loop)', async () => {
-        // M3 PR-G review fix: retryUserInit が permanent 失敗で throw した場合
-        // needsUserInit=true のままだと AI 呼出のたびに無限 retry ループに入る。
-        // throw しつつ flag を false に戻す contract を固定。
+        // retryUserInit が permanent 失敗で throw した場合、needsUserInit=true
+        // のままだと AI 呼出のたびに無限 retry ループに入る。throw しつつ flag
+        // を false に戻す contract を固定。
         const { slice, state } = createTestSlice();
         state.needsUserInit = true;
         fetchMock.mockResolvedValueOnce(

--- a/store/authSlice.test.ts
+++ b/store/authSlice.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// firebaseClient の auth を vi.mock。currentUser と getIdToken を制御。
+const getIdTokenMock = vi.fn();
+const authMock = {
+    currentUser: { getIdToken: getIdTokenMock } as { getIdToken: typeof getIdTokenMock } | null,
+};
+vi.mock('../firebaseClient', () => ({ auth: authMock }));
+
+// firebase/auth は initAuth / signInWithGoogle / signOut で使うが、本 test では
+// retryUserInit のみ検証するので onAuthStateChanged 等は no-op stub で十分。
+vi.mock('firebase/auth', () => ({
+    GoogleAuthProvider: class {},
+    onAuthStateChanged: () => () => {},
+    signInWithPopup: vi.fn(),
+    signOut: vi.fn(),
+}));
+
+const { createAuthSlice, __testing } = await import('./authSlice');
+
+interface TestState {
+    needsUserInit: boolean;
+    showToast?: (message: string, type: string) => void;
+    retryUserInit: () => Promise<void>;
+}
+
+const createTestSlice = () => {
+    const state: TestState = {
+        needsUserInit: false,
+        retryUserInit: async () => {},
+    };
+    const set = (partial: Partial<TestState>) => Object.assign(state, partial);
+    const get = () => state;
+    const slice = createAuthSlice(set, get);
+    state.retryUserInit = slice.retryUserInit;
+    return { slice, state };
+};
+
+describe('retryUserInit', () => {
+    let fetchMock: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        getIdTokenMock.mockReset();
+        getIdTokenMock.mockResolvedValue('mock-id-token');
+        authMock.currentUser = { getIdToken: getIdTokenMock };
+        fetchMock = vi.fn();
+        global.fetch = fetchMock as unknown as typeof fetch;
+        // module-scope inFlightUserInitRetry の前 test リーク防止
+        __testing.resetInFlightUserInitRetry();
+    });
+
+    it('clears needsUserInit on successful retry', async () => {
+        const { slice, state } = createTestSlice();
+        state.needsUserInit = true;
+        fetchMock.mockResolvedValueOnce(new Response(null, { status: 200 }));
+
+        await slice.retryUserInit();
+
+        expect(state.needsUserInit).toBe(false);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('clears needsUserInit even when retry throws (no permanent retry loop)', async () => {
+        // M3 PR-G review fix: retryUserInit が permanent 失敗で throw した場合
+        // needsUserInit=true のままだと AI 呼出のたびに無限 retry ループに入る。
+        // throw しつつ flag を false に戻す contract を固定。
+        const { slice, state } = createTestSlice();
+        state.needsUserInit = true;
+        fetchMock.mockResolvedValueOnce(
+            new Response(JSON.stringify({ error: 'permanent' }), { status: 401 }),
+        );
+
+        await expect(slice.retryUserInit()).rejects.toThrow();
+        expect(state.needsUserInit).toBe(false);
+    });
+
+    it('shares in-flight Promise across concurrent retries (single users/init call)', async () => {
+        const { slice, state } = createTestSlice();
+        state.needsUserInit = true;
+        let resolveFetch: ((value: Response) => void) | null = null;
+        const fetchPromise = new Promise<Response>((resolve) => {
+            resolveFetch = resolve;
+        });
+        fetchMock.mockReturnValue(fetchPromise);
+
+        const p1 = slice.retryUserInit();
+        const p2 = slice.retryUserInit();
+        const p3 = slice.retryUserInit();
+
+        // microtask を 1 段進めて fetchMock を発火させる
+        await Promise.resolve();
+        // resolveFetch が代入されている時点で response を返す
+        resolveFetch!(new Response(null, { status: 200 }));
+        await Promise.all([p1, p2, p3]);
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(state.needsUserInit).toBe(false);
+    });
+
+    it('throws when called without authenticated user', async () => {
+        const { slice } = createTestSlice();
+        authMock.currentUser = null;
+        await expect(slice.retryUserInit()).rejects.toThrow(/without authenticated user/);
+    });
+
+    it('classifies fetch network failure (status=0) and propagates', async () => {
+        const { slice, state } = createTestSlice();
+        state.needsUserInit = true;
+        fetchMock.mockRejectedValueOnce(new Error('network down'));
+
+        await expect(slice.retryUserInit()).rejects.toMatchObject({ status: 0 });
+        // network 断は transient だが、上位 retry を 1 回に止めるため flag は false に戻す
+        expect(state.needsUserInit).toBe(false);
+    });
+});

--- a/store/authSlice.ts
+++ b/store/authSlice.ts
@@ -20,9 +20,15 @@ export interface AuthSlice {
     currentUser: CurrentUser | null;
     authStatus: AuthStatus;
     authError: string | null;
+    // users/init が transient 失敗した場合に true。AI 呼出前の retry signal として
+    // apiClient が確認し、再試行を 1 度だけ行う（permanent 失敗の無限ループ防止）。
+    needsUserInit: boolean;
     initAuth: () => () => void;
     signInWithGoogle: () => Promise<void>;
     signOut: () => Promise<void>;
+    // 内部用: AI 呼出前に呼ぶ retry。成功で needsUserInit=false、失敗時は throw。
+    // in-flight guard で同時多発の users/init 多重発火を防ぐ。
+    retryUserInit: () => Promise<void>;
 }
 
 const toCurrentUser = (user: User | null): CurrentUser | null =>
@@ -48,13 +54,57 @@ const reportAuthError = (
     return message;
 };
 
+// users/init 呼出で transient と扱うべき HTTP status。
+// - 503: Firestore UNAVAILABLE / DEADLINE_EXCEEDED 由来 (handleApiError)
+// - 504: Gateway timeout、Cloud Run / プロキシ層由来
+// - 0: fetch 自体が失敗 (ネットワーク断、CORS 拒否等)。response が無いケースで
+//   呼出元が status=0 を埋めて渡す。
+const isTransientUserInitError = (status: number): boolean =>
+    status === 503 || status === 504 || status === 0;
+
+const callUsersInit = async (user: User): Promise<void> => {
+    const idToken = await user.getIdToken();
+    let resp: Response;
+    try {
+        resp = await fetch('/api/users/init', {
+            method: 'POST',
+            headers: { Authorization: `Bearer ${idToken}` },
+        });
+    } catch (fetchErr) {
+        // ネットワーク断 / CORS 拒否等で fetch 自体が throw した場合、status=0 で
+        // transient 扱いにする（isTransientUserInitError が 0 を transient 判定）。
+        const error = new Error(
+            fetchErr instanceof Error ? fetchErr.message : 'network error',
+        ) as Error & { status?: number };
+        error.status = 0;
+        throw error;
+    }
+    if (resp.ok) return;
+    const body = await resp.json().catch(() => null) as { error?: string } | null;
+    const error = new Error(body?.error ?? `users/init responded ${resp.status}`) as Error & { status?: number };
+    error.status = resp.status;
+    throw error;
+};
+
+// 同時多発防止のための module-scope in-flight guard。同一 retry が複数 AI 呼出
+// から並列に走らないようにする（同 Promise を共有）。authSlice の state には
+// 入れず closure local で管理（Zustand の re-render を起こさないため）。
+let inFlightUserInitRetry: Promise<void> | null = null;
+
+// test 間の module-scope state リーク防止のため、test 専用 reset を export する。
+// 本番コードからは参照しない。
+export const __testing = {
+    resetInFlightUserInitRetry: (): void => {
+        inFlightUserInitRetry = null;
+    },
+};
+
 export const createAuthSlice = (set, get): AuthSlice => ({
     currentUser: null,
     authStatus: 'initializing' as AuthStatus,
     authError: null,
+    needsUserInit: false,
 
-    // Subscribe to onAuthStateChanged. Returns unsubscribe function.
-    // Per ADR-0001 / spec: IndexedDB is NOT touched on login/logout.
     initAuth: () => {
         const unsubscribe = onAuthStateChanged(
             auth,
@@ -82,27 +132,21 @@ export const createAuthSlice = (set, get): AuthSlice => ({
             // currentUser update flows through onAuthStateChanged listener.
 
             // Server-side transaction creates/refreshes users/{uid} metadata
-            // and preserves createdAt across re-logins. Failure here is
-            // surfaced via toast but does not block login — future AI gating
-            // will check this metadata server-side on each AI request.
+            // and preserves createdAt across re-logins. transient (503) は
+            // needsUserInit=true で残し、AI 呼出時に retry させる。permanent
+            // (4xx) はトーストのみで残す（再 init しても直らないため）。
             try {
-                const idToken = await result.user.getIdToken();
-                const resp = await fetch('/api/users/init', {
-                    method: 'POST',
-                    headers: { Authorization: `Bearer ${idToken}` },
-                });
-                if (!resp.ok) {
-                    const body = await resp.json().catch(() => null) as { error?: string } | null;
-                    throw new Error(body?.error ?? `users/init responded ${resp.status}`);
-                }
-            } catch (initError) {
+                await callUsersInit(result.user);
+                set({ needsUserInit: false });
+            } catch (initError: unknown) {
                 console.error('users/init failed:', initError);
                 reportAuthError(get, 'ユーザー初期化に失敗しました', initError);
+                const status = (initError as { status?: number }).status ?? 0;
+                if (isTransientUserInitError(status)) {
+                    set({ needsUserInit: true });
+                }
             }
         } catch (error: unknown) {
-            // User-intent cancels (closed popup, double-clicked sign-in) are
-            // not errors — silence them so the toast stays for actual problems
-            // (network failure, popup blocker, provider config).
             const code = (error as { code?: string }).code;
             if (code === 'auth/popup-closed-by-user' || code === 'auth/cancelled-popup-request') {
                 return;
@@ -120,11 +164,38 @@ export const createAuthSlice = (set, get): AuthSlice => ({
         try {
             set({ authError: null });
             await firebaseSignOut(auth);
+            set({ needsUserInit: false });
             // currentUser update flows through onAuthStateChanged listener.
         } catch (error: unknown) {
             console.error('signOut failed:', error);
             const message = reportAuthError(get, 'ログアウトに失敗しました', error);
             set({ authError: message });
         }
+    },
+
+    retryUserInit: async () => {
+        // 同一 retry を複数の AI 呼出が並列に走らせると users/init が多重発火
+        // するため、in-flight Promise を共有して重複呼出を 1 本にまとめる。
+        if (inFlightUserInitRetry) return inFlightUserInitRetry;
+
+        const user = auth.currentUser;
+        if (!user) throw new Error('retryUserInit called without authenticated user');
+
+        inFlightUserInitRetry = (async () => {
+            try {
+                await callUsersInit(user);
+                set({ needsUserInit: false });
+            } catch (error) {
+                // permanent / 設定不能な失敗の場合 needsUserInit=true のままだと
+                // AI 呼出のたびに再 retry が走り続ける。一旦 false に戻し、AI 呼出側
+                // (apiClient) は throw を catch して AUTH_REQUIRED で AI を止める。
+                // 本当に transient なら次回ログイン or onAuthStateChanged で復帰する。
+                set({ needsUserInit: false });
+                throw error;
+            } finally {
+                inFlightUserInitRetry = null;
+            }
+        })();
+        return inFlightUserInitRetry;
     },
 });

--- a/store/authSlice.ts
+++ b/store/authSlice.ts
@@ -54,6 +54,22 @@ const reportAuthError = (
     return message;
 };
 
+// users/init 呼出のエラー型。status が必須なので、catch 側で type guard を
+// 通せば「foreign error が status 未定義のまま transient 判定に流れ込む」
+// silent fallthrough を防げる。
+export interface UserInitError extends Error {
+    status: number;
+}
+
+const isUserInitError = (e: unknown): e is UserInitError =>
+    e instanceof Error && typeof (e as { status?: unknown }).status === 'number';
+
+const makeUserInitError = (message: string, status: number): UserInitError => {
+    const err = new Error(message) as UserInitError;
+    err.status = status;
+    return err;
+};
+
 // users/init 呼出で transient と扱うべき HTTP status。
 // - 503: Firestore UNAVAILABLE / DEADLINE_EXCEEDED 由来 (handleApiError)
 // - 504: Gateway timeout、Cloud Run / プロキシ層由来
@@ -73,17 +89,17 @@ const callUsersInit = async (user: User): Promise<void> => {
     } catch (fetchErr) {
         // ネットワーク断 / CORS 拒否等で fetch 自体が throw した場合、status=0 で
         // transient 扱いにする（isTransientUserInitError が 0 を transient 判定）。
-        const error = new Error(
+        throw makeUserInitError(
             fetchErr instanceof Error ? fetchErr.message : 'network error',
-        ) as Error & { status?: number };
-        error.status = 0;
-        throw error;
+            0,
+        );
     }
     if (resp.ok) return;
     const body = await resp.json().catch(() => null) as { error?: string } | null;
-    const error = new Error(body?.error ?? `users/init responded ${resp.status}`) as Error & { status?: number };
-    error.status = resp.status;
-    throw error;
+    throw makeUserInitError(
+        body?.error ?? `users/init responded ${resp.status}`,
+        resp.status,
+    );
 };
 
 // 同時多発防止のための module-scope in-flight guard。同一 retry が複数 AI 呼出
@@ -141,12 +157,17 @@ export const createAuthSlice = (set, get): AuthSlice => ({
             } catch (initError: unknown) {
                 console.error('users/init failed:', initError);
                 reportAuthError(get, 'ユーザー初期化に失敗しました', initError);
-                const status = (initError as { status?: number }).status ?? 0;
-                if (isTransientUserInitError(status)) {
+                // type guard 経由で UserInitError の status を読む。foreign error
+                // (例: SDK 内部の TypeError) は status 不明のため transient 判定せず、
+                // needsUserInit=false のまま (= AI 呼出で AUTH_EXPIRED 経路に倒す)。
+                if (isUserInitError(initError) && isTransientUserInitError(initError.status)) {
                     set({ needsUserInit: true });
                 }
             }
         } catch (error: unknown) {
+            // User-intent cancels (closed popup, double-clicked sign-in) are
+            // not errors — silence them so the toast stays for actual problems
+            // (network failure, popup blocker, provider config).
             const code = (error as { code?: string }).code;
             if (code === 'auth/popup-closed-by-user' || code === 'auth/cancelled-popup-request') {
                 return;


### PR DESCRIPTION
## Summary

M3 マイルストーンの仕上げ。FE 側に Bearer 認証 + requestId 自動付与 + 共通エラー分類器を導入し、Cloud Run を `--allow-unauthenticated` で public 化する。これで Tier 1 (free) ユーザーが BE 認証 + 月 100 円上限の usage クォータ付きで AI 機能を使える状態になる。

- **`apiClient.ts`**: `getIdToken()` で Bearer 自動付与、`crypto.randomUUID()` で requestId 自動生成、401/429/503/409 を `AuthGateErrorCode` 列挙でユーザー向け文言に分類（AUTH_EXPIRED / QUOTA_EXCEEDED / SERVICE_UNAVAILABLE / DUPLICATE_REQUEST / NETWORK_ERROR / SERVER_ERROR の網羅性で silent fallthrough 排除）
- **`store/authSlice.ts`**: `needsUserInit` flag + `retryUserInit()` 追加（M2 持越 #2 解消）。signInWithGoogle で users/init が transient 失敗（503/504/network 断）した場合に flag=true、AI 呼出前に 1 度 retry。`inFlightUserInitRetry` module-scope guard で並列多重発火防止
- **`.github/workflows/deploy.yml`**: Cloud Run flags に `--allow-unauthenticated` + `NODE_ENV=production` 追加。BE は M3 PR-D/E/F で `verifyIdToken` + `withUsageQuota` が一括 mount されており、public 化しても Vertex AI / Imagen への無認証 access は構造的に不可能

## Acceptance Criteria

- [x] **G1**: `apiCall` が `auth.currentUser.getIdToken()` で Bearer 付与、未ログイン時は AUTH_REQUIRED で BE 到達前に拒否
- [x] **G2**: body に requestId が無ければ `crypto.randomUUID()` で自動付与、呼出元指定があれば上書きしない
- [x] **G3**: 401 → AUTH_EXPIRED「ログイン期限が切れました」、429 → QUOTA_EXCEEDED「今月の AI 利用枠の上限」、503/504 → SERVICE_UNAVAILABLE、409 → DUPLICATE_REQUEST、500/その他 → SERVER_ERROR、fetch 例外 → NETWORK_ERROR
- [x] **G4**: `needsUserInit=true` 状態で AI 呼出 → users/init を 1 度 retry、成功で flag false、失敗で AUTH_REQUIRED
- [x] **G5**: 並列 AI 呼出時の retryUserInit 多重発火防止（in-flight Promise 共有）
- [x] **G6**: `.github/workflows/deploy.yml` の Cloud Run flags に `--allow-unauthenticated` 明示
- [ ] **G7**: PR merge 後、`curl -i $URL/api/ai/utility/names -H 'Content-Type: application/json' -d '{"requestId":"manual-check-..."}'` → **401 確認**（DoD）
- [ ] **G8**: PR merge 後、ID Token 付き curl → **200** 確認（DoD）
- [x] **G9**: ADR-0001 ロードマップ表 M3 ✅、M3 振り返りセクション追記
- [x] **G10**: lint 0 / vitest 172 / firestore-rules 20 / build PASS

## ローカル検証結果

```
$ npm run lint                    → 0 error
$ npm run test                    → 172 passed (前 139 + 新規 33)
$ npm run test:firestore-rules    → 20/20 passed
$ npm run build                   → built in 1.10s
```

## 品質ゲート

- [x] /simplify (reuse / quality / efficiency 3 並列) → 4 件反映（NETWORK_ERROR/SERVER_ERROR 追加で網羅性、504 統合、retryUserInit throw 時 flag リセット、isTransientUserInitError 拡張）
- [ ] /review-pr (6 エージェント並列) → 本 PR 後に実行
- [ ] (任意) /codex review → 中規模 PR のため不要判断

## Test plan / Definition of Done

- [ ] PR push 時に CI test job PASS、deploy job skipping 確認
- [ ] /review-pr 6 エージェント並列レビュー実行
- [ ] **merge 後 main deploy 完了を待つ**
- [ ] **`curl -i $CLOUD_RUN_URL/api/ai/utility/names -H 'Content-Type: application/json' -d '{"requestId":"manual-check-20260427"}'` → 401 確認**
- [ ] 401 でない場合は **即座に `gcloud run services update novel-writer --region asia-northeast1 --no-allow-unauthenticated` で rollback**
- [ ] (任意) ID Token 付き正常系 curl で 200 確認
- [ ] 本番 Firestore に rules を手動デプロイ: `firebase deploy --only firestore:rules -P novel-writer-dev`

## Out of scope (M4 以降 or 別 PR)

- 残量バー UI（usage rules 緩和 + コンポーネント追加、M3 完了後別 PR）
- 401 自動 sign-out + 再ログイン UI（PR-G では文言誘導のみ、別 PR で実装）
- Tier 2 (paid) の `users.plan` 動的取得（M5 Stripe）
- actual metadata 精算（observability 追加、別 Issue）
- Sen branded type / AiRouteKey 単一レジストリ化 / AuthedRequest assertion 化（PR-F review で持越）

## Closes

M3 マイルストーン完了（PR-D #37 / PR-E #39 / CI #44 / PR-F #45 / PR-G 本 PR）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)