### PR TITLE
test(m4): H6 isBackupStale 境界値テスト + setSystemTime 固定

### DIFF
--- a/store/backupSlice.test.ts
+++ b/store/backupSlice.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createBackupSlice } from './backupSlice';
 import { Project } from '../types';
 import { defaultAiSettings, defaultDisplaySettings } from '../constants';
@@ -214,9 +214,24 @@ describe('prepareImport / executeImport (AC-3, AC-5)', () => {
 });
 
 describe('isBackupStale (AC-7)', () => {
+    // Anchor "now" so day-boundary math is deterministic. Without a fixed clock
+    // a test comparing exact 30-day deltas would race the wall clock and flake
+    // around midnight UTC.
+    const FIXED_NOW = new Date('2026-05-01T00:00:00.000Z');
+    const DAY_MS = 24 * 60 * 60 * 1000;
+
     const setLoaded = (fake: ReturnType<typeof createFakeStore>, lastExportedAt: string | null) => {
         fake.set({ lastExportedAt, backupMetaStatus: 'loaded' });
     };
+    const isoFromNowMinus = (ms: number) => new Date(FIXED_NOW.getTime() - ms).toISOString();
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(FIXED_NOW);
+    });
+    afterEach(() => {
+        vi.useRealTimers();
+    });
 
     it('returns true when never exported (loaded + null)', () => {
         const fake = createFakeStore();
@@ -226,13 +241,13 @@ describe('isBackupStale (AC-7)', () => {
 
     it('returns false when exported within 30 days', () => {
         const fake = createFakeStore();
-        setLoaded(fake, new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString());
+        setLoaded(fake, isoFromNowMinus(5 * DAY_MS));
         expect(fake.state.isBackupStale()).toBe(false);
     });
 
     it('returns true when exported >30 days ago', () => {
         const fake = createFakeStore();
-        setLoaded(fake, new Date(Date.now() - 31 * 24 * 60 * 60 * 1000).toISOString());
+        setLoaded(fake, isoFromNowMinus(31 * DAY_MS));
         expect(fake.state.isBackupStale()).toBe(true);
     });
 
@@ -240,5 +255,41 @@ describe('isBackupStale (AC-7)', () => {
         const fake = createFakeStore();
         setLoaded(fake, 'not-an-iso');
         expect(fake.state.isBackupStale()).toBe(true);
+    });
+
+    // H6: Boundary tests — `isBackupStale` flips on `days > 30`, where
+    // `days = floor((now - exportedAt) / ms_per_day)`. Verify both sides of
+    // the floor (just-under / just-over) and the exact 30-day mark to lock
+    // the contract against accidental `>=` regressions.
+    describe('H6 boundary (exactly 30 days)', () => {
+        it('is NOT stale at exactly 30 days 0 ms (days === 30, boundary inclusive of fresh)', () => {
+            const fake = createFakeStore();
+            setLoaded(fake, isoFromNowMinus(30 * DAY_MS));
+            expect(fake.state.isBackupStale()).toBe(false);
+        });
+
+        it('is NOT stale at 30 days + 1 ms (still floors to 30)', () => {
+            const fake = createFakeStore();
+            setLoaded(fake, isoFromNowMinus(30 * DAY_MS + 1));
+            expect(fake.state.isBackupStale()).toBe(false);
+        });
+
+        it('is NOT stale just under 31 days (30 days + DAY_MS - 1 ms still floors to 30)', () => {
+            const fake = createFakeStore();
+            setLoaded(fake, isoFromNowMinus(31 * DAY_MS - 1));
+            expect(fake.state.isBackupStale()).toBe(false);
+        });
+
+        it('IS stale at exactly 31 days 0 ms (days === 31, first stale tick)', () => {
+            const fake = createFakeStore();
+            setLoaded(fake, isoFromNowMinus(31 * DAY_MS));
+            expect(fake.state.isBackupStale()).toBe(true);
+        });
+
+        it('IS stale at 31 days + 1 ms', () => {
+            const fake = createFakeStore();
+            setLoaded(fake, isoFromNowMinus(31 * DAY_MS + 1));
+            expect(fake.state.isBackupStale()).toBe(true);
+        });
     });
 });

--- a/store/backupSlice.test.ts
+++ b/store/backupSlice.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createBackupSlice } from './backupSlice';
 import { Project } from '../types';
 import { defaultAiSettings, defaultDisplaySettings } from '../constants';
+import { STALE_BACKUP_DAYS } from '../utils/backupFormat';
 
 // Mock the db layer so backupSlice can run without a real IndexedDB.
 const readSnapshot = vi.fn();
@@ -214,9 +215,9 @@ describe('prepareImport / executeImport (AC-3, AC-5)', () => {
 });
 
 describe('isBackupStale (AC-7)', () => {
-    // Anchor "now" so day-boundary math is deterministic. Without a fixed clock
-    // a test comparing exact 30-day deltas would race the wall clock and flake
-    // around midnight UTC.
+    // Anchor "now" so day-boundary math is deterministic. Without a fixed
+    // clock, an exact-N-day delta test would race the wall clock and flake
+    // around any day rollover (`Math.floor` flips precisely on the boundary).
     const FIXED_NOW = new Date('2026-05-01T00:00:00.000Z');
     const DAY_MS = 24 * 60 * 60 * 1000;
 
@@ -239,15 +240,15 @@ describe('isBackupStale (AC-7)', () => {
         expect(fake.state.isBackupStale()).toBe(true);
     });
 
-    it('returns false when exported within 30 days', () => {
+    it('returns false when exported within STALE_BACKUP_DAYS', () => {
         const fake = createFakeStore();
         setLoaded(fake, isoFromNowMinus(5 * DAY_MS));
         expect(fake.state.isBackupStale()).toBe(false);
     });
 
-    it('returns true when exported >30 days ago', () => {
+    it('returns true when exported beyond STALE_BACKUP_DAYS', () => {
         const fake = createFakeStore();
-        setLoaded(fake, isoFromNowMinus(31 * DAY_MS));
+        setLoaded(fake, isoFromNowMinus((STALE_BACKUP_DAYS + 1) * DAY_MS));
         expect(fake.state.isBackupStale()).toBe(true);
     });
 
@@ -257,38 +258,38 @@ describe('isBackupStale (AC-7)', () => {
         expect(fake.state.isBackupStale()).toBe(true);
     });
 
-    // H6: Boundary tests — `isBackupStale` flips on `days > 30`, where
-    // `days = floor((now - exportedAt) / ms_per_day)`. Verify both sides of
-    // the floor (just-under / just-over) and the exact 30-day mark to lock
-    // the contract against accidental `>=` regressions.
-    describe('H6 boundary (exactly 30 days)', () => {
-        it('is NOT stale at exactly 30 days 0 ms (days === 30, boundary inclusive of fresh)', () => {
+    // H6: Boundary tests — `isBackupStale` flips on `days > STALE_BACKUP_DAYS`,
+    // where `days = floor((now - exportedAt) / ms_per_day)`. Verify both sides
+    // of the floor (just-under / just-over) and the exact-threshold mark to
+    // lock the contract against accidental `>=` regressions.
+    describe(`H6 boundary (exactly STALE_BACKUP_DAYS=${STALE_BACKUP_DAYS} days)`, () => {
+        it(`is NOT stale at exactly STALE_BACKUP_DAYS 0 ms (days === ${STALE_BACKUP_DAYS}, predicate is strict >)`, () => {
             const fake = createFakeStore();
-            setLoaded(fake, isoFromNowMinus(30 * DAY_MS));
+            setLoaded(fake, isoFromNowMinus(STALE_BACKUP_DAYS * DAY_MS));
             expect(fake.state.isBackupStale()).toBe(false);
         });
 
-        it('is NOT stale at 30 days + 1 ms (still floors to 30)', () => {
+        it(`is NOT stale at STALE_BACKUP_DAYS + 1 ms (floor still pins days to ${STALE_BACKUP_DAYS})`, () => {
             const fake = createFakeStore();
-            setLoaded(fake, isoFromNowMinus(30 * DAY_MS + 1));
+            setLoaded(fake, isoFromNowMinus(STALE_BACKUP_DAYS * DAY_MS + 1));
             expect(fake.state.isBackupStale()).toBe(false);
         });
 
-        it('is NOT stale just under 31 days (30 days + DAY_MS - 1 ms still floors to 30)', () => {
+        it(`is NOT stale just under STALE_BACKUP_DAYS+1 (DAY_MS - 1 ms before the next floor tick)`, () => {
             const fake = createFakeStore();
-            setLoaded(fake, isoFromNowMinus(31 * DAY_MS - 1));
+            setLoaded(fake, isoFromNowMinus((STALE_BACKUP_DAYS + 1) * DAY_MS - 1));
             expect(fake.state.isBackupStale()).toBe(false);
         });
 
-        it('IS stale at exactly 31 days 0 ms (days === 31, first stale tick)', () => {
+        it(`IS stale at exactly STALE_BACKUP_DAYS+1 0 ms (days === ${STALE_BACKUP_DAYS + 1}, first stale tick)`, () => {
             const fake = createFakeStore();
-            setLoaded(fake, isoFromNowMinus(31 * DAY_MS));
+            setLoaded(fake, isoFromNowMinus((STALE_BACKUP_DAYS + 1) * DAY_MS));
             expect(fake.state.isBackupStale()).toBe(true);
         });
 
-        it('IS stale at 31 days + 1 ms', () => {
+        it(`IS stale at STALE_BACKUP_DAYS+1 + 1 ms`, () => {
             const fake = createFakeStore();
-            setLoaded(fake, isoFromNowMinus(31 * DAY_MS + 1));
+            setLoaded(fake, isoFromNowMinus((STALE_BACKUP_DAYS + 1) * DAY_MS + 1));
             expect(fake.state.isBackupStale()).toBe(true);
         });
     });


### PR DESCRIPTION
## Summary

- Issue #49 H6 (rating 7) の対応: `isBackupStale` の exact 30 日境界値テスト追加
- CLAUDE.md `Test First` MUST「境界値（最小/最大/±1）を必ず含める」違反の解消
- `rules/testing.md` §1 MUST「時刻依存テストは必ず `vi.setSystemTime` で固定」違反の併せ解消（既存 4 ケース + 新規 5 ケースを `useFakeTimers + setSystemTime` 配下に統一）

## 変更内容

`isBackupStale` のフリップ条件 `days > 30` に対し、`>=` 等への回帰を防ぐ 5 ケースを追加:

| 入力 (now との差) | days (`Math.floor`) | 期待 |
|---|---|---|
| 30 days 0 ms | 30 | NOT stale ✅ |
| 30 days + 1 ms | 30 | NOT stale ✅ |
| 31 days − 1 ms | 30 | NOT stale ✅ |
| 31 days 0 ms | 31 | **stale** ✅ |
| 31 days + 1 ms | 31 | **stale** ✅ |

実装側 (`utils/backupFormat.ts` の `daysSince` + `STALE_BACKUP_DAYS = 30`) は既存挙動が境界値仕様に正しく従っていたため変更なし。本 PR のスコープは「仕様の固定（回帰検知）」のみ。

## Test plan

- [x] `npm run test -- store/backupSlice.test.ts` → 16/16 PASS（既存 11 + 新規 5）
- [x] `npm run test`（全体回帰）→ 209/209 PASS
- [x] `npm run lint`（`tsc --noEmit`）→ 0 errors
- [x] 変更コードパス（H6 境界値 5 ケース）を vitest で実行し全 PASS 確認

## Issue 進捗

`Refs #49`（Issue #49 は 5 件束ねの parent。本 PR は H6 のみ消化、close しない）

- [ ] H2 (`prepareImport` flushSave UX) — 未着手（設計判断要）
- [ ] H4 (`setImportResolution → executeImport` 通しテスト) — 未着手
- [ ] H5 (TOCTOU 再 read 回帰テスト) — 未着手
- [x] **H6 (isBackupStale 境界値テスト) — 本 PR**
- [ ] H10 (Dexie blocked event ハンドラ) — 未着手

🤖 Generated with [Claude Code](https://claude.com/claude-code)