### PR TITLE
test(m4): H4 setImportResolution flow + H5 TOCTOU re-read 回帰テスト

### DIFF
--- a/store/backupSlice.test.ts
+++ b/store/backupSlice.test.ts
@@ -211,12 +211,16 @@ describe('prepareImport / executeImport (AC-3, AC-5)', () => {
         await expect(fake.state.executeImport()).rejects.toThrow(/quota/);
         // importPlan retained so user can retry / inspect
         expect(fake.state.importPlan).not.toBeNull();
+        // Without the finally block resetting isImporting, the slice would
+        // refuse all subsequent imports with "既にインポート処理中です。" — guard
+        // against accidental removal of `backupSlice.ts` finally cleanup.
+        expect(fake.state.isImporting).toBe(false);
     });
 
     // H4: full prepareImport → setImportResolution → executeImport flow.
     // Existing tests cover the default-overwrite path; this block exercises
-    // resolution mutation (skip / duplicate / mixed) so the Map seeded from
-    // `plan.conflicts` reaches `resolveImportProjects` intact.
+    // resolution mutation (skip / duplicate / mixed) so per-conflict resolutions
+    // propagate to `resolveImportProjects` intact.
     describe('H4 setImportResolution → executeImport flow', () => {
         it('skip resolution drops conflicting incoming, keeps non-conflicting', async () => {
             readSnapshot.mockResolvedValue({
@@ -234,7 +238,7 @@ describe('prepareImport / executeImport (AC-3, AC-5)', () => {
                     makeProject({ id: 'p-existing', name: 'インポート' }),
                     makeProject({ id: 'p-new', name: '新規' }),
                 ],
-                tutorialState: {},
+                tutorialState: { hasCompletedGlobalTutorial: true },
                 analysisHistory: [],
             });
 
@@ -246,6 +250,10 @@ describe('prepareImport / executeImport (AC-3, AC-5)', () => {
             const payload = writeImport.mock.calls[0][0];
             expect(payload.toUpsert.map((p: Project) => p.id)).toEqual(['p-new']);
             expect(payload.toCreate).toEqual([]);
+            // Non-project sidecar fields must travel atomically with the
+            // project payload (writeImport is the single transaction).
+            expect(payload.tutorialState).toEqual({ hasCompletedGlobalTutorial: true });
+            expect(payload.analysisHistory).toEqual([]);
             expect(result).toEqual({ upserted: 1, created: 0, skipped: 1 });
         });
 
@@ -273,7 +281,7 @@ describe('prepareImport / executeImport (AC-3, AC-5)', () => {
             const payload = writeImport.mock.calls[0][0];
             expect(payload.toUpsert).toEqual([]);
             expect(payload.toCreate).toHaveLength(1);
-            expect(payload.toCreate[0].id).not.toBe('p-existing'); // freshly minted UUID
+            expect(payload.toCreate[0].id).not.toBe('p-existing');
             expect(payload.toCreate[0].name).toBe('インポート版 (インポート)');
             expect(result).toEqual({ upserted: 0, created: 1, skipped: 0 });
         });
@@ -290,6 +298,13 @@ describe('prepareImport / executeImport (AC-3, AC-5)', () => {
             });
             writeImport.mockResolvedValue(undefined);
             const fake = createFakeStore();
+            const minimalAnalysis = {
+                characters: {},
+                worldContext: {},
+                worldTerms: {},
+                dialogues: [],
+                notes: [],
+            };
             const raw = JSON.stringify({
                 schemaVersion: 1,
                 exportedAt: '2026-04-28T00:00:00.000Z',
@@ -301,7 +316,7 @@ describe('prepareImport / executeImport (AC-3, AC-5)', () => {
                     makeProject({ id: 'p-d', name: 'D入力（新規）' }),
                 ],
                 tutorialState: {},
-                analysisHistory: [],
+                analysisHistory: [minimalAnalysis],
             });
 
             await fake.state.prepareImport(raw);
@@ -312,22 +327,50 @@ describe('prepareImport / executeImport (AC-3, AC-5)', () => {
 
             expect(writeImport).toHaveBeenCalledOnce();
             const payload = writeImport.mock.calls[0][0];
-            // p-a (overwrite) + p-d (new) → toUpsert
             expect(payload.toUpsert.map((p: Project) => p.id).sort()).toEqual(['p-a', 'p-d']);
-            // p-c (duplicate) → toCreate with fresh id
             expect(payload.toCreate).toHaveLength(1);
             expect(payload.toCreate[0].id).not.toBe('p-c');
-            // p-b (skip) → absent everywhere
             const allOutgoingIds = [...payload.toUpsert, ...payload.toCreate].map((p: Project) => p.id);
             expect(allOutgoingIds).not.toContain('p-b');
+            // analysisHistory must travel through the same transaction so a
+            // future split (projects vs sidecars) doesn't silently drop it.
+            expect(payload.analysisHistory).toHaveLength(1);
             expect(result).toEqual({ upserted: 2, created: 1, skipped: 1 });
         });
 
         it('setImportResolution is a no-op when there is no active plan (defensive)', () => {
             const fake = createFakeStore();
-            // Should not throw, should not flip importPlan from null.
             fake.state.setImportResolution('does-not-matter', 'skip');
             expect(fake.state.importPlan).toBeNull();
+        });
+
+        it('subsequent setImportResolution overwrites the prior choice (last-write-wins)', async () => {
+            readSnapshot.mockResolvedValue({
+                projects: [makeProject({ id: 'p-existing', name: '既存' })],
+                tutorialState: {},
+                analysisHistory: [],
+            });
+            writeImport.mockResolvedValue(undefined);
+            const fake = createFakeStore();
+            const raw = JSON.stringify({
+                schemaVersion: 1,
+                exportedAt: '2026-04-28T00:00:00.000Z',
+                appVersion: '0.0.0',
+                projects: [makeProject({ id: 'p-existing', name: 'インポート' })],
+                tutorialState: {},
+                analysisHistory: [],
+            });
+
+            await fake.state.prepareImport(raw);
+            // User toggles in the modal: skip → overwrite. The last call wins;
+            // the conflict's resolution is mutated in place, not appended.
+            fake.state.setImportResolution('p-existing', 'skip');
+            fake.state.setImportResolution('p-existing', 'overwrite');
+            const result = await fake.state.executeImport();
+
+            const payload = writeImport.mock.calls[0][0];
+            expect(payload.toUpsert.map((p: Project) => p.id)).toEqual(['p-existing']);
+            expect(result).toEqual({ upserted: 1, created: 0, skipped: 0 });
         });
     });
 
@@ -365,8 +408,8 @@ describe('prepareImport / executeImport (AC-3, AC-5)', () => {
 
             await fake.state.prepareImport(raw);
             // User picks "skip" because they thought it would clash. By execute
-            // time the row is gone, so resolveImportProjects sees no conflict
-            // and treats the incoming project as a fresh insert (toUpsert).
+            // time the row is gone, so resolveImportProjects treats it as
+            // non-conflicting and routes it to toUpsert (no id remap).
             fake.state.setImportResolution('p-existing', 'skip');
             const result = await fake.state.executeImport();
 
@@ -410,6 +453,50 @@ describe('prepareImport / executeImport (AC-3, AC-5)', () => {
             await expect(fake.state.executeImport()).rejects.toThrow(/衝突解決方針/);
             expect(writeImport).not.toHaveBeenCalled();
             // importPlan retained so the UI can re-prepare or surface the race.
+            expect(fake.state.importPlan).not.toBeNull();
+            // Same isImporting-finally guard as AC-5 rejection: a future
+            // refactor that loses the finally would deadlock all imports.
+            expect(fake.state.isImporting).toBe(false);
+        });
+
+        it('double-shift: target deleted AND new id inserted between prepare and execute', async () => {
+            const fake = createFakeStore();
+            writeImport.mockResolvedValue(undefined);
+
+            // 1st read: p-old is on disk → conflict seeded for p-old.
+            readSnapshot.mockResolvedValueOnce({
+                projects: [makeProject({ id: 'p-old', name: '旧' })],
+                tutorialState: {},
+                analysisHistory: [],
+            });
+            // 2nd read: p-old gone, p-new appeared. Both shifts at once.
+            readSnapshot.mockResolvedValueOnce({
+                projects: [makeProject({ id: 'p-new', name: '別タブが追加' })],
+                tutorialState: {},
+                analysisHistory: [],
+            });
+
+            const raw = JSON.stringify({
+                schemaVersion: 1,
+                exportedAt: '2026-04-28T00:00:00.000Z',
+                appVersion: '0.0.0',
+                projects: [
+                    makeProject({ id: 'p-old', name: 'インポート旧' }),
+                    makeProject({ id: 'p-new', name: 'インポート新' }),
+                ],
+                tutorialState: {},
+                analysisHistory: [],
+            });
+
+            await fake.state.prepareImport(raw);
+            // User picked overwrite for p-old before the double shift. p-new
+            // wasn't in the original conflict list so it carries no resolution.
+            fake.state.setImportResolution('p-old', 'overwrite');
+            // The new collision (p-new) has no resolutions entry, so the
+            // execute-time re-read forces a BackupValidationError instead of
+            // silently overwriting whatever the other tab just wrote.
+            await expect(fake.state.executeImport()).rejects.toThrow(/衝突解決方針/);
+            expect(writeImport).not.toHaveBeenCalled();
             expect(fake.state.importPlan).not.toBeNull();
         });
     });

--- a/store/backupSlice.test.ts
+++ b/store/backupSlice.test.ts
@@ -212,6 +212,207 @@ describe('prepareImport / executeImport (AC-3, AC-5)', () => {
         // importPlan retained so user can retry / inspect
         expect(fake.state.importPlan).not.toBeNull();
     });
+
+    // H4: full prepareImport → setImportResolution → executeImport flow.
+    // Existing tests cover the default-overwrite path; this block exercises
+    // resolution mutation (skip / duplicate / mixed) so the Map seeded from
+    // `plan.conflicts` reaches `resolveImportProjects` intact.
+    describe('H4 setImportResolution → executeImport flow', () => {
+        it('skip resolution drops conflicting incoming, keeps non-conflicting', async () => {
+            readSnapshot.mockResolvedValue({
+                projects: [makeProject({ id: 'p-existing', name: '既存' })],
+                tutorialState: {},
+                analysisHistory: [],
+            });
+            writeImport.mockResolvedValue(undefined);
+            const fake = createFakeStore();
+            const raw = JSON.stringify({
+                schemaVersion: 1,
+                exportedAt: '2026-04-28T00:00:00.000Z',
+                appVersion: '0.0.0',
+                projects: [
+                    makeProject({ id: 'p-existing', name: 'インポート' }),
+                    makeProject({ id: 'p-new', name: '新規' }),
+                ],
+                tutorialState: {},
+                analysisHistory: [],
+            });
+
+            await fake.state.prepareImport(raw);
+            fake.state.setImportResolution('p-existing', 'skip');
+            const result = await fake.state.executeImport();
+
+            expect(writeImport).toHaveBeenCalledOnce();
+            const payload = writeImport.mock.calls[0][0];
+            expect(payload.toUpsert.map((p: Project) => p.id)).toEqual(['p-new']);
+            expect(payload.toCreate).toEqual([]);
+            expect(result).toEqual({ upserted: 1, created: 0, skipped: 1 });
+        });
+
+        it('duplicate resolution issues fresh id + (インポート) suffix into toCreate', async () => {
+            readSnapshot.mockResolvedValue({
+                projects: [makeProject({ id: 'p-existing', name: '既存' })],
+                tutorialState: {},
+                analysisHistory: [],
+            });
+            writeImport.mockResolvedValue(undefined);
+            const fake = createFakeStore();
+            const raw = JSON.stringify({
+                schemaVersion: 1,
+                exportedAt: '2026-04-28T00:00:00.000Z',
+                appVersion: '0.0.0',
+                projects: [makeProject({ id: 'p-existing', name: 'インポート版' })],
+                tutorialState: {},
+                analysisHistory: [],
+            });
+
+            await fake.state.prepareImport(raw);
+            fake.state.setImportResolution('p-existing', 'duplicate');
+            const result = await fake.state.executeImport();
+
+            const payload = writeImport.mock.calls[0][0];
+            expect(payload.toUpsert).toEqual([]);
+            expect(payload.toCreate).toHaveLength(1);
+            expect(payload.toCreate[0].id).not.toBe('p-existing'); // freshly minted UUID
+            expect(payload.toCreate[0].name).toBe('インポート版 (インポート)');
+            expect(result).toEqual({ upserted: 0, created: 1, skipped: 0 });
+        });
+
+        it('mixed resolutions: overwrite + skip + duplicate produce a single consolidated writeImport', async () => {
+            readSnapshot.mockResolvedValue({
+                projects: [
+                    makeProject({ id: 'p-a', name: 'A既存' }),
+                    makeProject({ id: 'p-b', name: 'B既存' }),
+                    makeProject({ id: 'p-c', name: 'C既存' }),
+                ],
+                tutorialState: {},
+                analysisHistory: [],
+            });
+            writeImport.mockResolvedValue(undefined);
+            const fake = createFakeStore();
+            const raw = JSON.stringify({
+                schemaVersion: 1,
+                exportedAt: '2026-04-28T00:00:00.000Z',
+                appVersion: '0.0.0',
+                projects: [
+                    makeProject({ id: 'p-a', name: 'A入力' }),
+                    makeProject({ id: 'p-b', name: 'B入力' }),
+                    makeProject({ id: 'p-c', name: 'C入力' }),
+                    makeProject({ id: 'p-d', name: 'D入力（新規）' }),
+                ],
+                tutorialState: {},
+                analysisHistory: [],
+            });
+
+            await fake.state.prepareImport(raw);
+            fake.state.setImportResolution('p-a', 'overwrite');
+            fake.state.setImportResolution('p-b', 'skip');
+            fake.state.setImportResolution('p-c', 'duplicate');
+            const result = await fake.state.executeImport();
+
+            expect(writeImport).toHaveBeenCalledOnce();
+            const payload = writeImport.mock.calls[0][0];
+            // p-a (overwrite) + p-d (new) → toUpsert
+            expect(payload.toUpsert.map((p: Project) => p.id).sort()).toEqual(['p-a', 'p-d']);
+            // p-c (duplicate) → toCreate with fresh id
+            expect(payload.toCreate).toHaveLength(1);
+            expect(payload.toCreate[0].id).not.toBe('p-c');
+            // p-b (skip) → absent everywhere
+            const allOutgoingIds = [...payload.toUpsert, ...payload.toCreate].map((p: Project) => p.id);
+            expect(allOutgoingIds).not.toContain('p-b');
+            expect(result).toEqual({ upserted: 2, created: 1, skipped: 1 });
+        });
+
+        it('setImportResolution is a no-op when there is no active plan (defensive)', () => {
+            const fake = createFakeStore();
+            // Should not throw, should not flip importPlan from null.
+            fake.state.setImportResolution('does-not-matter', 'skip');
+            expect(fake.state.importPlan).toBeNull();
+        });
+    });
+
+    // H5: TOCTOU between prepareImport and executeImport. The slice re-reads
+    // existingIds at execute time so concurrent deletes/inserts don't lock the
+    // user into a stale conflict picture. Switch readSnapshot via
+    // `mockResolvedValueOnce` to simulate the two reads returning different
+    // states, and assert the second read drives the actual write.
+    describe('H5 TOCTOU re-read between prepareImport and executeImport', () => {
+        it('delete-after-prepare: skip resolution is overridden when target no longer exists at execute', async () => {
+            const fake = createFakeStore();
+            writeImport.mockResolvedValue(undefined);
+
+            // 1st read (prepareImport): p-existing is on disk → conflict detected.
+            readSnapshot.mockResolvedValueOnce({
+                projects: [makeProject({ id: 'p-existing', name: '既存' })],
+                tutorialState: {},
+                analysisHistory: [],
+            });
+            // 2nd read (executeImport): p-existing was deleted in another tab → no longer conflicts.
+            readSnapshot.mockResolvedValueOnce({
+                projects: [],
+                tutorialState: {},
+                analysisHistory: [],
+            });
+
+            const raw = JSON.stringify({
+                schemaVersion: 1,
+                exportedAt: '2026-04-28T00:00:00.000Z',
+                appVersion: '0.0.0',
+                projects: [makeProject({ id: 'p-existing', name: 'インポート' })],
+                tutorialState: {},
+                analysisHistory: [],
+            });
+
+            await fake.state.prepareImport(raw);
+            // User picks "skip" because they thought it would clash. By execute
+            // time the row is gone, so resolveImportProjects sees no conflict
+            // and treats the incoming project as a fresh insert (toUpsert).
+            fake.state.setImportResolution('p-existing', 'skip');
+            const result = await fake.state.executeImport();
+
+            expect(readSnapshot).toHaveBeenCalledTimes(2);
+            const payload = writeImport.mock.calls[0][0];
+            expect(payload.toUpsert.map((p: Project) => p.id)).toEqual(['p-existing']);
+            expect(result.upserted).toBe(1);
+        });
+
+        it('insert-after-prepare: new conflict without resolution surfaces a BackupValidationError instead of silently overwriting', async () => {
+            const fake = createFakeStore();
+            writeImport.mockResolvedValue(undefined);
+
+            // 1st read: empty disk → no conflicts seeded.
+            readSnapshot.mockResolvedValueOnce({
+                projects: [],
+                tutorialState: {},
+                analysisHistory: [],
+            });
+            // 2nd read: another tab inserted p-1 between prepare and execute.
+            readSnapshot.mockResolvedValueOnce({
+                projects: [makeProject({ id: 'p-1', name: '他タブで追加' })],
+                tutorialState: {},
+                analysisHistory: [],
+            });
+
+            const raw = JSON.stringify({
+                schemaVersion: 1,
+                exportedAt: '2026-04-28T00:00:00.000Z',
+                appVersion: '0.0.0',
+                projects: [makeProject({ id: 'p-1', name: 'インポート' })],
+                tutorialState: {},
+                analysisHistory: [],
+            });
+
+            await fake.state.prepareImport(raw);
+            // No setImportResolution call — plan.conflicts was empty. The TOCTOU
+            // re-read discovers a new collision, but resolutions Map has nothing
+            // to say, so resolveImportProjects refuses to silently overwrite and
+            // throws. Critical invariant: writeImport must NOT be called.
+            await expect(fake.state.executeImport()).rejects.toThrow(/衝突解決方針/);
+            expect(writeImport).not.toHaveBeenCalled();
+            // importPlan retained so the UI can re-prepare or surface the race.
+            expect(fake.state.importPlan).not.toBeNull();
+        });
+    });
 });
 
 describe('isBackupStale (AC-7)', () => {


### PR DESCRIPTION
## Summary

- Issue #49 H4 (rating 8) + H5 (rating 8) の対応
- `prepareImport → setImportResolution → executeImport` の通しテストと、prepare/execute 間の TOCTOU 再 read 挙動を回帰検知で固定
- 1 ファイル変更: `store/backupSlice.test.ts` (+201/-0)、実装側変更なし（既存挙動が仕様通り）

## H4: setImportResolution → executeImport 通しテスト（4 ケース）

| シナリオ | 期待 |
|---|---|
| skip resolution | conflicting 消失、non-conflicting のみ upsert |
| duplicate resolution | 新 UUID + `(インポート)` suffix で toCreate |
| mixed (overwrite + skip + duplicate) | 単一 writeImport に集約、id ごとに正しい振り分け |
| importPlan が null | setImportResolution は no-op（防御テスト） |

既存テストは default-overwrite 経路のみカバーしていたため、resolution 変更経路で `plan.conflicts` から組み立てた Map が `resolveImportProjects` まで正しく流れることを通しで担保。

## H5: TOCTOU 再 read 回帰テスト（2 ケース）

| シナリオ | 期待 |
|---|---|
| delete-after-prepare | prepare 時に conflict 検知 → ユーザー skip 選択 → execute 時には削除済 → resolution 無視され toUpsert として書込 |
| insert-after-prepare | prepare 時 empty → 他タブが insert → execute 時 conflict + resolutions Map 空 → `BackupValidationError` で停止、`writeImport` は呼ばれない |

`mockResolvedValueOnce` を 2 段切替して `executeImport` が `readSnapshot` を 2 回目に呼び直すこと、および 2 回目の結果に基づき `resolveImportProjects` が動くことを assert。silent overwrite 回避の不変条件を固定。

## 実装側の変更

なし。既存実装 (`store/backupSlice.ts:207-208` の execute 時 readSnapshot 再 read + `utils/backupSchema.ts:211-215` の missing resolution throw) は仕様通り。本 PR のスコープは「仕様の固定（回帰検知）」のみ。

## Test plan

- [x] `npm run test -- store/backupSlice.test.ts` → 22/22 PASS（既存 16 + 新規 6）
- [x] `npm run test`（全体回帰）→ 215/215 PASS
- [x] `npm run lint`（`tsc --noEmit`）→ 0 errors
- [x] 変更コードパス（H4: 4 ケース / H5: 2 ケース）を vitest で実行し全 PASS 確認

## Issue 進捗

`Refs #49`（Issue #49 は 5 件束ねの parent）

- [ ] H2 (`prepareImport` flushSave UX) — 未着手（設計判断要）
- [x] **H4 (setImportResolution → executeImport 通しテスト) — 本 PR**
- [x] **H5 (TOCTOU 再 read 回帰テスト) — 本 PR**
- [x] H6 (isBackupStale 境界値テスト) — PR #51 でマージ済
- [ ] H10 (Dexie blocked event ハンドラ) — 未着手
- [ ] H6-followup-1 (`backupMetaStatus='unknown'` × non-null) — PR #51 review より
- [ ] H6-followup-2 (`daysSince` 空文字列 ケース) — PR #51 review より

🤖 Generated with [Claude Code](https://claude.com/claude-code)