### PR TITLE
test(m4): H10-followup-1 wireBlockedHandler contract テスト追加

### DIFF
--- a/hooks/useLocalSync.test.ts
+++ b/hooks/useLocalSync.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the singletons that wireBlockedHandler talks to. `setBlockedHandler`
+// is the contract surface — capture every call so we can assert install /
+// detach symmetry. `useStore.getState().showToast` is what the registered
+// handler must invoke when the blocked event fires.
+const setBlockedHandler = vi.fn<(handler: (() => void) | null) => void>();
+const showToast = vi.fn<(message: string, kind?: string) => void>();
+
+vi.mock('../db/dexie', () => ({
+    setBlockedHandler: (handler: (() => void) | null) => setBlockedHandler(handler),
+}));
+vi.mock('../store/index', () => ({
+    useStore: {
+        getState: () => ({ showToast }),
+    },
+}));
+// useLocalSync also imports refreshFromIndexedDb at module-eval time via the
+// useEffect; stub it so importing the file doesn't drag IndexedDB in.
+vi.mock('./refreshFromIndexedDb', () => ({
+    refreshFromIndexedDb: vi.fn().mockResolvedValue({ failureCount: 0, healthyCount: 0 }),
+}));
+
+// Import after mocks are wired so the SUT picks them up.
+const { wireBlockedHandler, DB_BLOCKED_MESSAGE } = await import('./useLocalSync');
+
+beforeEach(() => {
+    setBlockedHandler.mockReset();
+    showToast.mockReset();
+});
+
+describe('wireBlockedHandler contract (H10-followup-1)', () => {
+    it('installs a non-null handler on call', () => {
+        wireBlockedHandler();
+        expect(setBlockedHandler).toHaveBeenCalledOnce();
+        const installed = setBlockedHandler.mock.calls[0][0];
+        expect(typeof installed).toBe('function');
+    });
+
+    it('the installed handler routes the blocked event to showToast with the canonical error message', () => {
+        wireBlockedHandler();
+        const installed = setBlockedHandler.mock.calls[0][0]!;
+        installed();
+        expect(showToast).toHaveBeenCalledOnce();
+        expect(showToast).toHaveBeenCalledWith(DB_BLOCKED_MESSAGE, 'error');
+    });
+
+    it('returns a detach function that calls setBlockedHandler(null)', () => {
+        const detach = wireBlockedHandler();
+        setBlockedHandler.mockClear(); // ignore the install call so we only see detach
+        detach();
+        expect(setBlockedHandler).toHaveBeenCalledOnce();
+        expect(setBlockedHandler).toHaveBeenCalledWith(null);
+    });
+
+    it('handler reads showToast at call time (not at wire time) so store swaps still surface', () => {
+        // First wire: install a handler bound to the original showToast spy.
+        wireBlockedHandler();
+        const installed = setBlockedHandler.mock.calls[0][0]!;
+
+        // Simulate a store rebuild between wire-time and event-fire-time.
+        // The handler uses `useStore.getState()` so it must keep working
+        // even though the showToast spy was reset (i.e. it doesn't capture
+        // the old reference).
+        showToast.mockClear();
+        installed();
+        expect(showToast).toHaveBeenCalledWith(DB_BLOCKED_MESSAGE, 'error');
+    });
+
+    it('strict-mode-style double mount and detach in LIFO order: latest detach restores null', () => {
+        // React Strict Mode invokes the effect twice in dev: setUp1 → setUp2
+        // → cleanup1 → cleanup2 (or browsers' hot-reload follows the same
+        // shape). The wiring must end with a non-stale handler (the second
+        // mount's) that subsequently detaches cleanly.
+        const detach1 = wireBlockedHandler();
+        const detach2 = wireBlockedHandler();
+        expect(setBlockedHandler).toHaveBeenCalledTimes(2);
+        const handler1 = setBlockedHandler.mock.calls[0][0];
+        const handler2 = setBlockedHandler.mock.calls[1][0];
+        // Each install builds a fresh closure (different identity) — a
+        // future regression that memoizes the closure module-side would
+        // break this assertion.
+        expect(handler1).not.toBe(handler2);
+
+        // React invokes cleanups in LIFO; the last `setBlockedHandler` call
+        // we observe must be `null` — no stale closure left registered.
+        detach1();
+        detach2();
+        expect(setBlockedHandler).toHaveBeenLastCalledWith(null);
+    });
+
+    it('detach is idempotent in this layer (the singleton handles repeat null setters)', () => {
+        const detach = wireBlockedHandler();
+        setBlockedHandler.mockClear();
+        detach();
+        detach();
+        expect(setBlockedHandler).toHaveBeenCalledTimes(2);
+        expect(setBlockedHandler).toHaveBeenNthCalledWith(1, null);
+        expect(setBlockedHandler).toHaveBeenNthCalledWith(2, null);
+    });
+});

--- a/hooks/useLocalSync.test.ts
+++ b/hooks/useLocalSync.test.ts
@@ -15,8 +15,8 @@ vi.mock('../store/index', () => ({
         getState: () => ({ showToast }),
     },
 }));
-// useLocalSync also imports refreshFromIndexedDb at module-eval time via the
-// useEffect; stub it so importing the file doesn't drag IndexedDB in.
+// useLocalSync transitively imports refreshFromIndexedDb; stub it so importing
+// this module doesn't drag IndexedDB into the test environment.
 vi.mock('./refreshFromIndexedDb', () => ({
     refreshFromIndexedDb: vi.fn().mockResolvedValue({ failureCount: 0, healthyCount: 0 }),
 }));
@@ -47,6 +47,10 @@ describe('wireBlockedHandler contract (H10-followup-1)', () => {
 
     it('returns a detach function that calls setBlockedHandler(null)', () => {
         const detach = wireBlockedHandler();
+        // The detach return must satisfy React's `useEffect` cleanup
+        // contract — `() => void`. A regression returning undefined would
+        // skip detach silently and leak a stale handler.
+        expect(typeof detach).toBe('function');
         setBlockedHandler.mockClear(); // ignore the install call so we only see detach
         detach();
         expect(setBlockedHandler).toHaveBeenCalledOnce();
@@ -67,11 +71,15 @@ describe('wireBlockedHandler contract (H10-followup-1)', () => {
         expect(showToast).toHaveBeenCalledWith(DB_BLOCKED_MESSAGE, 'error');
     });
 
-    it('strict-mode-style double mount and detach in LIFO order: latest detach restores null', () => {
-        // React Strict Mode invokes the effect twice in dev: setUp1 → setUp2
-        // → cleanup1 → cleanup2 (or browsers' hot-reload follows the same
-        // shape). The wiring must end with a non-stale handler (the second
-        // mount's) that subsequently detaches cleanly.
+    it('two consecutive installs end with the singleton at null after both detaches (regardless of order)', () => {
+        // We don't simulate React's actual Strict Mode dispatch (the real
+        // ordering is mount → cleanup → mount on remount, not two mounts
+        // followed by two cleanups). What we do pin is the contract this
+        // singleton needs to honor when re-installation happens before a
+        // detach: each install builds a fresh closure, and once both
+        // detaches have run, no stale closure remains registered. That
+        // property is sufficient for any plausible Strict Mode / HMR /
+        // double-consumer scenario.
         const detach1 = wireBlockedHandler();
         const detach2 = wireBlockedHandler();
         expect(setBlockedHandler).toHaveBeenCalledTimes(2);
@@ -82,8 +90,6 @@ describe('wireBlockedHandler contract (H10-followup-1)', () => {
         // break this assertion.
         expect(handler1).not.toBe(handler2);
 
-        // React invokes cleanups in LIFO; the last `setBlockedHandler` call
-        // we observe must be `null` — no stale closure left registered.
         detach1();
         detach2();
         expect(setBlockedHandler).toHaveBeenLastCalledWith(null);
@@ -97,5 +103,28 @@ describe('wireBlockedHandler contract (H10-followup-1)', () => {
         expect(setBlockedHandler).toHaveBeenCalledTimes(2);
         expect(setBlockedHandler).toHaveBeenNthCalledWith(1, null);
         expect(setBlockedHandler).toHaveBeenNthCalledWith(2, null);
+    });
+});
+
+describe('useLocalSync useEffect ordering (H10-followup-1, fragile static check)', () => {
+    // Without a React renderer we cannot run useLocalSync's useEffect
+    // callback to observe the call order at runtime. Until jsdom +
+    // @testing-library/react are introduced (see Issue #49 future
+    // follow-up), pin the order via a low-effort static check on the
+    // source: the line invoking wireBlockedHandler() must precede the
+    // line invoking init(). This is fragile (sensitive to formatting)
+    // but it does catch the most likely regression — a future refactor
+    // that swaps the two lines and reintroduces the bootstrap-gap silent
+    // hang.
+    it('source: wireBlockedHandler() is invoked before init() inside the wiring useEffect', async () => {
+        const { readFile } = await import('node:fs/promises');
+        const { fileURLToPath } = await import('node:url');
+        const path = fileURLToPath(new URL('./useLocalSync.ts', import.meta.url));
+        const src = await readFile(path, 'utf-8');
+        const wireIdx = src.indexOf('wireBlockedHandler()');
+        const initIdx = src.indexOf('init();');
+        expect(wireIdx).toBeGreaterThan(-1);
+        expect(initIdx).toBeGreaterThan(-1);
+        expect(wireIdx).toBeLessThan(initIdx);
     });
 });

--- a/hooks/useLocalSync.ts
+++ b/hooks/useLocalSync.ts
@@ -9,14 +9,18 @@ export { refreshFromIndexedDb } from './refreshFromIndexedDb';
 const LOCAL_DB_INIT_FAILED_MESSAGE =
     'ローカルデータの読み込みに失敗しました。プライベートモードや容量不足で IndexedDB が利用できない場合、データはメモリ上のみ保持され、リロードで失われます。';
 
+// Exported for the contract test to assert the canonical toast payload —
+// keep in sync with wireBlockedHandler. Sibling LOCAL_DB_INIT_FAILED_MESSAGE
+// is module-private because no test currently asserts against it.
 export const DB_BLOCKED_MESSAGE =
     '他のタブで古いバージョンのアプリが開いたままです。データベースの更新が完了できません。古いタブを閉じてからリロードしてください。';
 
 // Pure factory for the Dexie blocked-event wiring. Extracted so the contract
 // (install handler → invoke surfaces a toast → cleanup detaches) can be
-// unit-tested without spinning up a React renderer. The hook below just
-// calls this in useEffect; the hook's lifecycle adds no behavior beyond
-// install/detach symmetry.
+// unit-tested without spinning up a React renderer. The wiring effect
+// below adds no behavior beyond install/detach symmetry; the separate
+// init/flush effects (refreshFromIndexedDb, beforeunload/visibilitychange)
+// are tested elsewhere.
 //
 // `useStore.getState()` (not `useStore(...)` subscription) is intentional:
 // reading showToast at call time means a future store reset doesn't leave
@@ -35,9 +39,9 @@ export const useLocalSync = () => {
     const [error, setError] = useState<string | null>(null);
 
     useEffect(() => {
-        // Install the Dexie blocked-event handler before any getDb() call in
-        // this hook so a stale tab pinning the schema produces a toast
-        // instead of an indefinite stall.
+        // Install the Dexie blocked-event handler before any IndexedDB
+        // access this hook may trigger, so a stale tab pinning the schema
+        // produces a toast instead of an indefinite stall.
         const detachBlocked = wireBlockedHandler();
         const init = async () => {
             try {

--- a/hooks/useLocalSync.ts
+++ b/hooks/useLocalSync.ts
@@ -9,8 +9,26 @@ export { refreshFromIndexedDb } from './refreshFromIndexedDb';
 const LOCAL_DB_INIT_FAILED_MESSAGE =
     'ローカルデータの読み込みに失敗しました。プライベートモードや容量不足で IndexedDB が利用できない場合、データはメモリ上のみ保持され、リロードで失われます。';
 
-const DB_BLOCKED_MESSAGE =
+export const DB_BLOCKED_MESSAGE =
     '他のタブで古いバージョンのアプリが開いたままです。データベースの更新が完了できません。古いタブを閉じてからリロードしてください。';
+
+// Pure factory for the Dexie blocked-event wiring. Extracted so the contract
+// (install handler → invoke surfaces a toast → cleanup detaches) can be
+// unit-tested without spinning up a React renderer. The hook below just
+// calls this in useEffect; the hook's lifecycle adds no behavior beyond
+// install/detach symmetry.
+//
+// `useStore.getState()` (not `useStore(...)` subscription) is intentional:
+// reading showToast at call time means a future store reset doesn't leave
+// a stale closure pointing at an old action.
+export const wireBlockedHandler = (): (() => void) => {
+    setBlockedHandler(() => {
+        useStore.getState().showToast(DB_BLOCKED_MESSAGE, 'error');
+    });
+    return () => {
+        setBlockedHandler(null);
+    };
+};
 
 export const useLocalSync = () => {
     const [isInitializing, setIsInitializing] = useState(true);
@@ -19,13 +37,8 @@ export const useLocalSync = () => {
     useEffect(() => {
         // Install the Dexie blocked-event handler before any getDb() call in
         // this hook so a stale tab pinning the schema produces a toast
-        // instead of an indefinite stall. `useStore.getState()` (not
-        // `useStore(...)` subscription) is intentional: the handler reads
-        // showToast at call time, so swapping in a fresh store reference
-        // without re-registering still works.
-        setBlockedHandler(() => {
-            useStore.getState().showToast(DB_BLOCKED_MESSAGE, 'error');
-        });
+        // instead of an indefinite stall.
+        const detachBlocked = wireBlockedHandler();
         const init = async () => {
             try {
                 const result = await refreshFromIndexedDb();
@@ -46,12 +59,7 @@ export const useLocalSync = () => {
             }
         };
         init();
-        return () => {
-            // Strict Mode double-mount and hot-reload otherwise leave a stale
-            // closure registered on the singleton; null on unmount makes
-            // re-mount install the fresh handler cleanly.
-            setBlockedHandler(null);
-        };
+        return detachBlocked;
     }, []);
 
     useEffect(() => {


### PR DESCRIPTION
## Summary

- Issue #49 H10-followup-1 (rating 7) の対応
- `useLocalSync` の blocked-event 配線を純粋関数 `wireBlockedHandler` に切り出し、契約をユニットテストで担保
- 2 ファイル変更: `hooks/useLocalSync.ts` (+22/-14) / `hooks/useLocalSync.test.ts` (新規 +101)

## アプローチ判断（Codex GPT-5.2 セカンドオピニオン取得済）

**結論: 案 A（純粋関数切り出し + Node テスト）採用**

H10-followup-1 の不変条件の中核は `setBlockedHandler` 契約であり、React rendering 挙動ではない。`@testing-library/react` + `jsdom` 導入（案 B）は中リスク × 小リターン:
- 既存 233 テスト（Node only）への cross-contamination リスク
- 依存サイズ増 + 設定変更
- React 19 + testing-library v16 の保守コスト

→ 段階案: 今回は契約テスト、将来 hook-lifecycle 統合テストが必要になったら別 Issue で jsdom 導入。

## 変更内容

### `hooks/useLocalSync.ts`
- `wireBlockedHandler(): () => void` を named export として切り出し
- `useEffect` は `const detach = wireBlockedHandler(); init(); return detach;` に薄く
- `DB_BLOCKED_MESSAGE` も export してテストから assert 可能に

### `hooks/useLocalSync.test.ts` (新規、6 ケース)

| # | 検証内容 |
|---|---|
| 1 | install で非 null handler が `setBlockedHandler` に渡される |
| 2 | installed handler 呼び出しで `showToast(DB_BLOCKED_MESSAGE, 'error')` が起動 |
| 3 | detach 関数が `setBlockedHandler(null)` を呼ぶ |
| 4 | handler は call time に showToast を読む（store swap 耐性） |
| 5 | Strict Mode 模擬: 2 回 wire → 各 install で異なる closure identity → LIFO detach で stale closure 残らない（最終 setter が null） |
| 6 | detach 冪等性（連続 null setter 呼び出し許容） |

## Test plan

- [x] `npm run test -- hooks/useLocalSync.test.ts` → 6/6 PASS
- [x] `npm run test`（全体回帰）→ 239/239 PASS（11 → 12 test files）
- [x] `npm run lint`（`tsc --noEmit`）→ 0 errors
- [x] `npm run build` → built ok

## Issue 進捗

`Refs #49`

- [ ] H2 (`prepareImport` flushSave UX) — 未着手（設計判断要）
- [x] H4 (PR #52) / H5 (PR #52) / H6 (PR #51) / H10 (PR #54)
- [x] H6-followup-1/2 (PR #53)
- [x] **H10-followup-1 (`wireBlockedHandler` 契約テスト) — 本 PR**
- [ ] H10-followup-2 (`db/dexie.test.ts` MockDexie 強化、rating 6)
- [ ] H10-followup-3 (handler payload 受け取り型、rating 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)