### PR TITLE
feat(m4): Export/Import 強化 + バックアップ警告 UI

### DIFF
--- a/App.mobile.tsx
+++ b/App.mobile.tsx
@@ -5,6 +5,7 @@ import { ModalManager } from './components/ModalManager';
 import { CommandPalette } from './components/CommandPalette';
 import { Tutorial } from './components/Tutorial';
 import { TutorialModeSelectionModal } from './components/TutorialModeSelectionModal';
+import { BackupWarningBanner } from './components/BackupWarningBanner';
 import { useStore } from './store/index';
 import { LeftPanel } from './components/LeftPanel';
 import { RightPanel } from './components/RightPanel';
@@ -176,6 +177,7 @@ const AppMobile: React.FC = () => {
 
             {/* ヘッダーエリア */}
             <div className="w-full border-b border-gray-700 bg-gray-800 flex-shrink-0 z-30">
+                <BackupWarningBanner />
                 <Header displayMenuButtonRef={displayMenuButtonRef} isMobile={true} />
             </div>
 

--- a/App.tsx
+++ b/App.tsx
@@ -16,6 +16,7 @@ import { useSidebarResize } from './hooks/useSidebarResize';
 import { ProjectSelectionScreen } from './components/ProjectSelectionScreen';
 import { Toast } from './components/Toast';
 import { TutorialModeSelectionModal } from './components/TutorialModeSelectionModal';
+import { BackupWarningBanner } from './components/BackupWarningBanner';
 import AppMobile from './App.mobile';
 import { useLocalSync } from './hooks/useLocalSync';
 
@@ -56,10 +57,15 @@ export default function App() {
     const setEditingChunkId = useStore(state => state.setEditingChunkId);
     const loadTutorialData = useStore(state => state.loadTutorialData);
     const initAuth = useStore(state => state.initAuth);
+    const initBackupState = useStore(state => state.initBackupState);
 
     useEffect(() => {
         loadTutorialData();
     }, [loadTutorialData]);
+
+    useEffect(() => {
+        void initBackupState();
+    }, [initBackupState]);
 
     useEffect(() => {
         const unsubscribe = initAuth();
@@ -200,6 +206,8 @@ export default function App() {
         return (
             <>
                 <Toast />
+                <ModalManager displayMenuButtonRef={displayMenuButtonRef} isMobile={isMobile} />
+                <BackupWarningBanner />
                 <ProjectSelectionScreen
                     projects={Object.values(allProjectsData)}
                     onCreateProject={createProject}
@@ -236,6 +244,7 @@ export default function App() {
 
     const mainContent = (
         <div className="flex-1 flex flex-col bg-app-bg min-w-0 min-h-0">
+            <BackupWarningBanner />
             <Header displayMenuButtonRef={displayMenuButtonRef} />
             <NovelEditor />
         </div>

--- a/components/BackupWarningBanner.tsx
+++ b/components/BackupWarningBanner.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import * as Icons from '../icons';
+import { useStore } from '../store/index';
+import { STALE_BACKUP_DAYS, formatLastExportedAt } from '../utils/backupFormat';
+
+export const BackupWarningBanner: React.FC = () => {
+    const lastExportedAt = useStore(state => state.lastExportedAt);
+    const isStale = useStore(state => state.isBackupStale());
+    const isExporting = useStore(state => state.isExporting);
+    const exportAllData = useStore(state => state.exportAllData);
+
+    if (!isStale) return null;
+
+    const base = formatLastExportedAt(lastExportedAt);
+    const label = lastExportedAt ? `${base} (推奨は${STALE_BACKUP_DAYS}日以内)` : base;
+    return (
+        <div
+            role="alert"
+            className="flex items-start gap-3 border-b border-yellow-700/60 bg-yellow-900/30 px-4 py-2 text-sm text-yellow-100"
+        >
+            <Icons.AlertTriangleIcon className="h-5 w-5 flex-shrink-0 text-yellow-400" />
+            <div className="flex-grow">
+                <span className="font-semibold text-yellow-300">バックアップ未取得: </span>
+                最終バックアップ {label}。データはこの端末のブラウザにのみ保存されています。
+            </div>
+            <button
+                type="button"
+                onClick={() => void exportAllData()}
+                disabled={isExporting}
+                className="flex items-center gap-1 rounded bg-yellow-600 px-3 py-1 text-xs font-semibold text-white transition hover:bg-yellow-500 disabled:opacity-50 btn-pressable"
+            >
+                <Icons.DownloadIcon className="h-3 w-3" />
+                {isExporting ? 'エクスポート中…' : '今すぐエクスポート'}
+            </button>
+        </div>
+    );
+};

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -4,7 +4,6 @@ import * as Icons from '../icons';
 import { useStore } from '../store/index';
 import { Tooltip } from './Tooltip';
 import { AuthButton } from './AuthButton';
-import { loadAnalysisHistory as loadAnalysisHistoryFromDb } from '../db/analysisHistoryRepository';
 
 interface HeaderProps {
     displayMenuButtonRef: React.RefObject<HTMLButtonElement>;
@@ -101,32 +100,8 @@ export const Header: React.FC<HeaderProps> = ({ displayMenuButtonRef, isMobile =
         URL.revokeObjectURL(link.href);
     };
 
-    const handleExportAll = async () => {
-        const state = useStore.getState();
-        const allData = {
-            localStorage: {
-                allProjectsData: state.allProjectsData,
-                activeProjectId: state.activeProjectId,
-                isLeftSidebarOpen: state.isLeftSidebarOpen,
-                isRightSidebarOpen: state.isRightSidebarOpen,
-                leftSidebarWidth: state.leftSidebarWidth,
-                rightSidebarWidth: state.rightSidebarWidth,
-                isNewChunkInputOpen: state.isNewChunkInputOpen,
-                userMode: state.userMode,
-                undoScope: state.undoScope,
-                historyTree: state.historyTree,
-                pinnedSettingIds: state.pinnedSettingIds,
-            },
-            analysisHistory: { history: await loadAnalysisHistoryFromDb() }
-        };
-
-        const blob = new Blob([JSON.stringify(allData, null, 2)], { type: 'application/json' });
-        const link = document.createElement('a');
-        link.href = URL.createObjectURL(blob);
-        link.download = `all_data_export_${new Date().toISOString()}.json`;
-        link.click();
-        URL.revokeObjectURL(link.href);
-    };
+    const exportAllData = useStore(state => state.exportAllData);
+    const handleExportAll = () => void exportAllData();
 
     if (!activeProjectData) return null;
 

--- a/components/ModalManager.tsx
+++ b/components/ModalManager.tsx
@@ -19,6 +19,7 @@ import { SettingItem, KnowledgeItem, PlotItem } from '../types';
 import * as utilityApi from '../utilityApi';
 import { SyncDialog } from './SyncDialog';
 import { ImportTextModal } from './ImportTextModal';
+import { ImportConflictModal } from './modals/ImportConflictModal';
 
 interface ModalManagerProps {
     displayMenuButtonRef: React.RefObject<HTMLButtonElement>;
@@ -51,6 +52,13 @@ export const ModalManager: React.FC<ModalManagerProps> = ({ displayMenuButtonRef
     const exportHtml = useStore(state => state.exportHtml);
 
     const activeProjectData = activeProjectId ? allProjectsData[activeProjectId] : null;
+
+    // importConflict can fire from ProjectSelectionScreen (no active project),
+    // so handle it before the activeProjectData early-return that other modals
+    // depend on.
+    if (activeModal === 'importConflict') {
+        return <ImportConflictModal onComplete={closeModal} />;
+    }
 
     if (!activeProjectData) return null;
 

--- a/components/modals/ImportConflictModal.tsx
+++ b/components/modals/ImportConflictModal.tsx
@@ -1,0 +1,155 @@
+import React, { useState } from 'react';
+import * as Icons from '../../icons';
+import { ImportConflictResolution } from '../../types';
+import { useStore } from '../../store/index';
+
+const RESOLUTION_LABELS: Record<ImportConflictResolution, string> = {
+    overwrite: '上書き',
+    duplicate: '新ID で複製',
+    skip: 'スキップ',
+};
+
+const RESOLUTION_DESC: Record<ImportConflictResolution, string> = {
+    overwrite: '既存プロジェクトをインポート内容で上書きします。',
+    duplicate: '別 ID として並存させます（既存プロジェクトは保持）。',
+    skip: 'このプロジェクトはインポートしません。',
+};
+
+interface ImportConflictModalProps {
+    onComplete: () => void;
+}
+
+export const ImportConflictModal: React.FC<ImportConflictModalProps> = ({ onComplete }) => {
+    const plan = useStore(state => state.importPlan);
+    const setImportResolution = useStore(state => state.setImportResolution);
+    const cancelImport = useStore(state => state.cancelImport);
+    const executeImport = useStore(state => state.executeImport);
+    const isImporting = useStore(state => state.isImporting);
+    const [error, setError] = useState<string | null>(null);
+
+    if (!plan) return null;
+
+    const incomingCount = plan.backup.projects.length;
+    const conflictCount = plan.conflicts.length;
+    const newCount = incomingCount - conflictCount;
+
+    const handleConfirm = async () => {
+        setError(null);
+        try {
+            await executeImport();
+            onComplete();
+        } catch (e: any) {
+            setError(e?.message ?? String(e));
+        }
+    };
+
+    return (
+        <div
+            role="dialog"
+            aria-labelledby="import-conflict-title"
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4"
+        >
+            <div className="w-full max-w-2xl rounded-lg bg-gray-800 shadow-xl">
+                <div className="flex items-start justify-between border-b border-gray-700 px-6 py-4">
+                    <div>
+                        <h2 id="import-conflict-title" className="text-lg font-semibold text-white">
+                            インポート内容の確認
+                        </h2>
+                        <p className="mt-1 text-sm text-gray-400">
+                            合計 {incomingCount} 件 (新規 {newCount} 件 / 既存と衝突 {conflictCount} 件)
+                            。バックアップ取得日時:{' '}
+                            <span className="font-mono">{plan.backup.exportedAt}</span>
+                        </p>
+                    </div>
+                    <button
+                        type="button"
+                        onClick={cancelImport}
+                        className="text-gray-400 hover:text-white"
+                        aria-label="閉じる"
+                    >
+                        <Icons.XIcon className="h-5 w-5" />
+                    </button>
+                </div>
+
+                <div className="max-h-[60vh] overflow-y-auto px-6 py-4">
+                    {conflictCount === 0 ? (
+                        <p className="text-sm text-gray-300">
+                            既存と衝突するプロジェクトはありません。{newCount} 件すべてを新規にインポートします。
+                        </p>
+                    ) : (
+                        <ul className="space-y-3">
+                            {plan.conflicts.map(c => (
+                                <li
+                                    key={c.incomingId}
+                                    className="rounded border border-gray-700 bg-gray-900/40 px-4 py-3"
+                                >
+                                    <div className="mb-2 text-sm">
+                                        <div className="font-semibold text-white">{c.incomingName}</div>
+                                        <div className="text-xs text-gray-400">
+                                            既存名: {c.existingName} (ID:{' '}
+                                            <span className="font-mono">{c.incomingId.slice(0, 8)}…</span>)
+                                        </div>
+                                    </div>
+                                    <div className="grid grid-cols-3 gap-2">
+                                        {(['overwrite', 'duplicate', 'skip'] as const).map(opt => (
+                                            <label
+                                                key={opt}
+                                                className={`flex cursor-pointer items-start gap-2 rounded border p-2 text-xs ${
+                                                    c.resolution === opt
+                                                        ? 'border-indigo-500 bg-indigo-900/30 text-white'
+                                                        : 'border-gray-700 bg-gray-800/40 text-gray-300 hover:bg-gray-700/50'
+                                                }`}
+                                            >
+                                                <input
+                                                    type="radio"
+                                                    name={`resolution-${c.incomingId}`}
+                                                    value={opt}
+                                                    checked={c.resolution === opt}
+                                                    onChange={() => setImportResolution(c.incomingId, opt)}
+                                                    className="mt-0.5"
+                                                />
+                                                <span>
+                                                    <span className="block font-semibold">
+                                                        {RESOLUTION_LABELS[opt]}
+                                                    </span>
+                                                    <span className="block text-[11px] text-gray-400">
+                                                        {RESOLUTION_DESC[opt]}
+                                                    </span>
+                                                </span>
+                                            </label>
+                                        ))}
+                                    </div>
+                                </li>
+                            ))}
+                        </ul>
+                    )}
+
+                    {error && (
+                        <div className="mt-4 rounded border border-red-700 bg-red-900/40 px-3 py-2 text-sm text-red-200">
+                            {error}
+                        </div>
+                    )}
+                </div>
+
+                <div className="flex items-center justify-end gap-2 border-t border-gray-700 px-6 py-3">
+                    <button
+                        type="button"
+                        onClick={cancelImport}
+                        disabled={isImporting}
+                        className="rounded px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 disabled:opacity-50"
+                    >
+                        キャンセル
+                    </button>
+                    <button
+                        type="button"
+                        onClick={() => void handleConfirm()}
+                        disabled={isImporting}
+                        className="rounded bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-500 disabled:opacity-50 btn-pressable"
+                    >
+                        {isImporting ? 'インポート中…' : 'この内容でインポート'}
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/components/panels/SettingsPanel.tsx
+++ b/components/panels/SettingsPanel.tsx
@@ -1,8 +1,10 @@
 
-import React, { useMemo } from 'react';
+import React, { useMemo, useRef } from 'react';
 import * as Icons from '../../icons';
 import { useStore } from '../../store/index';
 import { Tooltip } from '../Tooltip';
+import { STALE_BACKUP_DAYS, formatLastExportedAt } from '../../utils/backupFormat';
+import { readFileAsText } from '../../utils/readFileAsText';
 
 interface SettingsPanelProps {
     onExportProject: () => void;
@@ -12,6 +14,27 @@ interface SettingsPanelProps {
 export const SettingsPanel: React.FC<SettingsPanelProps> = ({ onExportProject, onExportTxt }) => {
     const openModal = useStore(state => state.openModal);
     const userMode = useStore(state => state.userMode);
+    const lastExportedAt = useStore(state => state.lastExportedAt);
+    const isStale = useStore(state => state.isBackupStale());
+    const isExporting = useStore(state => state.isExporting);
+    const exportAllData = useStore(state => state.exportAllData);
+    const prepareImport = useStore(state => state.prepareImport);
+    const showToast = useStore(state => state.showToast);
+    const importInputRef = useRef<HTMLInputElement>(null);
+
+    const handleImportFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
+        const file = e.target.files?.[0];
+        e.target.value = '';
+        if (!file) return;
+        try {
+            const raw = await readFileAsText(file);
+            await prepareImport(raw);
+            openModal('importConflict');
+        } catch (err: unknown) {
+            const msg = err instanceof Error ? err.message : 'インポートの準備に失敗しました';
+            showToast(msg, 'error');
+        }
+    };
     
     const tools = useMemo(() => [
         { label: '相関図', icon: <Icons.UserCogIcon />, action: () => openModal('characterChart'), color: 'text-violet-300', helpId: 'chart_open' },
@@ -67,6 +90,40 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({ onExportProject, o
                             <span>{exp.label}</span>
                         </button>
                     ))}
+                </div>
+            </div>
+
+            <div>
+                <h3 className="text-sm font-semibold text-gray-400 mb-2">全データバックアップ</h3>
+                <div className={`text-xs mb-2 ${isStale ? 'text-yellow-400' : 'text-gray-400'}`}>
+                    最終バックアップ: {formatLastExportedAt(lastExportedAt)}
+                    {isStale && ` (推奨は${STALE_BACKUP_DAYS}日以内)`}
+                </div>
+                <div className="space-y-2">
+                    <button
+                        type="button"
+                        onClick={() => void exportAllData()}
+                        disabled={isExporting}
+                        className="w-full text-sm px-3 py-2 bg-emerald-700 hover:bg-emerald-600 rounded-md transition flex items-center gap-2 btn-pressable text-white disabled:opacity-50"
+                    >
+                        <Icons.DownloadIcon className="h-4 w-4 mr-1 flex-shrink-0" />
+                        <span>{isExporting ? 'エクスポート中…' : '全データをエクスポート'}</span>
+                    </button>
+                    <button
+                        type="button"
+                        onClick={() => importInputRef.current?.click()}
+                        className="w-full text-sm px-3 py-2 bg-gray-700 hover:bg-gray-600 rounded-md transition flex items-center gap-2 btn-pressable text-gray-300"
+                    >
+                        <Icons.UploadIcon className="h-4 w-4 mr-1 flex-shrink-0" />
+                        <span>バックアップから復元</span>
+                    </button>
+                    <input
+                        type="file"
+                        ref={importInputRef}
+                        onChange={handleImportFile}
+                        accept=".json,application/json"
+                        className="hidden"
+                    />
                 </div>
             </div>
         </div>

--- a/db/backupRepository.ts
+++ b/db/backupRepository.ts
@@ -1,0 +1,81 @@
+import { BackupV1, Project } from '../types';
+import { validateAndSanitizeProjectData } from '../utils';
+import {
+    ANALYSIS_HISTORY_KEY,
+    BACKUP_META_KEY,
+    TUTORIAL_STATE_VERSION,
+    getDb,
+} from './dexie';
+import { pickPersistableFields, stripInternalKeys } from './projectRepository';
+
+// Mirrors putProject's sanitize chain (validate → whitelist → strip "_" keys)
+// so the import path cannot bypass PERSISTABLE_KEYS. Kept inline so the whole
+// chain runs inside the import transaction without breaking atomicity.
+const sanitizeForImport = (project: Project): Project => {
+    const validated = validateAndSanitizeProjectData(project);
+    const persistable = pickPersistableFields(validated);
+    return stripInternalKeys(persistable) as Project;
+};
+
+export interface ExportSnapshot {
+    projects: Project[];
+    tutorialState: BackupV1['tutorialState'];
+    analysisHistory: BackupV1['analysisHistory'];
+}
+
+export const readSnapshot = async (): Promise<ExportSnapshot> => {
+    const db = getDb();
+    const [projects, tutorialRecord, analysisRecord] = await Promise.all([
+        db.projects.orderBy('lastModified').reverse().toArray(),
+        db.tutorialState.get(TUTORIAL_STATE_VERSION),
+        db.analysisHistory.get(ANALYSIS_HISTORY_KEY),
+    ]);
+    const tutorialState = (() => {
+        if (!tutorialRecord) return {};
+        const { version: _v, ...flags } = tutorialRecord;
+        return flags;
+    })();
+    return {
+        projects: projects.map(p => validateAndSanitizeProjectData(p)),
+        tutorialState,
+        analysisHistory: analysisRecord?.history ?? [],
+    };
+};
+
+export interface WriteImportPayload {
+    toUpsert: Project[];
+    toCreate: Project[];
+    tutorialState: BackupV1['tutorialState'];
+    analysisHistory: BackupV1['analysisHistory'];
+}
+
+// Single Dexie transaction so a partial failure never leaves IndexedDB in a
+// half-imported state. AC-5 atomicity.
+export const writeImport = async (payload: WriteImportPayload): Promise<void> => {
+    const db = getDb();
+    await db.transaction(
+        'rw',
+        [db.projects, db.tutorialState, db.analysisHistory],
+        async () => {
+            for (const p of payload.toUpsert) await db.projects.put(sanitizeForImport(p));
+            for (const p of payload.toCreate) await db.projects.put(sanitizeForImport(p));
+            await db.tutorialState.put({
+                version: TUTORIAL_STATE_VERSION,
+                ...payload.tutorialState,
+            });
+            await db.analysisHistory.put({
+                key: ANALYSIS_HISTORY_KEY,
+                history: payload.analysisHistory,
+            });
+        },
+    );
+};
+
+export const loadLastExportedAt = async (): Promise<string | null> => {
+    const record = await getDb().backupMeta.get(BACKUP_META_KEY);
+    return record?.lastExportedAt ?? null;
+};
+
+export const saveLastExportedAt = async (iso: string): Promise<void> => {
+    await getDb().backupMeta.put({ key: BACKUP_META_KEY, lastExportedAt: iso });
+};

--- a/db/dexie.ts
+++ b/db/dexie.ts
@@ -22,23 +22,36 @@ export interface AnalysisHistoryRecord {
     history: AnalysisResult[];
 }
 
+export interface BackupMetaRecord {
+    key: string;
+    lastExportedAt: string | null;
+}
+
 export type AppDexieDb = Dexie & {
     projects: EntityTable<Project, 'id'>;
     tutorialState: EntityTable<TutorialStateRecord, 'version'>;
     analysisHistory: EntityTable<AnalysisHistoryRecord, 'key'>;
+    backupMeta: EntityTable<BackupMetaRecord, 'key'>;
 };
 
 export const DB_NAME = 'novelWriterDb';
-export const DB_VERSION = 1;
+export const DB_VERSION = 2;
 export const TUTORIAL_STATE_VERSION = 1;
 export const ANALYSIS_HISTORY_KEY = 'current';
+export const BACKUP_META_KEY = 'current';
 
 const createDb = (): AppDexieDb => {
     const instance = new Dexie(DB_NAME) as AppDexieDb;
+    instance.version(1).stores({
+        projects: 'id, lastModified',
+        tutorialState: 'version',
+        analysisHistory: 'key',
+    });
     instance.version(DB_VERSION).stores({
         projects: 'id, lastModified',
         tutorialState: 'version',
         analysisHistory: 'key',
+        backupMeta: 'key',
     });
     return instance;
 };

--- a/db/projectRepository.ts
+++ b/db/projectRepository.ts
@@ -41,7 +41,7 @@ type _MissingFromWhitelist = Exclude<
 const _coverageCheck: [_MissingFromWhitelist] extends [never] ? true : never = true;
 void _coverageCheck;
 
-const pickPersistableFields = (project: Project): Project => {
+export const pickPersistableFields = (project: Project): Project => {
     const out: Record<string, unknown> = {};
     for (const key of PERSISTABLE_KEYS) {
         const value = project[key];
@@ -53,7 +53,7 @@ const pickPersistableFields = (project: Project): Project => {
 // Recursive pass: pickPersistableFields whitelists only the top level, but
 // legacy fields like _order can be nested under settings/knowledgeBase/
 // novelContent. AC A6.
-const stripInternalKeys = (value: unknown): unknown => {
+export const stripInternalKeys = (value: unknown): unknown => {
     if (Array.isArray(value)) return value.map(stripInternalKeys);
     if (value && typeof value === 'object') {
         const out: Record<string, unknown> = {};

--- a/hooks/refreshFromIndexedDb.ts
+++ b/hooks/refreshFromIndexedDb.ts
@@ -1,0 +1,65 @@
+import { useStore } from '../store/index';
+import { Project } from '../types';
+import { getProject, listProjects } from '../db/projectRepository';
+import { ProjectValidationError } from '../utils';
+
+export interface RefreshFromIndexedDbResult {
+    failureCount: number;
+    healthyCount: number;
+}
+
+// Reload projects from IndexedDB and reseat allProjectsData. Used at startup
+// (useLocalSync) and after a successful import (backupSlice.executeImport)
+// so memory and disk stay in sync — otherwise the next markDirty/flushSave
+// would resurrect pre-import state and silently overwrite imported rows.
+//
+// Lives in its own module rather than alongside useLocalSync to avoid a
+// hooks → store → hooks import cycle that would otherwise break the slice
+// composition order at module evaluation time.
+export const refreshFromIndexedDb = async (
+    options: { keepActive?: boolean } = {},
+): Promise<RefreshFromIndexedDbResult> => {
+    const projectList = await listProjects();
+    if (projectList.length === 0) {
+        useStore.setState({ allProjectsData: {}, activeProjectId: null });
+        return { failureCount: 0, healthyCount: 0 };
+    }
+
+    let validationFailures = 0;
+    let infrastructureFailures = 0;
+    const projects = await Promise.all(
+        projectList.map(p =>
+            getProject(p.id).catch((err: unknown) => {
+                console.error(`Failed to load project ${p.id}:`, err);
+                if (err instanceof ProjectValidationError) {
+                    validationFailures++;
+                } else {
+                    infrastructureFailures++;
+                }
+                return null;
+            }),
+        ),
+    );
+    const allProjectsData: Record<string, Project> = {};
+    for (const p of projects) {
+        if (p) allProjectsData[p.id] = p;
+    }
+
+    const healthyProjects = projectList.filter(p => allProjectsData[p.id]);
+    const existingId = useStore.getState().activeProjectId;
+    const validExistingId =
+        existingId && allProjectsData[existingId] ? existingId : null;
+    const fallbackId = options.keepActive
+        ? validExistingId
+        : (validExistingId ?? healthyProjects[0]?.id ?? null);
+
+    useStore.setState({
+        allProjectsData,
+        activeProjectId: fallbackId,
+    });
+
+    return {
+        failureCount: validationFailures + infrastructureFailures,
+        healthyCount: healthyProjects.length,
+    };
+};

--- a/hooks/useLocalSync.ts
+++ b/hooks/useLocalSync.ts
@@ -1,8 +1,9 @@
 import { useEffect, useState } from 'react';
 import { useStore } from '../store/index';
-import { Project } from '../types';
-import { getProject, listProjects } from '../db/projectRepository';
-import { ProjectValidationError } from '../utils';
+import { refreshFromIndexedDb } from './refreshFromIndexedDb';
+
+export type { RefreshFromIndexedDbResult } from './refreshFromIndexedDb';
+export { refreshFromIndexedDb } from './refreshFromIndexedDb';
 
 const LOCAL_DB_INIT_FAILED_MESSAGE =
     'ローカルデータの読み込みに失敗しました。プライベートモードや容量不足で IndexedDB が利用できない場合、データはメモリ上のみ保持され、リロードで失われます。';
@@ -14,55 +15,10 @@ export const useLocalSync = () => {
     useEffect(() => {
         const init = async () => {
             try {
-                const projectList = await listProjects();
-                if (projectList.length === 0) {
-                    useStore.setState({ activeProjectId: null });
-                    return;
-                }
-
-                let validationFailures = 0;
-                let infrastructureFailures = 0;
-                const projects = await Promise.all(
-                    projectList.map(p =>
-                        getProject(p.id).catch((err: unknown) => {
-                            console.error(`Failed to load project ${p.id}:`, err);
-                            if (err instanceof ProjectValidationError) {
-                                validationFailures++;
-                            } else {
-                                infrastructureFailures++;
-                            }
-                            return null;
-                        }),
-                    ),
-                );
-                const allProjectsData: Record<string, Project> = {};
-                for (const p of projects) {
-                    if (p) allProjectsData[p.id] = p;
-                }
-
-                // Filter while preserving listProjects' lastModified-DESC order
-                // so the fallback below picks the most recent healthy project.
-                const healthyProjects = projectList.filter(p => allProjectsData[p.id]);
-
-                // Dangling-id guard: a persisted activeProjectId may point at a
-                // project that is now missing or corrupted across sessions.
-                const existingId = useStore.getState().activeProjectId;
-                const validExistingId =
-                    existingId && allProjectsData[existingId] ? existingId : null;
-                const fallbackId = healthyProjects[0]?.id ?? null;
-
-                useStore.setState({
-                    allProjectsData,
-                    activeProjectId: validExistingId ?? fallbackId,
-                });
-
-                const failureCount = validationFailures + infrastructureFailures;
-                if (failureCount > 0) {
-                    const detail = infrastructureFailures > 0
-                        ? '一時的なエラーの可能性があります。リロードで復旧する場合があります'
-                        : '破損データを除外しました';
+                const result = await refreshFromIndexedDb();
+                if (result.failureCount > 0) {
                     useStore.getState().showToast(
-                        `プロジェクト ${failureCount} 件の読み込みに失敗しました（${detail}）`,
+                        `プロジェクト ${result.failureCount} 件の読み込みに失敗しました（破損データを除外、または一時的エラーの可能性）`,
                         'error',
                     );
                 }

--- a/store/backupSlice.test.ts
+++ b/store/backupSlice.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createBackupSlice } from './backupSlice';
+import { Project } from '../types';
+import { defaultAiSettings, defaultDisplaySettings } from '../constants';
+
+// Mock the db layer so backupSlice can run without a real IndexedDB.
+const readSnapshot = vi.fn();
+const writeImport = vi.fn();
+const loadLastExportedAt = vi.fn();
+const saveLastExportedAt = vi.fn();
+
+vi.mock('../db/backupRepository', () => ({
+    readSnapshot: (...args: unknown[]) => readSnapshot(...args),
+    writeImport: (...args: unknown[]) => writeImport(...args),
+    loadLastExportedAt: (...args: unknown[]) => loadLastExportedAt(...args),
+    saveLastExportedAt: (...args: unknown[]) => saveLastExportedAt(...args),
+}));
+
+const makeProject = (over: Partial<Project> = {}): Project => ({
+    id: over.id ?? 'p-1',
+    name: over.name ?? 'P',
+    lastModified: '2026-04-28T00:00:00.000Z',
+    isSimpleMode: false,
+    settings: [],
+    novelContent: [],
+    chatHistory: [],
+    knowledgeBase: [],
+    plotBoard: [],
+    plotTypeColors: {},
+    plotRelations: [],
+    plotNodePositions: [],
+    timeline: [],
+    timelineLanes: [],
+    characterRelations: [],
+    nodePositions: [],
+    aiSettings: defaultAiSettings,
+    displaySettings: defaultDisplaySettings,
+    ...over,
+});
+
+interface FakeStore {
+    state: ReturnType<typeof createBackupSlice> & { showToast?: any };
+    set: (partial: any) => void;
+    get: () => FakeStore['state'];
+}
+
+const createFakeStore = (): FakeStore => {
+    const fake: FakeStore = { state: {} as any, set: () => {}, get: () => fake.state };
+    fake.set = (partial: any) => {
+        const next = typeof partial === 'function' ? partial(fake.state) : partial;
+        fake.state = { ...fake.state, ...next };
+    };
+    fake.get = () => fake.state;
+    fake.state = {
+        ...createBackupSlice(fake.set, fake.get),
+        showToast: vi.fn(),
+    } as any;
+    return fake;
+};
+
+beforeEach(() => {
+    readSnapshot.mockReset();
+    writeImport.mockReset();
+    loadLastExportedAt.mockReset();
+    saveLastExportedAt.mockReset();
+
+    // jsdom is not loaded in node env; stub minimal browser bits used by exportAllData.
+    (globalThis as any).URL ??= {} as any;
+    (globalThis as any).URL.createObjectURL = vi.fn(() => 'blob:mock');
+    (globalThis as any).URL.revokeObjectURL = vi.fn();
+    (globalThis as any).Blob = class { constructor(public parts: any, public opts: any) {} } as any;
+    (globalThis as any).document ??= {} as any;
+    (globalThis as any).document.createElement = vi.fn(() => ({
+        click: vi.fn(),
+        remove: vi.fn(),
+        style: {},
+    }));
+    (globalThis as any).document.body ??= { appendChild: vi.fn() };
+});
+
+describe('initBackupState (AC-6)', () => {
+    it('loads lastExportedAt from db', async () => {
+        loadLastExportedAt.mockResolvedValue('2026-04-01T00:00:00.000Z');
+        const fake = createFakeStore();
+        await fake.state.initBackupState();
+        expect(fake.state.lastExportedAt).toBe('2026-04-01T00:00:00.000Z');
+    });
+
+    it('keeps null when nothing persisted', async () => {
+        loadLastExportedAt.mockResolvedValue(null);
+        const fake = createFakeStore();
+        await fake.state.initBackupState();
+        expect(fake.state.lastExportedAt).toBeNull();
+    });
+});
+
+describe('exportAllData (AC-1, AC-6)', () => {
+    it('serializes snapshot, persists lastExportedAt, surfaces toast', async () => {
+        readSnapshot.mockResolvedValue({
+            projects: [makeProject({ id: 'p-1' }), makeProject({ id: 'p-2' })],
+            tutorialState: { hasCompletedGlobalTutorial: true },
+            analysisHistory: [],
+        });
+        const fake = createFakeStore();
+        await fake.state.exportAllData();
+        expect(saveLastExportedAt).toHaveBeenCalledOnce();
+        expect(fake.state.lastExportedAt).toBeTruthy();
+        expect((fake.state.showToast as any)).toHaveBeenCalled();
+    });
+});
+
+describe('prepareImport / executeImport (AC-3, AC-5)', () => {
+    it('detects conflicts against existing IndexedDB ids', async () => {
+        readSnapshot.mockResolvedValue({
+            projects: [makeProject({ id: 'p-existing', name: '既存' })],
+            tutorialState: {},
+            analysisHistory: [],
+        });
+        const fake = createFakeStore();
+        const raw = JSON.stringify({
+            schemaVersion: 1,
+            exportedAt: '2026-04-28T00:00:00.000Z',
+            appVersion: '0.0.0',
+            projects: [
+                makeProject({ id: 'p-existing', name: 'インポート' }),
+                makeProject({ id: 'p-new', name: '新規' }),
+            ],
+            tutorialState: {},
+            analysisHistory: [],
+        });
+        const plan = await fake.state.prepareImport(raw);
+        expect(plan.conflicts).toHaveLength(1);
+        expect(plan.conflicts[0].incomingId).toBe('p-existing');
+        expect(plan.conflicts[0].existingName).toBe('既存');
+        expect(plan.conflicts[0].resolution).toBe('overwrite'); // default
+    });
+
+    it('AC-5 (atomicity): writeImport invoked once with consolidated payload', async () => {
+        readSnapshot.mockResolvedValue({
+            projects: [makeProject({ id: 'p-existing' })],
+            tutorialState: {},
+            analysisHistory: [],
+        });
+        writeImport.mockResolvedValue(undefined);
+        const fake = createFakeStore();
+        const raw = JSON.stringify({
+            schemaVersion: 1,
+            exportedAt: '2026-04-28T00:00:00.000Z',
+            appVersion: '0.0.0',
+            projects: [
+                makeProject({ id: 'p-existing' }),
+                makeProject({ id: 'p-new' }),
+            ],
+            tutorialState: { hasCompletedGlobalTutorial: true },
+            analysisHistory: [],
+        });
+        await fake.state.prepareImport(raw);
+        const result = await fake.state.executeImport();
+        expect(writeImport).toHaveBeenCalledOnce();
+        const payload = writeImport.mock.calls[0][0];
+        expect(payload.toUpsert.map((p: Project) => p.id).sort()).toEqual(['p-existing', 'p-new']);
+        expect(result.upserted).toBe(2);
+        expect(result.created).toBe(0);
+    });
+
+    it('AC-5 (atomicity): writeImport rejection bubbles up, no partial state in store', async () => {
+        readSnapshot.mockResolvedValue({
+            projects: [],
+            tutorialState: {},
+            analysisHistory: [],
+        });
+        writeImport.mockRejectedValue(new Error('quota exceeded'));
+        const fake = createFakeStore();
+        const raw = JSON.stringify({
+            schemaVersion: 1,
+            exportedAt: '2026-04-28T00:00:00.000Z',
+            appVersion: '0.0.0',
+            projects: [makeProject({ id: 'p-1' })],
+            tutorialState: {},
+            analysisHistory: [],
+        });
+        await fake.state.prepareImport(raw);
+        await expect(fake.state.executeImport()).rejects.toThrow(/quota/);
+        // importPlan retained so user can retry / inspect
+        expect(fake.state.importPlan).not.toBeNull();
+    });
+});
+
+describe('isBackupStale (AC-7)', () => {
+    it('returns true when never exported', () => {
+        const fake = createFakeStore();
+        expect(fake.state.isBackupStale()).toBe(true);
+    });
+
+    it('returns false when exported within 30 days', () => {
+        const fake = createFakeStore();
+        fake.set({ lastExportedAt: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString() });
+        expect(fake.state.isBackupStale()).toBe(false);
+    });
+
+    it('returns true when exported >30 days ago', () => {
+        const fake = createFakeStore();
+        fake.set({ lastExportedAt: new Date(Date.now() - 31 * 24 * 60 * 60 * 1000).toISOString() });
+        expect(fake.state.isBackupStale()).toBe(true);
+    });
+
+    it('returns true on malformed iso', () => {
+        const fake = createFakeStore();
+        fake.set({ lastExportedAt: 'not-an-iso' });
+        expect(fake.state.isBackupStale()).toBe(true);
+    });
+});

--- a/store/backupSlice.test.ts
+++ b/store/backupSlice.test.ts
@@ -8,12 +8,24 @@ const readSnapshot = vi.fn();
 const writeImport = vi.fn();
 const loadLastExportedAt = vi.fn();
 const saveLastExportedAt = vi.fn();
+const refreshFromIndexedDb = vi.fn();
+const loadTutorialState = vi.fn();
+const loadAnalysisHistory = vi.fn();
 
 vi.mock('../db/backupRepository', () => ({
     readSnapshot: (...args: unknown[]) => readSnapshot(...args),
     writeImport: (...args: unknown[]) => writeImport(...args),
     loadLastExportedAt: (...args: unknown[]) => loadLastExportedAt(...args),
     saveLastExportedAt: (...args: unknown[]) => saveLastExportedAt(...args),
+}));
+vi.mock('../hooks/refreshFromIndexedDb', () => ({
+    refreshFromIndexedDb: (...args: unknown[]) => refreshFromIndexedDb(...args),
+}));
+vi.mock('../db/tutorialRepository', () => ({
+    loadTutorialState: (...args: unknown[]) => loadTutorialState(...args),
+}));
+vi.mock('../db/analysisHistoryRepository', () => ({
+    loadAnalysisHistory: (...args: unknown[]) => loadAnalysisHistory(...args),
 }));
 
 const makeProject = (over: Partial<Project> = {}): Project => ({
@@ -63,6 +75,9 @@ beforeEach(() => {
     writeImport.mockReset();
     loadLastExportedAt.mockReset();
     saveLastExportedAt.mockReset();
+    refreshFromIndexedDb.mockReset().mockResolvedValue({ failureCount: 0, healthyCount: 0 });
+    loadTutorialState.mockReset().mockResolvedValue({});
+    loadAnalysisHistory.mockReset().mockResolvedValue([]);
 
     // jsdom is not loaded in node env; stub minimal browser bits used by exportAllData.
     (globalThis as any).URL ??= {} as any;
@@ -79,11 +94,12 @@ beforeEach(() => {
 });
 
 describe('initBackupState (AC-6)', () => {
-    it('loads lastExportedAt from db', async () => {
+    it('loads lastExportedAt from db and marks status loaded', async () => {
         loadLastExportedAt.mockResolvedValue('2026-04-01T00:00:00.000Z');
         const fake = createFakeStore();
         await fake.state.initBackupState();
         expect(fake.state.lastExportedAt).toBe('2026-04-01T00:00:00.000Z');
+        expect(fake.state.backupMetaStatus).toBe('loaded');
     });
 
     it('keeps null when nothing persisted', async () => {
@@ -91,6 +107,17 @@ describe('initBackupState (AC-6)', () => {
         const fake = createFakeStore();
         await fake.state.initBackupState();
         expect(fake.state.lastExportedAt).toBeNull();
+        expect(fake.state.backupMetaStatus).toBe('loaded');
+    });
+
+    it('H3: keeps backupMetaStatus=unknown on db error and toasts', async () => {
+        loadLastExportedAt.mockRejectedValue(new Error('IndexedDB closed'));
+        const fake = createFakeStore();
+        await fake.state.initBackupState();
+        expect(fake.state.backupMetaStatus).toBe('unknown');
+        expect((fake.state.showToast as any)).toHaveBeenCalled();
+        // Stale should be suppressed in unknown state to avoid lying to the user.
+        expect(fake.state.isBackupStale()).toBe(false);
     });
 });
 
@@ -187,26 +214,31 @@ describe('prepareImport / executeImport (AC-3, AC-5)', () => {
 });
 
 describe('isBackupStale (AC-7)', () => {
-    it('returns true when never exported', () => {
+    const setLoaded = (fake: ReturnType<typeof createFakeStore>, lastExportedAt: string | null) => {
+        fake.set({ lastExportedAt, backupMetaStatus: 'loaded' });
+    };
+
+    it('returns true when never exported (loaded + null)', () => {
         const fake = createFakeStore();
+        setLoaded(fake, null);
         expect(fake.state.isBackupStale()).toBe(true);
     });
 
     it('returns false when exported within 30 days', () => {
         const fake = createFakeStore();
-        fake.set({ lastExportedAt: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString() });
+        setLoaded(fake, new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString());
         expect(fake.state.isBackupStale()).toBe(false);
     });
 
     it('returns true when exported >30 days ago', () => {
         const fake = createFakeStore();
-        fake.set({ lastExportedAt: new Date(Date.now() - 31 * 24 * 60 * 60 * 1000).toISOString() });
+        setLoaded(fake, new Date(Date.now() - 31 * 24 * 60 * 60 * 1000).toISOString());
         expect(fake.state.isBackupStale()).toBe(true);
     });
 
     it('returns true on malformed iso', () => {
         const fake = createFakeStore();
-        fake.set({ lastExportedAt: 'not-an-iso' });
+        setLoaded(fake, 'not-an-iso');
         expect(fake.state.isBackupStale()).toBe(true);
     });
 });

--- a/store/backupSlice.ts
+++ b/store/backupSlice.ts
@@ -20,6 +20,9 @@ import {
     writeImport,
 } from '../db/backupRepository';
 import { STALE_BACKUP_DAYS, daysSince } from '../utils/backupFormat';
+import { refreshFromIndexedDb } from '../hooks/refreshFromIndexedDb';
+import { loadTutorialState } from '../db/tutorialRepository';
+import { loadAnalysisHistory } from '../db/analysisHistoryRepository';
 
 // `__APP_VERSION__` is replaced at build time by vite (see vite.config.ts).
 // In tests / non-Vite contexts, fall back to a literal so this slice still
@@ -29,12 +32,17 @@ const APP_VERSION: string = typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSI
 // Slice-local view of get(): showToast lives on UiSlice but the type union
 // is built only in store/index.ts; mirror authSlice's typed-cast pattern.
 type WithToast = { showToast?: (m: string, t?: 'info' | 'success' | 'error') => void };
+type WithFlushSave = { flushSave?: () => Promise<void> };
+type WithCloseModal = { closeModal?: () => void };
 
 const errorMessage = (e: unknown): string =>
     e instanceof Error ? e.message : String(e);
 
+export type BackupMetaStatus = 'unknown' | 'loaded';
+
 export interface BackupSlice {
     lastExportedAt: string | null;
+    backupMetaStatus: BackupMetaStatus;
     importPlan: ImportPlan | null;
     isExporting: boolean;
     isImporting: boolean;
@@ -82,6 +90,7 @@ const detectConflicts = (incoming: Project[], existing: Project[]): ImportConfli
 
 export const createBackupSlice = (set, get): BackupSlice => ({
     lastExportedAt: null,
+    backupMetaStatus: 'unknown',
     importPlan: null,
     isExporting: false,
     isImporting: false,
@@ -89,9 +98,17 @@ export const createBackupSlice = (set, get): BackupSlice => ({
     initBackupState: async () => {
         try {
             const iso = await loadLastExportedAt();
-            set({ lastExportedAt: iso });
+            set({ lastExportedAt: iso, backupMetaStatus: 'loaded' });
         } catch (e) {
+            // Don't promote unknown to "loaded": isBackupStale needs to know
+            // we couldn't read so it can suppress the warning banner instead
+            // of showing "未実施" indefinitely.
             console.error('Failed to load lastExportedAt:', e);
+            set({ lastExportedAt: null, backupMetaStatus: 'unknown' });
+            (get() as WithToast).showToast?.(
+                `バックアップ状態の読込に失敗しました: ${errorMessage(e)}`,
+                'error',
+            );
         }
     },
 
@@ -108,11 +125,29 @@ export const createBackupSlice = (set, get): BackupSlice => ({
             });
             const json = serializeBackup(backup);
             const filename = buildBackupFilename();
+
+            // 1. Trigger the download. If this fails (e.g. blob/anchor APIs
+            //    unavailable), nothing has been saved yet — propagate as a
+            //    plain export failure.
             triggerDownload(filename, json);
-            await saveLastExportedAt(backup.exportedAt);
-            set({ lastExportedAt: backup.exportedAt });
+
+            // 2. Persist lastExportedAt separately. The user already has the
+            //    file at this point, so a save failure here is recoverable
+            //    (banner stays "stale" but the data is on disk). Differentiate
+            //    the messaging so the user isn't told the export "failed"
+            //    when the JSON is actually in their downloads folder.
             const count = backup.projects.length;
-            (get() as WithToast).showToast?.(`${count} 件のプロジェクトをエクスポートしました`, 'success');
+            try {
+                await saveLastExportedAt(backup.exportedAt);
+                set({ lastExportedAt: backup.exportedAt, backupMetaStatus: 'loaded' });
+                (get() as WithToast).showToast?.(`${count} 件のプロジェクトをエクスポートしました`, 'success');
+            } catch (e: unknown) {
+                console.error('saveLastExportedAt failed (download succeeded):', e);
+                (get() as WithToast).showToast?.(
+                    `${count} 件のプロジェクトをエクスポートしました（最終バックアップ日時の記録に失敗: ${errorMessage(e)}）`,
+                    'error',
+                );
+            }
         } catch (e: unknown) {
             console.error('exportAllData failed:', e);
             (get() as WithToast).showToast?.(`エクスポートに失敗しました: ${errorMessage(e)}`, 'error');
@@ -122,6 +157,15 @@ export const createBackupSlice = (set, get): BackupSlice => ({
     },
 
     prepareImport: async (raw: string) => {
+        // Flush in-memory edits to IndexedDB first so that conflict detection
+        // sees the user's latest unsaved work and overwrite/skip choices apply
+        // to the actual on-disk state. Without this, a project that the user
+        // is currently editing would not appear in conflicts.
+        try {
+            await (get() as WithFlushSave).flushSave?.();
+        } catch (e) {
+            console.error('flushSave before prepareImport failed:', e);
+        }
         const backup = parseBackup(raw);
         const snapshot = await readSnapshot();
         const conflicts = detectConflicts(backup.projects, snapshot.projects);
@@ -142,7 +186,13 @@ export const createBackupSlice = (set, get): BackupSlice => ({
         set({ importPlan: next });
     },
 
-    cancelImport: () => set({ importPlan: null }),
+    cancelImport: () => {
+        // Also close the modal so we don't leak an `activeModal === 'importConflict'`
+        // state with no plan to back it (ModalManager would render an empty
+        // component and other modal/help routes would be silently blocked).
+        set({ importPlan: null });
+        (get() as WithCloseModal).closeModal?.();
+    },
 
     executeImport: async () => {
         const plan = get().importPlan;
@@ -170,8 +220,23 @@ export const createBackupSlice = (set, get): BackupSlice => ({
                 tutorialState: plan.backup.tutorialState,
                 analysisHistory: plan.backup.analysisHistory,
             });
+
+            // Re-hydrate in-memory state from IndexedDB. Without this,
+            // allProjectsData/tutorialState/analysisHistory keep their pre-import
+            // shape and the next markDirty/flushSave would silently overwrite
+            // the freshly imported rows.
+            await refreshFromIndexedDb({ keepActive: true });
+            try {
+                const flags = await loadTutorialState();
+                const history = await loadAnalysisHistory();
+                set({ ...flags, analysisHistory: history });
+            } catch (e) {
+                console.error('post-import side-store refresh failed:', e);
+            }
+
             const skipped = plan.conflicts.filter(c => c.resolution === 'skip').length;
             set({ importPlan: null });
+            (get() as WithCloseModal).closeModal?.();
             (get() as WithToast).showToast?.(
                 `${toUpsert.length + toCreate.length} 件のプロジェクトを復元しました（スキップ ${skipped} 件）`,
                 'success',
@@ -189,6 +254,10 @@ export const createBackupSlice = (set, get): BackupSlice => ({
     },
 
     isBackupStale: () => {
+        // If we couldn't read backupMeta we can't tell whether the user has a
+        // recent export — suppress the banner rather than mislead them with
+        // "未実施" while the underlying read keeps failing.
+        if (get().backupMetaStatus === 'unknown') return false;
         const days = daysSince(get().lastExportedAt);
         return days === null || days > STALE_BACKUP_DAYS;
     },

--- a/store/backupSlice.ts
+++ b/store/backupSlice.ts
@@ -1,0 +1,195 @@
+import {
+    BackupV1,
+    ImportConflict,
+    ImportConflictResolution,
+    ImportPlan,
+    Project,
+} from '../types';
+import {
+    BackupValidationError,
+    buildBackupFilename,
+    buildBackupV1,
+    parseBackup,
+    resolveImportProjects,
+    serializeBackup,
+} from '../utils/backupSchema';
+import {
+    loadLastExportedAt,
+    readSnapshot,
+    saveLastExportedAt,
+    writeImport,
+} from '../db/backupRepository';
+import { STALE_BACKUP_DAYS, daysSince } from '../utils/backupFormat';
+
+// `__APP_VERSION__` is replaced at build time by vite (see vite.config.ts).
+// In tests / non-Vite contexts, fall back to a literal so this slice still
+// loads. Guarded with typeof to avoid ReferenceError under vitest.
+const APP_VERSION: string = typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : 'test';
+
+// Slice-local view of get(): showToast lives on UiSlice but the type union
+// is built only in store/index.ts; mirror authSlice's typed-cast pattern.
+type WithToast = { showToast?: (m: string, t?: 'info' | 'success' | 'error') => void };
+
+const errorMessage = (e: unknown): string =>
+    e instanceof Error ? e.message : String(e);
+
+export interface BackupSlice {
+    lastExportedAt: string | null;
+    importPlan: ImportPlan | null;
+    isExporting: boolean;
+    isImporting: boolean;
+
+    initBackupState: () => Promise<void>;
+    exportAllData: () => Promise<void>;
+    prepareImport: (raw: string) => Promise<ImportPlan>;
+    setImportResolution: (incomingId: string, resolution: ImportConflictResolution) => void;
+    cancelImport: () => void;
+    executeImport: () => Promise<{ upserted: number; created: number; skipped: number }>;
+    isBackupStale: () => boolean;
+}
+
+const triggerDownload = (filename: string, content: string) => {
+    const blob = new Blob([content], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+    // Defer revoke so Safari/Firefox can resolve the blob before it is freed.
+    // Synchronous revoke after click() races with the browser's download
+    // pipeline and produces empty files in those engines.
+    setTimeout(() => URL.revokeObjectURL(url), 0);
+};
+
+const detectConflicts = (incoming: Project[], existing: Project[]): ImportConflict[] => {
+    const existingMap = new Map(existing.map(p => [p.id, p]));
+    const conflicts: ImportConflict[] = [];
+    for (const p of incoming) {
+        const existed = existingMap.get(p.id);
+        if (existed) {
+            conflicts.push({
+                incomingId: p.id,
+                incomingName: p.name,
+                existingName: existed.name,
+                resolution: 'overwrite',
+            });
+        }
+    }
+    return conflicts;
+};
+
+export const createBackupSlice = (set, get): BackupSlice => ({
+    lastExportedAt: null,
+    importPlan: null,
+    isExporting: false,
+    isImporting: false,
+
+    initBackupState: async () => {
+        try {
+            const iso = await loadLastExportedAt();
+            set({ lastExportedAt: iso });
+        } catch (e) {
+            console.error('Failed to load lastExportedAt:', e);
+        }
+    },
+
+    exportAllData: async () => {
+        if (get().isExporting) return;
+        set({ isExporting: true });
+        try {
+            const snapshot = await readSnapshot();
+            const backup: BackupV1 = buildBackupV1({
+                projects: snapshot.projects,
+                tutorialState: snapshot.tutorialState,
+                analysisHistory: snapshot.analysisHistory,
+                appVersion: APP_VERSION,
+            });
+            const json = serializeBackup(backup);
+            const filename = buildBackupFilename();
+            triggerDownload(filename, json);
+            await saveLastExportedAt(backup.exportedAt);
+            set({ lastExportedAt: backup.exportedAt });
+            const count = backup.projects.length;
+            (get() as WithToast).showToast?.(`${count} 件のプロジェクトをエクスポートしました`, 'success');
+        } catch (e: unknown) {
+            console.error('exportAllData failed:', e);
+            (get() as WithToast).showToast?.(`エクスポートに失敗しました: ${errorMessage(e)}`, 'error');
+        } finally {
+            set({ isExporting: false });
+        }
+    },
+
+    prepareImport: async (raw: string) => {
+        const backup = parseBackup(raw);
+        const snapshot = await readSnapshot();
+        const conflicts = detectConflicts(backup.projects, snapshot.projects);
+        const plan: ImportPlan = { backup, conflicts };
+        set({ importPlan: plan });
+        return plan;
+    },
+
+    setImportResolution: (incomingId, resolution) => {
+        const plan = get().importPlan;
+        if (!plan) return;
+        const next: ImportPlan = {
+            ...plan,
+            conflicts: plan.conflicts.map(c =>
+                c.incomingId === incomingId ? { ...c, resolution } : c,
+            ),
+        };
+        set({ importPlan: next });
+    },
+
+    cancelImport: () => set({ importPlan: null }),
+
+    executeImport: async () => {
+        const plan = get().importPlan;
+        if (!plan) throw new BackupValidationError('インポート対象がありません。');
+        if (get().isImporting) throw new Error('既にインポート処理中です。');
+        set({ isImporting: true });
+        try {
+            // Re-read existing IDs to avoid TOCTOU between prepareImport and
+            // execute: a delete done elsewhere shouldn't force resolution that
+            // no longer applies, and an insert done elsewhere shouldn't be
+            // silently overwritten without confirmation.
+            const snapshot = await readSnapshot();
+            const existingIds = new Set(snapshot.projects.map(p => p.id));
+            const resolutions = new Map<string, ImportConflictResolution>(
+                plan.conflicts.map(c => [c.incomingId, c.resolution]),
+            );
+            const { toUpsert, toCreate } = resolveImportProjects(
+                plan.backup.projects,
+                existingIds,
+                resolutions,
+            );
+            await writeImport({
+                toUpsert,
+                toCreate,
+                tutorialState: plan.backup.tutorialState,
+                analysisHistory: plan.backup.analysisHistory,
+            });
+            const skipped = plan.conflicts.filter(c => c.resolution === 'skip').length;
+            set({ importPlan: null });
+            (get() as WithToast).showToast?.(
+                `${toUpsert.length + toCreate.length} 件のプロジェクトを復元しました（スキップ ${skipped} 件）`,
+                'success',
+            );
+            return { upserted: toUpsert.length, created: toCreate.length, skipped };
+        } catch (e: unknown) {
+            // Don't toast here: ImportConflictModal renders the same message
+            // inline (red banner). Surfacing a toast in addition would double
+            // up the same error in two places.
+            console.error('executeImport failed:', e);
+            throw e;
+        } finally {
+            set({ isImporting: false });
+        }
+    },
+
+    isBackupStale: () => {
+        const days = daysSince(get().lastExportedAt);
+        return days === null || days > STALE_BACKUP_DAYS;
+    },
+});

--- a/store/index.ts
+++ b/store/index.ts
@@ -10,8 +10,9 @@ import { createAnalysisHistorySlice, AnalysisHistorySlice } from './analysisHist
 import { createFormSlice, FormSlice } from './formSlice';
 import { createSyncSlice, SyncSlice } from './syncSlice';
 import { createAuthSlice, AuthSlice } from './authSlice';
+import { createBackupSlice, BackupSlice } from './backupSlice';
 
-export const useStore = create<AppState & AppActions & ProjectSlice & UiSlice & DataSlice & AiSlice & HistorySlice & TutorialSlice & AnalysisHistorySlice & FormSlice & SyncSlice & AuthSlice>()(
+export const useStore = create<AppState & AppActions & ProjectSlice & UiSlice & DataSlice & AiSlice & HistorySlice & TutorialSlice & AnalysisHistorySlice & FormSlice & SyncSlice & AuthSlice & BackupSlice>()(
     (set, get, api) => ({
         ...createProjectSlice(set, get),
         ...createUiSlice(set, get),
@@ -23,6 +24,7 @@ export const useStore = create<AppState & AppActions & ProjectSlice & UiSlice & 
         ...createFormSlice(set, get),
         ...createSyncSlice(set, get),
         ...createAuthSlice(set, get),
+        ...createBackupSlice(set, get),
         loadInitialState: () => {},
     })
 );

--- a/store/projectSlice.ts
+++ b/store/projectSlice.ts
@@ -3,8 +3,8 @@ import React from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import { Project, AppState, AppActions, HistoryTree, HistoryNode } from '../types';
 import { defaultAiSettings, defaultDisplaySettings, simpleModeAiSettings, simpleModeDisplaySettings } from '../constants';
-import { validateAndSanitizeProjectData } from '../utils';
 import { deleteProject as deleteProjectFromDb, putProject } from '../db/projectRepository';
+import { readFileAsText } from '../utils/readFileAsText';
 
 const initialState = {
     allProjectsData: {} as { [key: string]: Project },
@@ -103,38 +103,29 @@ export const createProjectSlice = (set, get): ProjectSlice => ({
             (get() as any).showToast?.(`プロジェクトの削除に失敗しました: ${err.message}`, 'error');
         });
     },
-    importProject: (event) => {
-        const file = event.target.files[0];
+    // Import goes through backupSlice (prepareImport + ImportConflictModal) to
+    // handle multi-project bundles and conflict resolution. ProjectSelectionScreen
+    // still uses this single-project entry point for the legacy ".json" file
+    // input, deferring to the same pipeline.
+    importProject: async (event) => {
+        const file = event.target.files?.[0];
+        if (event.target) event.target.value = '';
         if (!file) return;
-        const reader = new FileReader();
-        reader.onload = (e) => {
-            try {
-                const parsedJson = JSON.parse(e.target.result as string);
-                const rawProjectData = (parsedJson.project && parsedJson.project.id) ? parsedJson.project : parsedJson;
-                let projectToLoad = validateAndSanitizeProjectData(rawProjectData);
-
-                const historyTree = projectToLoad.historyTree || createInitialHistoryTree(projectToLoad);
-                projectToLoad = { ...projectToLoad, historyTree };
-
-                set(state => {
-                    return {
-                        ...state,
-                        allProjectsData: { ...state.allProjectsData, [projectToLoad.id]: projectToLoad },
-                        activeProjectId: projectToLoad.id,
-                        historyTree: historyTree,
-                    };
-                });
-                putProject(projectToLoad).catch(err => {
-                    console.error('Failed to save imported project:', err);
-                    (get() as any).showToast?.(`インポートしたプロジェクトの保存に失敗しました: ${err.message}`, 'error');
-                });
-            } catch (err) {
-                alert(`ファイルの読み込みに失敗しました: ${err.message}`);
-                console.error(err);
-            }
+        type ImportSurface = {
+            prepareImport: (raw: string) => Promise<unknown>;
+            openModal?: (type: string) => void;
+            showToast?: (m: string, t?: 'info' | 'success' | 'error') => void;
         };
-        reader.readAsText(file);
-        event.target.value = null;
+        const store = get() as ImportSurface;
+        try {
+            const raw = await readFileAsText(file);
+            await store.prepareImport(raw);
+            store.openModal?.('importConflict');
+        } catch (err: unknown) {
+            const msg = err instanceof Error ? err.message : String(err);
+            store.showToast?.(`ファイルの読み込みに失敗しました: ${msg}`, 'error');
+            console.error(err);
+        }
     },
     setSimpleMode: (isSimple) => {
         const project = get().allProjectsData[get().activeProjectId];

--- a/types.ts
+++ b/types.ts
@@ -332,7 +332,44 @@ export type ModalType =
   | 'syncDialog'
   | 'tutorialModeSelection'
   | 'displaySettings'
-  | 'importText';
+  | 'importText'
+  | 'importConflict';
+
+// --- Backup (M4) ---
+
+// Schema version for full-data backup. Bump when adding/removing top-level
+// keys or changing project-field shape. Importing a higher version must fail
+// loudly (AC-4) so users do not silently lose data.
+export const BACKUP_SCHEMA_VERSION = 1;
+
+export interface BackupV1 {
+    schemaVersion: 1;
+    exportedAt: string;
+    appVersion: string;
+    projects: Project[];
+    tutorialState: {
+        hasCompletedGlobalTutorial?: boolean;
+        hasCompletedGlobalKnowledgeTutorial?: boolean;
+        hasCompletedGlobalChartTutorial?: boolean;
+        hasCompletedGlobalPlotBoardTutorial?: boolean;
+        hasCompletedGlobalTimelineTutorial?: boolean;
+    };
+    analysisHistory: AnalysisResult[];
+}
+
+export type ImportConflictResolution = 'overwrite' | 'duplicate' | 'skip';
+
+export interface ImportConflict {
+    incomingId: string;
+    incomingName: string;
+    existingName: string;
+    resolution: ImportConflictResolution;
+}
+
+export interface ImportPlan {
+    backup: BackupV1;
+    conflicts: ImportConflict[];
+}
 
 export interface AppActions {
     loadInitialState: () => void;

--- a/utils/backupFormat.ts
+++ b/utils/backupFormat.ts
@@ -1,0 +1,19 @@
+// Threshold beyond which the warning banner kicks in. Mirrored as the cutoff
+// for `isBackupStale` in store/backupSlice.ts; keep them in lock-step here.
+export const STALE_BACKUP_DAYS = 30;
+
+const MS_PER_DAY = 1000 * 60 * 60 * 24;
+
+export const daysSince = (iso: string | null): number | null => {
+    if (!iso) return null;
+    const t = new Date(iso).getTime();
+    if (Number.isNaN(t)) return null;
+    return Math.floor((Date.now() - t) / MS_PER_DAY);
+};
+
+export const formatLastExportedAt = (iso: string | null): string => {
+    const days = daysSince(iso);
+    if (days === null) return '未実施';
+    if (days <= 0) return '本日';
+    return `${days}日前`;
+};

--- a/utils/backupSchema.test.ts
+++ b/utils/backupSchema.test.ts
@@ -124,6 +124,67 @@ describe('parseBackup (AC-4, AC-5, AC-9, AC-10)', () => {
         expect(result.projects).toHaveLength(1);
         expect(result.projects[0].id).toBe('p-1');
     });
+
+    it('B1: legacy bare-project JSON (no schemaVersion) is wrapped into BackupV1', () => {
+        const legacy = JSON.stringify(makeProject({ id: 'legacy-p', name: '旧プロジェクト' }));
+        const result = parseBackup(legacy, { rawSize: legacy.length });
+        expect(result.schemaVersion).toBe(1);
+        expect(result.appVersion).toBe('legacy');
+        expect(result.projects).toHaveLength(1);
+        expect(result.projects[0].id).toBe('legacy-p');
+        expect(result.projects[0].name).toBe('旧プロジェクト');
+    });
+
+    it('B1: legacy { project: {...} } envelope is unwrapped and accepted', () => {
+        const legacy = JSON.stringify({ project: makeProject({ id: 'env-p' }) });
+        const result = parseBackup(legacy, { rawSize: legacy.length });
+        expect(result.projects).toHaveLength(1);
+        expect(result.projects[0].id).toBe('env-p');
+    });
+
+    it('H1: tutorialState non-boolean values are dropped (string "yes" → omitted)', () => {
+        const raw = JSON.stringify({
+            schemaVersion: 1,
+            exportedAt: '2026-04-28T00:00:00.000Z',
+            appVersion: '0.0.0',
+            projects: [],
+            tutorialState: {
+                hasCompletedGlobalTutorial: 'yes',
+                hasCompletedGlobalKnowledgeTutorial: true,
+                evil_key: 'should be dropped',
+            },
+            analysisHistory: [],
+        });
+        const result = parseBackup(raw, { rawSize: raw.length });
+        expect(result.tutorialState).not.toHaveProperty('hasCompletedGlobalTutorial');
+        expect(result.tutorialState.hasCompletedGlobalKnowledgeTutorial).toBe(true);
+        expect(result.tutorialState).not.toHaveProperty('evil_key');
+    });
+
+    it('H1: analysisHistory items missing required fields are filtered out', () => {
+        const validItem = {
+            characters: { match: [], similar: [], new: [], extractedDetails: [] },
+            worldContext: { worldKeywords: [], genre: '', tone: '' },
+            worldTerms: { match: [], similar: [], new: [] },
+            dialogues: [],
+            notes: [],
+        };
+        const raw = JSON.stringify({
+            schemaVersion: 1,
+            exportedAt: '2026-04-28T00:00:00.000Z',
+            appVersion: '0.0.0',
+            projects: [],
+            tutorialState: {},
+            analysisHistory: [
+                validItem,
+                { characters: 'not an object' },
+                null,
+                { dialogues: [], notes: [] },
+            ],
+        });
+        const result = parseBackup(raw, { rawSize: raw.length });
+        expect(result.analysisHistory).toHaveLength(1);
+    });
 });
 
 describe('resolveImportProjects (AC-3)', () => {
@@ -191,5 +252,12 @@ describe('resolveImportProjects (AC-3)', () => {
         expect(r.toUpsert.map(p => p.id).sort()).toEqual(['new', 'over']);
         expect(r.toCreate).toHaveLength(1);
         expect(r.toCreate[0].id).not.toBe('dup');
+    });
+
+    it('H7: missing resolution for a conflicting id throws BackupValidationError', () => {
+        const incoming = [makeProject({ id: 'p-1' })];
+        expect(() =>
+            resolveImportProjects(incoming, new Set(['p-1']), new Map()),
+        ).toThrow(BackupValidationError);
     });
 });

--- a/utils/backupSchema.test.ts
+++ b/utils/backupSchema.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect } from 'vitest';
+import {
+    BackupValidationError,
+    buildBackupV1,
+    parseBackup,
+    resolveImportProjects,
+    serializeBackup,
+} from './backupSchema';
+import { Project } from '../types';
+import { defaultAiSettings, defaultDisplaySettings } from '../constants';
+
+const makeProject = (overrides: Partial<Project> = {}): Project => ({
+    id: overrides.id ?? 'p-1',
+    name: overrides.name ?? 'テスト物語',
+    lastModified: overrides.lastModified ?? '2026-04-28T00:00:00.000Z',
+    isSimpleMode: false,
+    settings: [],
+    novelContent: [],
+    chatHistory: [],
+    knowledgeBase: [],
+    plotBoard: [],
+    plotTypeColors: {},
+    plotRelations: [],
+    plotNodePositions: [],
+    timeline: [],
+    timelineLanes: [],
+    characterRelations: [],
+    nodePositions: [],
+    aiSettings: defaultAiSettings,
+    displaySettings: defaultDisplaySettings,
+    ...overrides,
+});
+
+describe('buildBackupV1 / serializeBackup (AC-1, AC-2)', () => {
+    it('AC-1: produces v1 envelope with projects/tutorialState/analysisHistory', () => {
+        const projects = [makeProject({ id: 'p-1' }), makeProject({ id: 'p-2' })];
+        const backup = buildBackupV1({
+            projects,
+            tutorialState: { hasCompletedGlobalTutorial: true },
+            analysisHistory: [{ id: 'a-1', createdAt: '2026-04-01', input: '...', output: '...' } as any],
+            appVersion: '0.0.0',
+            now: new Date('2026-04-28T01:23:45.000Z'),
+        });
+        expect(backup.schemaVersion).toBe(1);
+        expect(backup.exportedAt).toBe('2026-04-28T01:23:45.000Z');
+        expect(backup.appVersion).toBe('0.0.0');
+        expect(backup.projects).toHaveLength(2);
+        expect(backup.tutorialState.hasCompletedGlobalTutorial).toBe(true);
+        expect(backup.analysisHistory).toHaveLength(1);
+
+        const json = JSON.parse(serializeBackup(backup));
+        expect(json.schemaVersion).toBe(1);
+        expect(Array.isArray(json.projects)).toBe(true);
+    });
+
+    it('AC-2: historyTree is stripped from exported projects', () => {
+        const projWithHistory = makeProject({
+            id: 'p-1',
+            historyTree: {
+                nodes: { root: { id: 'root', parentId: null, childrenIds: [], timestamp: 0, type: 'settings', label: 'root', payload: {} as any } },
+                currentNodeId: 'root',
+                rootId: 'root',
+            },
+        });
+        const backup = buildBackupV1({
+            projects: [projWithHistory],
+            tutorialState: {},
+            analysisHistory: [],
+            appVersion: '0.0.0',
+        });
+        expect(backup.projects[0]).not.toHaveProperty('historyTree');
+    });
+});
+
+describe('parseBackup (AC-4, AC-5, AC-9, AC-10)', () => {
+    const validBackup = (over: Record<string, unknown> = {}) =>
+        JSON.stringify({
+            schemaVersion: 1,
+            exportedAt: '2026-04-28T00:00:00.000Z',
+            appVersion: '0.0.0',
+            projects: [makeProject({ id: 'p-1' })],
+            tutorialState: {},
+            analysisHistory: [],
+            ...over,
+        });
+
+    it('AC-4: rejects unsupported schema version', () => {
+        const bad = JSON.stringify({ schemaVersion: 999, projects: [] });
+        expect(() => parseBackup(bad, { rawSize: bad.length })).toThrow(BackupValidationError);
+        expect(() => parseBackup(bad, { rawSize: bad.length })).toThrow(/v999/);
+    });
+
+    it('AC-5: surfaces problematic project index in error message', () => {
+        const projects = [
+            makeProject({ id: 'p-1' }),
+            makeProject({ id: 'p-2' }),
+            { id: 'p-3' /* missing name -> validateAndSanitizeProjectData throws */ },
+        ];
+        const bad = JSON.stringify({
+            schemaVersion: 1,
+            exportedAt: '2026-04-28T00:00:00.000Z',
+            appVersion: '0.0.0',
+            projects,
+            tutorialState: {},
+            analysisHistory: [],
+        });
+        expect(() => parseBackup(bad, { rawSize: bad.length })).toThrow(/3件目/);
+    });
+
+    it('AC-9: rejects malformed JSON with descriptive message', () => {
+        const bad = '{"schemaVersion": 1, "projects": [';
+        expect(() => parseBackup(bad, { rawSize: bad.length })).toThrow(/壊れています/);
+    });
+
+    it('AC-10: rejects empty file', () => {
+        expect(() => parseBackup('', { rawSize: 0 })).toThrow(/空です/);
+        expect(() => parseBackup('   ', { rawSize: 3 })).toThrow(/空です/);
+    });
+
+    it('parses a valid backup round-trip', () => {
+        const raw = validBackup();
+        const result = parseBackup(raw, { rawSize: raw.length });
+        expect(result.schemaVersion).toBe(1);
+        expect(result.projects).toHaveLength(1);
+        expect(result.projects[0].id).toBe('p-1');
+    });
+});
+
+describe('resolveImportProjects (AC-3)', () => {
+    it('non-conflicting projects go to toUpsert as-is', () => {
+        const incoming = [makeProject({ id: 'p-new' })];
+        const existingIds = new Set<string>(['p-existing']);
+        const r = resolveImportProjects(incoming, existingIds, new Map());
+        expect(r.toUpsert).toHaveLength(1);
+        expect(r.toUpsert[0].id).toBe('p-new');
+        expect(r.toCreate).toHaveLength(0);
+    });
+
+    it('overwrite resolution upserts the incoming project keeping its id', () => {
+        const incoming = [makeProject({ id: 'p-1', name: 'incoming' })];
+        const r = resolveImportProjects(
+            incoming,
+            new Set(['p-1']),
+            new Map([['p-1', 'overwrite' as const]]),
+        );
+        expect(r.toUpsert).toHaveLength(1);
+        expect(r.toUpsert[0].id).toBe('p-1');
+        expect(r.toUpsert[0].name).toBe('incoming');
+    });
+
+    it('duplicate resolution writes a new uuid and decorated name', () => {
+        const incoming = [makeProject({ id: 'p-1', name: 'incoming' })];
+        const r = resolveImportProjects(
+            incoming,
+            new Set(['p-1']),
+            new Map([['p-1', 'duplicate' as const]]),
+        );
+        expect(r.toUpsert).toHaveLength(0);
+        expect(r.toCreate).toHaveLength(1);
+        expect(r.toCreate[0].id).not.toBe('p-1');
+        expect(r.toCreate[0].name).toBe('incoming (インポート)');
+    });
+
+    it('skip resolution drops the project entirely', () => {
+        const incoming = [makeProject({ id: 'p-1' })];
+        const r = resolveImportProjects(
+            incoming,
+            new Set(['p-1']),
+            new Map([['p-1', 'skip' as const]]),
+        );
+        expect(r.toUpsert).toHaveLength(0);
+        expect(r.toCreate).toHaveLength(0);
+    });
+
+    it('mixed batch: new + overwrite + skip + duplicate', () => {
+        const incoming = [
+            makeProject({ id: 'new' }),
+            makeProject({ id: 'over' }),
+            makeProject({ id: 'skip' }),
+            makeProject({ id: 'dup' }),
+        ];
+        const r = resolveImportProjects(
+            incoming,
+            new Set(['over', 'skip', 'dup']),
+            new Map([
+                ['over', 'overwrite' as const],
+                ['skip', 'skip' as const],
+                ['dup', 'duplicate' as const],
+            ]),
+        );
+        expect(r.toUpsert.map(p => p.id).sort()).toEqual(['new', 'over']);
+        expect(r.toCreate).toHaveLength(1);
+        expect(r.toCreate[0].id).not.toBe('dup');
+    });
+});

--- a/utils/backupSchema.ts
+++ b/utils/backupSchema.ts
@@ -1,0 +1,137 @@
+import { v4 as uuidv4 } from 'uuid';
+import {
+    AnalysisResult,
+    BACKUP_SCHEMA_VERSION,
+    BackupV1,
+    Project,
+} from '../types';
+import { ProjectValidationError, validateAndSanitizeProjectData } from '../utils';
+
+export class BackupValidationError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'BackupValidationError';
+    }
+}
+
+const isObject = (v: unknown): v is Record<string, unknown> =>
+    !!v && typeof v === 'object' && !Array.isArray(v);
+
+// historyTree is memory-only by ADR-0001 (cap=10, reset on reload). Strip it
+// from the export so backups stay small and don't carry stale undo state.
+const stripHistoryTree = (project: Project): Project => {
+    const { historyTree: _omitted, ...rest } = project;
+    return rest as Project;
+};
+
+export interface BuildBackupInput {
+    projects: Project[];
+    tutorialState: BackupV1['tutorialState'];
+    analysisHistory: AnalysisResult[];
+    appVersion: string;
+    now?: Date;
+}
+
+export const buildBackupV1 = (input: BuildBackupInput): BackupV1 => ({
+    schemaVersion: BACKUP_SCHEMA_VERSION,
+    exportedAt: (input.now ?? new Date()).toISOString(),
+    appVersion: input.appVersion,
+    projects: input.projects.map(stripHistoryTree),
+    tutorialState: { ...input.tutorialState },
+    analysisHistory: [...input.analysisHistory],
+});
+
+export const serializeBackup = (backup: BackupV1): string =>
+    JSON.stringify(backup, null, 2);
+
+export const buildBackupFilename = (now: Date = new Date()): string => {
+    const iso = now.toISOString().replace(/[:.]/g, '-');
+    return `novel-writer-backup_${iso}.json`;
+};
+
+interface ParseOptions {
+    rawSize: number;
+}
+
+export const parseBackup = (raw: string, opts: ParseOptions = { rawSize: raw.length }): BackupV1 => {
+    if (opts.rawSize === 0 || raw.trim() === '') {
+        throw new BackupValidationError('ファイルが空です。');
+    }
+    let json: unknown;
+    try {
+        json = JSON.parse(raw);
+    } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        throw new BackupValidationError(`バックアップファイルが壊れています: ${msg}`);
+    }
+    if (!isObject(json)) {
+        throw new BackupValidationError('バックアップファイルが有効なオブジェクトではありません。');
+    }
+
+    const { schemaVersion } = json;
+    if (schemaVersion !== BACKUP_SCHEMA_VERSION) {
+        throw new BackupValidationError(
+            `対応していないバックアップ形式です（v${String(schemaVersion)}、本アプリは v${BACKUP_SCHEMA_VERSION} のみ対応）。`,
+        );
+    }
+
+    const projectsRaw = json.projects;
+    if (!Array.isArray(projectsRaw)) {
+        throw new BackupValidationError('projects 配列がありません。');
+    }
+    const projects: Project[] = projectsRaw.map((p, i) => {
+        try {
+            return validateAndSanitizeProjectData(p);
+        } catch (e) {
+            const msg = e instanceof ProjectValidationError ? e.message : String(e);
+            throw new BackupValidationError(`${i + 1}件目のプロジェクトに問題があります: ${msg}`);
+        }
+    });
+
+    const tutorialState = isObject(json.tutorialState) ? (json.tutorialState as BackupV1['tutorialState']) : {};
+    const analysisHistory = Array.isArray(json.analysisHistory) ? (json.analysisHistory as AnalysisResult[]) : [];
+
+    const exportedAt = typeof json.exportedAt === 'string' ? json.exportedAt : new Date().toISOString();
+    const appVersion = typeof json.appVersion === 'string' ? json.appVersion : 'unknown';
+
+    return {
+        schemaVersion: BACKUP_SCHEMA_VERSION,
+        exportedAt,
+        appVersion,
+        projects,
+        tutorialState,
+        analysisHistory,
+    };
+};
+
+export interface ResolvedImportProjects {
+    toUpsert: Project[];
+    toCreate: Project[];
+}
+
+// Apply per-project conflict resolutions. `existingIds` is the set of IDs
+// currently in IndexedDB at executeImport time (re-read to avoid TOCTOU).
+export const resolveImportProjects = (
+    incoming: Project[],
+    existingIds: Set<string>,
+    resolutions: Map<string, 'overwrite' | 'duplicate' | 'skip'>,
+): ResolvedImportProjects => {
+    const toUpsert: Project[] = [];
+    const toCreate: Project[] = [];
+    for (const p of incoming) {
+        const isConflict = existingIds.has(p.id);
+        if (!isConflict) {
+            toUpsert.push(p);
+            continue;
+        }
+        const decision = resolutions.get(p.id) ?? 'skip';
+        if (decision === 'overwrite') {
+            toUpsert.push(p);
+        } else if (decision === 'duplicate') {
+            const newId = uuidv4();
+            toCreate.push({ ...p, id: newId, name: `${p.name} (インポート)` });
+        }
+        // skip: do nothing
+    }
+    return { toUpsert, toCreate };
+};

--- a/utils/backupSchema.ts
+++ b/utils/backupSchema.ts
@@ -17,6 +17,42 @@ export class BackupValidationError extends Error {
 const isObject = (v: unknown): v is Record<string, unknown> =>
     !!v && typeof v === 'object' && !Array.isArray(v);
 
+const TUTORIAL_FLAG_KEYS = [
+    'hasCompletedGlobalTutorial',
+    'hasCompletedGlobalKnowledgeTutorial',
+    'hasCompletedGlobalChartTutorial',
+    'hasCompletedGlobalPlotBoardTutorial',
+    'hasCompletedGlobalTimelineTutorial',
+] as const;
+
+// Pick only the known boolean flags from raw JSON. Anything else is dropped so
+// hostile JSON (e.g. `{ hasCompletedGlobalTutorial: "yes" }`) cannot poison
+// IndexedDB or break boolean equality checks downstream.
+const validateTutorialFlags = (v: unknown): BackupV1['tutorialState'] => {
+    if (!isObject(v)) return {};
+    const out: Record<string, boolean> = {};
+    for (const k of TUTORIAL_FLAG_KEYS) {
+        if (typeof v[k] === 'boolean') out[k] = v[k] as boolean;
+    }
+    return out as BackupV1['tutorialState'];
+};
+
+// Shape check against the AnalysisResult contract: characters/worldContext/
+// worldTerms/dialogues/notes are all required. Hostile JSON missing any of
+// these is dropped silently.
+const isAnalysisResult = (v: unknown): v is AnalysisResult =>
+    isObject(v)
+    && isObject(v.characters)
+    && isObject(v.worldContext)
+    && isObject(v.worldTerms)
+    && Array.isArray(v.dialogues)
+    && Array.isArray(v.notes);
+
+const validateAnalysisHistory = (v: unknown): AnalysisResult[] => {
+    if (!Array.isArray(v)) return [];
+    return v.filter(isAnalysisResult);
+};
+
 // historyTree is memory-only by ADR-0001 (cap=10, reset on reload). Strip it
 // from the export so backups stay small and don't carry stale undo state.
 const stripHistoryTree = (project: Project): Project => {
@@ -53,6 +89,31 @@ interface ParseOptions {
     rawSize: number;
 }
 
+// Legacy single-project export (handleExportProject in App.tsx) writes a bare
+// Project JSON without `schemaVersion`. Detect that shape and wrap it into a
+// BackupV1 so users can re-import their pre-M4 backups.
+const looksLikeLegacyProject = (json: Record<string, unknown>): boolean =>
+    typeof json.schemaVersion === 'undefined'
+    && typeof json.id === 'string'
+    && typeof json.name === 'string';
+
+const looksLikeLegacyEnvelope = (json: Record<string, unknown>): boolean =>
+    typeof json.schemaVersion === 'undefined'
+    && isObject(json.project)
+    && typeof (json.project as Record<string, unknown>).id === 'string';
+
+const wrapLegacyProject = (rawProject: unknown): BackupV1 => {
+    const project = validateAndSanitizeProjectData(rawProject);
+    return {
+        schemaVersion: BACKUP_SCHEMA_VERSION,
+        exportedAt: project.lastModified ?? new Date().toISOString(),
+        appVersion: 'legacy',
+        projects: [project],
+        tutorialState: {},
+        analysisHistory: [],
+    };
+};
+
 export const parseBackup = (raw: string, opts: ParseOptions = { rawSize: raw.length }): BackupV1 => {
     if (opts.rawSize === 0 || raw.trim() === '') {
         throw new BackupValidationError('ファイルが空です。');
@@ -66,6 +127,23 @@ export const parseBackup = (raw: string, opts: ParseOptions = { rawSize: raw.len
     }
     if (!isObject(json)) {
         throw new BackupValidationError('バックアップファイルが有効なオブジェクトではありません。');
+    }
+
+    if (looksLikeLegacyProject(json)) {
+        try {
+            return wrapLegacyProject(json);
+        } catch (e) {
+            const msg = e instanceof ProjectValidationError ? e.message : String(e);
+            throw new BackupValidationError(`旧形式のプロジェクトファイルを読み込めませんでした: ${msg}`);
+        }
+    }
+    if (looksLikeLegacyEnvelope(json)) {
+        try {
+            return wrapLegacyProject((json as { project: unknown }).project);
+        } catch (e) {
+            const msg = e instanceof ProjectValidationError ? e.message : String(e);
+            throw new BackupValidationError(`旧形式のプロジェクトファイルを読み込めませんでした: ${msg}`);
+        }
     }
 
     const { schemaVersion } = json;
@@ -88,8 +166,8 @@ export const parseBackup = (raw: string, opts: ParseOptions = { rawSize: raw.len
         }
     });
 
-    const tutorialState = isObject(json.tutorialState) ? (json.tutorialState as BackupV1['tutorialState']) : {};
-    const analysisHistory = Array.isArray(json.analysisHistory) ? (json.analysisHistory as AnalysisResult[]) : [];
+    const tutorialState = validateTutorialFlags(json.tutorialState);
+    const analysisHistory = validateAnalysisHistory(json.analysisHistory);
 
     const exportedAt = typeof json.exportedAt === 'string' ? json.exportedAt : new Date().toISOString();
     const appVersion = typeof json.appVersion === 'string' ? json.appVersion : 'unknown';
@@ -111,6 +189,11 @@ export interface ResolvedImportProjects {
 
 // Apply per-project conflict resolutions. `existingIds` is the set of IDs
 // currently in IndexedDB at executeImport time (re-read to avoid TOCTOU).
+//
+// Caller contract: every conflicting id MUST appear in `resolutions`. Missing
+// entries throw rather than defaulting silently — a hidden default would split
+// "user picked skip" from "we forgot to seed it" and mask future detection
+// bugs (the seed is owned by detectConflicts; the modal then mutates each).
 export const resolveImportProjects = (
     incoming: Project[],
     existingIds: Set<string>,
@@ -124,7 +207,12 @@ export const resolveImportProjects = (
             toUpsert.push(p);
             continue;
         }
-        const decision = resolutions.get(p.id) ?? 'skip';
+        const decision = resolutions.get(p.id);
+        if (decision === undefined) {
+            throw new BackupValidationError(
+                `内部エラー: プロジェクト ${p.id} の衝突解決方針が指定されていません。`,
+            );
+        }
         if (decision === 'overwrite') {
             toUpsert.push(p);
         } else if (decision === 'duplicate') {

--- a/utils/readFileAsText.ts
+++ b/utils/readFileAsText.ts
@@ -1,0 +1,10 @@
+// Promise wrapper around FileReader for utf-8 text payloads. Used by both
+// SettingsPanel (full-data import) and projectSlice.importProject (legacy
+// single-project import) so the reader/error handling stays in one place.
+export const readFileAsText = (file: File): Promise<string> =>
+    new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(String(reader.result ?? ''));
+        reader.onerror = () => reject(reader.error ?? new Error('FileReader failed'));
+        reader.readAsText(file);
+    });

--- a/vite-env.d.ts
+++ b/vite-env.d.ts
@@ -13,3 +13,5 @@ interface ImportMetaEnv {
 interface ImportMeta {
     readonly env: ImportMetaEnv;
 }
+
+declare const __APP_VERSION__: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,11 @@
 import path from 'path';
+import { readFileSync } from 'fs';
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+
+const pkg = JSON.parse(
+    readFileSync(path.resolve(__dirname, 'package.json'), 'utf-8'),
+) as { version: string };
 
 export default defineConfig({
     server: {
@@ -12,5 +17,8 @@ export default defineConfig({
         alias: {
             '@': path.resolve(__dirname, '.'),
         }
-    }
+    },
+    define: {
+        __APP_VERSION__: JSON.stringify(pkg.version),
+    },
 });


### PR DESCRIPTION
## Summary

- ADR-0001 ロードマップ M4 を完了。Local-first アーキテクチャの「端末紛失 = 小説喪失」リスクを Export/Import + 鮮度警告 UI で構造的に緩和
- Backup schema v1 (`utils/backupSchema.ts`) を定義: `{ schemaVersion, exportedAt, appVersion, projects, tutorialState, analysisHistory }`。M5 (Stripe Tier 2 backup) / M6 (E2EE) で再利用予定
- 既存の壊れた `handleExportAll` (Header.tsx の state 経由 export) と単一プロジェクト `importProject` を新 `backupSlice` 経由に置換、衝突解決 UI (上書き / 新ID で複製 / スキップ) を per-project に提供
- `BackupWarningBanner` + Settings 「全データバックアップ」セクションで `lastExportedAt` の鮮度 (STALE_BACKUP_DAYS=30) を可視化、IndexedDB の `backupMeta` ストア (DB v1→v2 migration) で永続化

## 主要設計判断

- **schema 確定の前倒し**: M5/M6 で再利用するためここで v1 を固定。`schemaVersion: 1` リテラル + `BACKUP_SCHEMA_VERSION` 定数の両方を持ち、不整合 detection は parse 時の runtime check で実施
- **Import atomicity**: Dexie transaction で 1 回 commit、途中失敗時は IndexedDB 未変更 (AC-5)
- **TOCTOU 対策**: `executeImport` で existingIds を再 read し、prepare 後に発生した変更を吸収
- **historyTree 除外**: ADR-0001 の「memory-only」方針に従い backup から除く
- **whitelist 一貫性**: import 経路でも `pickPersistableFields` + `stripInternalKeys` を経由 (品質ゲート修正で追加)

## Acceptance Criteria

| AC | 概要 | 検証方法 | 結果 |
|---|---|---|---|
| AC-1 | Export JSON が schemaVersion v1 envelope を満たす | vitest + 実機ダウンロード ✅ | PASS |
| AC-2 | historyTree は export しない | vitest + 実 JSON 検査 ✅ | PASS |
| AC-3 | Import 衝突時 per-project 選択 (overwrite/duplicate/skip) | vitest + UI ✅ | PASS |
| AC-4 | Schema 不一致は throw、IndexedDB 未変更 | vitest ✅ | PASS |
| AC-5 | Import バリデーション失敗で全件中止 (atomicity) | vitest ✅ | PASS |
| AC-6 | lastExportedAt は IndexedDB に永続化、リロード後も保持 | vitest + 実機リロード ✅ | PASS |
| AC-7 | 30 日以上 export してないとバナー表示、export 後に消失 | 実機 (60日 stale 偽装で confirm) ✅ | PASS |
| AC-8 | Settings に「最終バックアップ: ○日前」表示 + Export/Import ボタン | 実機 ✅ | PASS |
| AC-9 | 壊れた JSON は throw、IndexedDB 未変更 | vitest ✅ | PASS |
| AC-10 | 空ファイルは throw、IndexedDB 未変更 | vitest ✅ | PASS |
| AC-11 | 大規模データ性能 (実機検証は次フェーズ) | impl-plan 上のみ | UNTESTABLE |

## 品質ゲート (CLAUDE.md MUST 準拠)

- ✅ `tsc --noEmit` clean
- ✅ vitest 198/198 PASS (既存 176 + 新規 22)
- ✅ vite build 成功
- ✅ `/simplify` 3 並列 (reuse / quality / efficiency) 実行 → 7 件指摘を本 PR で吸収
- ✅ `evaluator` Agent (5+ ファイル変更で発動) 実行
- ✅ 大規模変更 (新規 9 + 改修 12 ファイル, +1210/-65 行) を 1 PR で完結

### 品質ゲート反映 (本 PR で吸収した review 指摘)

- writeImport の whitelist bypass 修正 (整合性バグ)
- URL.revokeObjectURL を setTimeout deferred 化 (Safari/Firefox 空ファイル race)
- `(get() as any).showToast` を typed cast (`WithToast`) に統一 (authSlice 既存パターン整合)
- executeImport の二重エラー表示 (toast + modal) 解消
- formatLastExportedAt + STALE_BACKUP_DAYS の `utils/backupFormat.ts` 集約
- ImportConflictModal を ModalManager に統合 (App.tsx/App.mobile.tsx の 5 経路マウントを 1 経路化)
- FileReader を `utils/readFileAsText.ts` に共通化

## Test plan

- [x] `npm run lint` (tsc --noEmit) clean
- [x] `npm run test` 198/198 PASS
- [x] `npm run build` 成功
- [x] dev サーバーで実機 export → JSON ダウンロード → 内容検証 (schemaVersion=1, historyTree なし, tutorialState/analysisHistory 含有)
- [x] Settings 「最終バックアップ: 本日」表示 + バナー消失
- [x] IndexedDB 直接介入で 60 日前に偽装 → リロードでバナー再表示 + 「60日前 (推奨は30日以内)」
- [x] CI (deploy.yml の test job) で regression 検知

## 次セッションへの申し送り（持越事項）

evaluator + simplify が指摘した rating 5-7 改善案で本 PR スコープ外:

1. **AC-11 (大規模データ) と DB v1→v2 migration の自動テスト**: `fake-indexeddb` 等の導入が必要。次セッションで `docs/spec/m4/acceptance-criteria.md` を起こす際にあわせて検討
2. **`docs/spec/m4/acceptance-criteria.md` の作成**: 現状 AC は impl-plan + PR description + test describe ラベルにしか存在しない。`docs/spec/m1..m3` と同形式で残すべき
3. **BackupV1.appVersion の dead-write 整理**: parser でフォールバック保持しているが読取側で未使用、削除 or undefined 化候補
4. **parseBackup の tutorialState/analysisHistory 型ガード強化**: 現状は `as` キャストで配列内要素は無検証。M5/M6 で schema bump 時にあわせて zod 等の導入を検討
5. **App.tsx / App.mobile.tsx / Header.tsx に残る個別 export の `triggerDownload` 5 重実装**: 本 PR 未介入の既存コード。次の cleanup PR で `utils/download.ts` に集約候補

これらは triage 基準 (rating ≥ 7 + confidence ≥ 80) を満たさないため Issue 化せず、次マイルストーン (M7-α 公開準備 or M5 Stripe) の対応 PR で吸収方針。

## Issue Net 変化

- Close: 0 件
- 新規起票: 0 件
- **Net: 0 件** (進捗の質: M4 マイルストーン完了 + 品質ゲート 7 件吸収、新規 Critical 問題は本セッションで未発生)

🤖 Generated with [Claude Code](https://claude.com/claude-code)