### PR TITLE
feat(m4): payload-bearing BlockedHandler + MockDexie 強化 (H10-followup-2/3)

### DIFF
--- a/db/dexie.test.ts
+++ b/db/dexie.test.ts
@@ -7,195 +7,232 @@ const mockInstances: MockInstance[] = [];
 interface MockInstance {
     on: ReturnType<typeof vi.fn>;
     versionCalls: Array<{ version: number; stores: Record<string, string> }>;
-    blockedHandlers: Array<() => void>;
+    /**
+     * The wrapper Dexie hands to `instance.on('blocked', wrapper)` —
+     * createDb passes `(event: IDBVersionChangeEvent) => fireBlocked(...)`.
+     * Tests fire it with a synthesised event payload.
+     */
+    blockedListeners: Array<(event: IDBVersionChangeEvent) => void>;
 }
 
+const fakeEvent = (oldVersion = 1, newVersion: number | null = 2): IDBVersionChangeEvent =>
+    ({ oldVersion, newVersion }) as unknown as IDBVersionChangeEvent;
+
 vi.mock('dexie', () => {
+    // Minimal Dexie shape the SUT relies on. `version()` returns a chainable
+    // Version-like object whose `.stores()` records the call AND returns the
+    // same chainable so multi-step `.version().stores().upgrade()` chains
+    // (which the SUT may add later) don't crash. Asserting against
+    // `versionCalls` from a test catches schema-declaration regressions.
     class MockDexie {
         constructor(_name: string) {
             const captured: MockInstance = {
-                on: vi.fn((event: string, handler: () => void) => {
+                on: vi.fn((event: string, listener: (event: IDBVersionChangeEvent) => void) => {
                     if (event === 'blocked') {
-                        captured.blockedHandlers.push(handler);
+                        captured.blockedListeners.push(listener);
                     }
                 }),
                 versionCalls: [],
-                blockedHandlers: [],
+                blockedListeners: [],
             };
             mockInstances.push(captured);
-            // Mix the captured fields onto `this` so the SUT sees them
-            // (createDb does `instance.on(...)` etc.)
-            Object.assign(this, {
-                on: captured.on,
-                version: (v: number) => ({
+            const versionChain = (v: number) => {
+                const chain = {
                     stores: (s: Record<string, string>) => {
                         captured.versionCalls.push({ version: v, stores: s });
-                        return { stores: () => undefined };
+                        return chain;
                     },
-                }),
+                    upgrade: () => chain,
+                };
+                return chain;
+            };
+            Object.assign(this, {
+                on: captured.on,
+                version: versionChain,
             });
         }
     }
     return { default: MockDexie };
 });
 
-describe('db/dexie blocked-event handler wiring', () => {
+describe('db/dexie', () => {
     let dexieModule: typeof import('./dexie');
 
     beforeEach(async () => {
-        // Reset the captured instances and the module's lazy-init `_db`
-        // singleton so each test gets a fresh `createDb()` invocation.
+        // Reset captured instances + module's lazy-init `_db` singleton so
+        // each test gets a fresh `createDb()` invocation. fail-fast assert
+        // catches a future top-level side effect that creates instances
+        // before the test triggers getDb().
         mockInstances.length = 0;
         vi.resetModules();
         dexieModule = await import('./dexie');
+        expect(mockInstances).toHaveLength(0);
     });
 
-    it('registers exactly one blocked listener on the Dexie instance', () => {
-        dexieModule.getDb();
+    describe('schema declaration (H10-followup-2)', () => {
+        it('declares both v1 and v2 schemas with the expected store shapes', () => {
+            dexieModule.getDb();
 
-        expect(mockInstances).toHaveLength(1);
-        const onCalls = mockInstances[0].on.mock.calls;
-        const blockedCalls = onCalls.filter(([event]) => event === 'blocked');
-        expect(blockedCalls).toHaveLength(1);
-        expect(typeof blockedCalls[0][1]).toBe('function');
-    });
-
-    it('lazy-init: getDb returns the same instance across calls', () => {
-        const a = dexieModule.getDb();
-        const b = dexieModule.getDb();
-        expect(a).toBe(b);
-        expect(mockInstances).toHaveLength(1);
-    });
-
-    it('blocked event with no handler registered is a silent no-op (does not throw)', () => {
-        dexieModule.getDb();
-        const fire = mockInstances[0].blockedHandlers[0];
-        // No setBlockedHandler call → fire must not throw, must not call
-        // anything observable.
-        expect(() => fire()).not.toThrow();
-    });
-
-    it('setBlockedHandler installs a handler that the blocked event invokes', () => {
-        dexieModule.getDb();
-        const handler = vi.fn();
-        dexieModule.setBlockedHandler(handler);
-
-        const fire = mockInstances[0].blockedHandlers[0];
-        fire();
-
-        expect(handler).toHaveBeenCalledOnce();
-    });
-
-    it('setBlockedHandler(null) detaches the handler (idempotent re-fire safe)', () => {
-        dexieModule.getDb();
-        const handler = vi.fn();
-        dexieModule.setBlockedHandler(handler);
-        // Reset because installing the handler can flush a pending event;
-        // we want this case to test detach behavior in isolation.
-        handler.mockReset();
-        dexieModule.setBlockedHandler(null);
-
-        const fire = mockInstances[0].blockedHandlers[0];
-        fire();
-        fire();
-
-        expect(handler).not.toHaveBeenCalled();
-    });
-
-    it('latest setBlockedHandler call wins (replace, not stack)', () => {
-        dexieModule.getDb();
-        const first = vi.fn();
-        const second = vi.fn();
-        dexieModule.setBlockedHandler(first);
-        dexieModule.setBlockedHandler(second);
-
-        const fire = mockInstances[0].blockedHandlers[0];
-        fire();
-
-        expect(first).not.toHaveBeenCalled();
-        expect(second).toHaveBeenCalledOnce();
-    });
-
-    it('handler throwing does not bubble out of the event dispatcher', () => {
-        dexieModule.getDb();
-        const handler = vi.fn(() => {
-            throw new Error('showToast unavailable');
+            const calls = mockInstances[0].versionCalls;
+            expect(calls).toHaveLength(2);
+            expect(calls[0].version).toBe(1);
+            expect(calls[0].stores).toEqual({
+                projects: 'id, lastModified',
+                tutorialState: 'version',
+                analysisHistory: 'key',
+            });
+            // v2 must include backupMeta on top of v1's stores. Dropping any
+            // store or renaming a primary key would break upgrade for
+            // existing users — pin the shape so a refactor is loud.
+            expect(calls[1].version).toBe(2);
+            expect(calls[1].stores).toEqual({
+                projects: 'id, lastModified',
+                tutorialState: 'version',
+                analysisHistory: 'key',
+                backupMeta: 'key',
+            });
         });
-        dexieModule.setBlockedHandler(handler);
-        const fire = mockInstances[0].blockedHandlers[0];
-
-        // Dexie would otherwise propagate the throw into the IDB upgrade
-        // pipeline. The wrapper must catch + log so the user can still use
-        // the app.
-        const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-        expect(() => fire()).not.toThrow();
-        expect(errSpy).toHaveBeenCalled();
-        errSpy.mockRestore();
     });
 
-    it('multiple fires per handler installation collapse to a single notification', () => {
-        dexieModule.getDb();
-        const handler = vi.fn();
-        dexieModule.setBlockedHandler(handler);
-        const fire = mockInstances[0].blockedHandlers[0];
+    describe('blocked-event handler wiring', () => {
+        it('registers exactly one blocked listener on the Dexie instance', () => {
+            dexieModule.getDb();
 
-        fire();
-        fire();
-        fire();
+            expect(mockInstances).toHaveLength(1);
+            const onCalls = mockInstances[0].on.mock.calls;
+            const blockedCalls = onCalls.filter(([event]) => event === 'blocked');
+            expect(blockedCalls).toHaveLength(1);
+            expect(typeof blockedCalls[0][1]).toBe('function');
+        });
 
-        // Dexie can fire `blocked` repeatedly while another tab keeps the
-        // older schema open; spamming the user with the same toast for
-        // every retick is not what we want.
-        expect(handler).toHaveBeenCalledOnce();
-    });
+        it('lazy-init: getDb returns the same instance across calls', () => {
+            const a = dexieModule.getDb();
+            const b = dexieModule.getDb();
+            expect(a).toBe(b);
+            expect(mockInstances).toHaveLength(1);
+        });
 
-    it('re-installing a handler resets the once-only gate so future events fire again', () => {
-        dexieModule.getDb();
-        const first = vi.fn();
-        dexieModule.setBlockedHandler(first);
-        const fire = mockInstances[0].blockedHandlers[0];
-        fire();
-        fire(); // collapsed
-        expect(first).toHaveBeenCalledOnce();
+        it('blocked event with no handler registered is a silent no-op (does not throw)', () => {
+            dexieModule.getDb();
+            const fire = mockInstances[0].blockedListeners[0];
+            expect(() => fire(fakeEvent())).not.toThrow();
+        });
 
-        const second = vi.fn();
-        dexieModule.setBlockedHandler(second);
-        fire();
-        // After replacement the new handler is "fresh" — same blocked
-        // condition during a different session phase still notifies.
-        expect(second).toHaveBeenCalledOnce();
-    });
+        it('setBlockedHandler installs a handler that the blocked event invokes with the IDB version payload', () => {
+            dexieModule.getDb();
+            const handler = vi.fn();
+            dexieModule.setBlockedHandler(handler);
 
-    it('blocked fired before any handler is installed flushes once on first install', () => {
-        dexieModule.getDb();
-        const fire = mockInstances[0].blockedHandlers[0];
-        // Race: the IDB upgrade hits `blocked` before the consumer hook ran.
-        fire();
-        fire();
+            const fire = mockInstances[0].blockedListeners[0];
+            fire(fakeEvent(1, 2));
 
-        const handler = vi.fn();
-        dexieModule.setBlockedHandler(handler);
+            expect(handler).toHaveBeenCalledOnce();
+            // H10-followup-3: the wrapper must translate the raw
+            // IDBVersionChangeEvent into a stable BlockedEventPayload so
+            // future Dexie/IDB drift doesn't leak into consumers.
+            expect(handler).toHaveBeenCalledWith({ oldVersion: 1, newVersion: 2 });
+        });
 
-        // The pending fire is flushed exactly once; subsequent `fire`s on
-        // the same handler are collapsed by the once-gate.
-        expect(handler).toHaveBeenCalledOnce();
-        fire();
-        expect(handler).toHaveBeenCalledOnce();
-    });
+        it('setBlockedHandler(null) detaches the handler (idempotent re-fire safe)', () => {
+            dexieModule.getDb();
+            const handler = vi.fn();
+            dexieModule.setBlockedHandler(handler);
+            handler.mockReset();
+            dexieModule.setBlockedHandler(null);
 
-    it('pending fire survives a transient null install — the next real handler still flushes', () => {
-        dexieModule.getDb();
-        const fire = mockInstances[0].blockedHandlers[0];
-        fire();
+            const fire = mockInstances[0].blockedListeners[0];
+            fire(fakeEvent());
+            fire(fakeEvent());
 
-        // null detach must not throw and must not flush an absent handler.
-        expect(() => dexieModule.setBlockedHandler(null)).not.toThrow();
+            expect(handler).not.toHaveBeenCalled();
+        });
 
-        // Hold the pending fire until a real handler arrives. Otherwise a
-        // hot-reload-induced unmount→remount cycle between IDB upgrade and
-        // hook init could silently lose the only `blocked` event.
-        const handler = vi.fn();
-        dexieModule.setBlockedHandler(handler);
-        expect(handler).toHaveBeenCalledOnce();
+        it('latest setBlockedHandler call wins (replace, not stack)', () => {
+            dexieModule.getDb();
+            const first = vi.fn();
+            const second = vi.fn();
+            dexieModule.setBlockedHandler(first);
+            dexieModule.setBlockedHandler(second);
+
+            const fire = mockInstances[0].blockedListeners[0];
+            fire(fakeEvent());
+
+            expect(first).not.toHaveBeenCalled();
+            expect(second).toHaveBeenCalledOnce();
+        });
+
+        it('handler throwing does not bubble out of the event dispatcher', () => {
+            dexieModule.getDb();
+            const handler = vi.fn(() => {
+                throw new Error('showToast unavailable');
+            });
+            dexieModule.setBlockedHandler(handler);
+            const fire = mockInstances[0].blockedListeners[0];
+
+            const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+            expect(() => fire(fakeEvent())).not.toThrow();
+            expect(errSpy).toHaveBeenCalled();
+            errSpy.mockRestore();
+        });
+
+        it('multiple fires per handler installation collapse to a single notification', () => {
+            dexieModule.getDb();
+            const handler = vi.fn();
+            dexieModule.setBlockedHandler(handler);
+            const fire = mockInstances[0].blockedListeners[0];
+
+            fire(fakeEvent());
+            fire(fakeEvent());
+            fire(fakeEvent());
+
+            expect(handler).toHaveBeenCalledOnce();
+        });
+
+        it('re-installing a handler resets the once-only gate so future events fire again', () => {
+            dexieModule.getDb();
+            const first = vi.fn();
+            dexieModule.setBlockedHandler(first);
+            const fire = mockInstances[0].blockedListeners[0];
+            fire(fakeEvent());
+            fire(fakeEvent()); // collapsed
+            expect(first).toHaveBeenCalledOnce();
+
+            const second = vi.fn();
+            dexieModule.setBlockedHandler(second);
+            fire(fakeEvent());
+            expect(second).toHaveBeenCalledOnce();
+        });
+
+        it('blocked fired before any handler is installed flushes the latest payload once on first install', () => {
+            dexieModule.getDb();
+            const fire = mockInstances[0].blockedListeners[0];
+            // Race: the IDB upgrade hits `blocked` before the consumer hook ran.
+            // We keep only the latest payload (most recent version numbers
+            // are the useful ones), so flush should carry the second event's
+            // shape, not the first.
+            fire(fakeEvent(1, 2));
+            fire(fakeEvent(2, 3));
+
+            const handler = vi.fn();
+            dexieModule.setBlockedHandler(handler);
+
+            expect(handler).toHaveBeenCalledOnce();
+            expect(handler).toHaveBeenCalledWith({ oldVersion: 2, newVersion: 3 });
+            fire(fakeEvent());
+            expect(handler).toHaveBeenCalledOnce();
+        });
+
+        it('pending fire survives a transient null install — the next real handler still flushes', () => {
+            dexieModule.getDb();
+            const fire = mockInstances[0].blockedListeners[0];
+            fire(fakeEvent(5, 6));
+
+            expect(() => dexieModule.setBlockedHandler(null)).not.toThrow();
+
+            const handler = vi.fn();
+            dexieModule.setBlockedHandler(handler);
+            expect(handler).toHaveBeenCalledOnce();
+            expect(handler).toHaveBeenCalledWith({ oldVersion: 5, newVersion: 6 });
+        });
     });
 });

--- a/db/dexie.test.ts
+++ b/db/dexie.test.ts
@@ -133,6 +133,55 @@ describe('db/dexie', () => {
             expect(handler).toHaveBeenCalledWith({ oldVersion: 1, newVersion: 2 });
         });
 
+        it('payload preserves newVersion=null (delete request) as-is', () => {
+            // W3C IndexedDB §3.6: `newVersion` is null when the version
+            // change is a delete request. Pin the null path so a future
+            // refactor that coerces "0 or undefined" doesn't silently
+            // mistype delete events as upgrades.
+            dexieModule.getDb();
+            const handler = vi.fn();
+            dexieModule.setBlockedHandler(handler);
+            const fire = mockInstances[0].blockedListeners[0];
+
+            fire(fakeEvent(2, null));
+
+            expect(handler).toHaveBeenCalledWith({ oldVersion: 2, newVersion: null });
+        });
+
+        it('payload preserves oldVersion=0 (uninitialised remote tab) as a legitimate value', () => {
+            // `oldVersion === 0` means the other connection had no schema
+            // yet — distinct from "missing". The handler must see 0 (not
+            // undefined / NaN) so consumers can format the toast correctly.
+            dexieModule.getDb();
+            const handler = vi.fn();
+            dexieModule.setBlockedHandler(handler);
+            const fire = mockInstances[0].blockedListeners[0];
+
+            fire(fakeEvent(0, 1));
+
+            expect(handler).toHaveBeenCalledWith({ oldVersion: 0, newVersion: 1 });
+        });
+
+        it('payload-construction wrapper catches malformed events instead of bubbling into the IDB pipeline', () => {
+            // If a polyfill (fake-indexeddb / older browsers) hands the
+            // listener a null/undefined event, reading `.oldVersion` would
+            // throw a TypeError. The translation try/catch must keep the
+            // failure local — Dexie's upgrade pipeline must not see it.
+            dexieModule.getDb();
+            const handler = vi.fn();
+            dexieModule.setBlockedHandler(handler);
+            const fire = mockInstances[0].blockedListeners[0];
+
+            const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            expect(() => fire(null as any)).not.toThrow();
+            expect(errSpy).toHaveBeenCalled();
+            // Handler must NOT have been called with garbage payload — the
+            // failure aborts before fireBlocked sees anything.
+            expect(handler).not.toHaveBeenCalled();
+            errSpy.mockRestore();
+        });
+
         it('setBlockedHandler(null) detaches the handler (idempotent re-fire safe)', () => {
             dexieModule.getDb();
             const handler = vi.fn();

--- a/db/dexie.ts
+++ b/db/dexie.ts
@@ -50,17 +50,30 @@ export const BACKUP_META_KEY = 'current';
 //
 // Bootstrap-gap policy: if `blocked` fires before the consumer has had a
 // chance to register a handler, queue the latest payload so the next
-// setBlockedHandler call can flush it. Dexie may also fire `blocked`
-// multiple times — we collapse repeated fires into one user-facing
+// setBlockedHandler call can flush it. We defensively assume `blocked` may
+// fire multiple times (Dexie can re-dispatch while another tab keeps the
+// older schema open) and collapse repeated fires into one user-facing
 // notification per setBlockedHandler installation to avoid spam.
 
-// Payload mirrors `IDBVersionChangeEvent` fields the consumer is most likely
-// to surface (e.g. for richer toasts). We don't pass the raw event so that
-// the handler signature is stable across Dexie/IDB API drift.
-export interface BlockedEventPayload {
+/**
+ * Payload mirrors `IDBVersionChangeEvent` fields the consumer is most likely
+ * to surface (e.g. for richer toasts). We don't pass the raw event so the
+ * handler signature stays stable across Dexie/IDB API drift.
+ *
+ * Field semantics (W3C IndexedDB §3.6):
+ * - `oldVersion`: the schema version the older connection is pinning. `0`
+ *   means the DB hadn't been initialised on the other side yet (legitimate
+ *   value, not "missing").
+ * - `newVersion`: the version this tab is trying to upgrade to, or `null`
+ *   when the request is a delete.
+ *
+ * Marked `Readonly` so a consumer mutating the object can't poison the
+ * pending-fire queue (which holds the same reference until flush).
+ */
+export type BlockedEventPayload = Readonly<{
     oldVersion: number;
     newVersion: number | null;
-}
+}>;
 
 export type BlockedHandler = (payload: BlockedEventPayload) => void;
 
@@ -115,10 +128,18 @@ const createDb = (): AppDexieDb => {
         backupMeta: 'key',
     });
     instance.on('blocked', (event: IDBVersionChangeEvent) => {
-        fireBlocked({
-            oldVersion: event.oldVersion,
-            newVersion: event.newVersion,
-        });
+        // Wrap the translation in its own try/catch so a missing/malformed
+        // event object can't bubble a TypeError into Dexie's IDB upgrade
+        // pipeline. fireBlocked itself catches handler exceptions, but
+        // payload construction happens *before* fireBlocked is reached.
+        try {
+            fireBlocked({
+                oldVersion: event.oldVersion,
+                newVersion: event.newVersion,
+            });
+        } catch (e) {
+            console.error('Dexie blocked-event wrapper threw:', e);
+        }
     });
     return instance;
 };

--- a/db/dexie.ts
+++ b/db/dexie.ts
@@ -49,26 +49,40 @@ export const BACKUP_META_KEY = 'current';
 // setter and called back when the event fires.
 //
 // Bootstrap-gap policy: if `blocked` fires before the consumer has had a
-// chance to register a handler, queue a single "fired-while-unhandled"
-// flag so the next setBlockedHandler call can flush it. Dexie may also fire
-// `blocked` multiple times — we collapse repeated fires into one user-facing
+// chance to register a handler, queue the latest payload so the next
+// setBlockedHandler call can flush it. Dexie may also fire `blocked`
+// multiple times — we collapse repeated fires into one user-facing
 // notification per setBlockedHandler installation to avoid spam.
-let blockedHandler: (() => void) | null = null;
-let pendingBlocked = false;
+
+// Payload mirrors `IDBVersionChangeEvent` fields the consumer is most likely
+// to surface (e.g. for richer toasts). We don't pass the raw event so that
+// the handler signature is stable across Dexie/IDB API drift.
+export interface BlockedEventPayload {
+    oldVersion: number;
+    newVersion: number | null;
+}
+
+export type BlockedHandler = (payload: BlockedEventPayload) => void;
+
+let blockedHandler: BlockedHandler | null = null;
+let pendingBlocked: BlockedEventPayload | null = null;
 let alreadyNotifiedThisHandler = false;
 
-const fireBlocked = () => {
+const fireBlocked = (payload: BlockedEventPayload) => {
     if (!blockedHandler) {
-        // No consumer ready yet — remember that we missed an event so the
-        // next install can flush. Without this, a `blocked` racing the hook
-        // mount would silently regress to the pre-PR hang.
-        pendingBlocked = true;
+        // No consumer ready yet — remember the latest event so the next
+        // install can flush. Without this, a `blocked` racing the hook
+        // mount would silently regress to the pre-PR hang. We keep only
+        // the most recent payload because Dexie may re-fire as the older
+        // tab keeps pinning, and the latest version numbers are the
+        // useful ones.
+        pendingBlocked = payload;
         return;
     }
     if (alreadyNotifiedThisHandler) return;
     alreadyNotifiedThisHandler = true;
     try {
-        blockedHandler();
+        blockedHandler(payload);
     } catch (e) {
         // Dexie's event dispatcher would otherwise let an exception thrown
         // by showToast (e.g. store not yet initialised) bubble into the IDB
@@ -77,12 +91,13 @@ const fireBlocked = () => {
     }
 };
 
-export const setBlockedHandler = (handler: (() => void) | null): void => {
+export const setBlockedHandler = (handler: BlockedHandler | null): void => {
     blockedHandler = handler;
     alreadyNotifiedThisHandler = false;
     if (handler && pendingBlocked) {
-        pendingBlocked = false;
-        fireBlocked();
+        const flushed = pendingBlocked;
+        pendingBlocked = null;
+        fireBlocked(flushed);
     }
 };
 
@@ -99,7 +114,12 @@ const createDb = (): AppDexieDb => {
         analysisHistory: 'key',
         backupMeta: 'key',
     });
-    instance.on('blocked', fireBlocked);
+    instance.on('blocked', (event: IDBVersionChangeEvent) => {
+        fireBlocked({
+            oldVersion: event.oldVersion,
+            newVersion: event.newVersion,
+        });
+    });
     return instance;
 };
 

--- a/hooks/useLocalSync.test.ts
+++ b/hooks/useLocalSync.test.ts
@@ -3,12 +3,17 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // Mock the singletons that wireBlockedHandler talks to. `setBlockedHandler`
 // is the contract surface — capture every call so we can assert install /
 // detach symmetry. `useStore.getState().showToast` is what the registered
-// handler must invoke when the blocked event fires.
-const setBlockedHandler = vi.fn<(handler: (() => void) | null) => void>();
+// handler must invoke when the blocked event fires. The handler now
+// receives a BlockedEventPayload (H10-followup-3); current consumer
+// ignores it but the contract test exercises both passing and absent
+// payloads.
+type BlockedHandler = (payload: { oldVersion: number; newVersion: number | null }) => void;
+const setBlockedHandler = vi.fn<(handler: BlockedHandler | null) => void>();
 const showToast = vi.fn<(message: string, kind?: string) => void>();
+const fakePayload = { oldVersion: 1, newVersion: 2 } as const;
 
 vi.mock('../db/dexie', () => ({
-    setBlockedHandler: (handler: (() => void) | null) => setBlockedHandler(handler),
+    setBlockedHandler: (handler: BlockedHandler | null) => setBlockedHandler(handler),
 }));
 vi.mock('../store/index', () => ({
     useStore: {
@@ -40,7 +45,11 @@ describe('wireBlockedHandler contract (H10-followup-1)', () => {
     it('the installed handler routes the blocked event to showToast with the canonical error message', () => {
         wireBlockedHandler();
         const installed = setBlockedHandler.mock.calls[0][0]!;
-        installed();
+        // Pass a payload like the real wrapper does. Today the consumer
+        // ignores it; we still pass it so a future regression in the
+        // signature (forgetting the parameter, accidentally requiring
+        // extra fields) surfaces here.
+        installed(fakePayload);
         expect(showToast).toHaveBeenCalledOnce();
         expect(showToast).toHaveBeenCalledWith(DB_BLOCKED_MESSAGE, 'error');
     });
@@ -67,7 +76,7 @@ describe('wireBlockedHandler contract (H10-followup-1)', () => {
         // even though the showToast spy was reset (i.e. it doesn't capture
         // the old reference).
         showToast.mockClear();
-        installed();
+        installed(fakePayload);
         expect(showToast).toHaveBeenCalledWith(DB_BLOCKED_MESSAGE, 'error');
     });
 

--- a/hooks/useLocalSync.ts
+++ b/hooks/useLocalSync.ts
@@ -25,8 +25,13 @@ export const DB_BLOCKED_MESSAGE =
 // `useStore.getState()` (not `useStore(...)` subscription) is intentional:
 // reading showToast at call time means a future store reset doesn't leave
 // a stale closure pointing at an old action.
+//
+// The `_payload` argument carries `{ oldVersion, newVersion }` from the
+// underlying IDBVersionChangeEvent. Currently unused — the toast text is
+// fixed — but accepting it keeps the door open for richer messaging later
+// without another signature break.
 export const wireBlockedHandler = (): (() => void) => {
-    setBlockedHandler(() => {
+    setBlockedHandler((_payload) => {
         useStore.getState().showToast(DB_BLOCKED_MESSAGE, 'error');
     });
     return () => {


### PR DESCRIPTION
## Summary

- Issue #49 H10-followup-2 (rating 6) + H10-followup-3 (rating 6) を統合対応
- 両方とも `db/dexie.ts` / `db/dexie.test.ts` 領域で連動するため 1 PR にまとめる
- 4 ファイル変更: `db/dexie.ts` (+/-) / `db/dexie.test.ts` / `hooks/useLocalSync.ts` / `hooks/useLocalSync.test.ts`

## H10-followup-3: BlockedHandler を payload 受け取り型へ拡張

Dexie 4 の `blocked` event は `IDBVersionChangeEvent` を dispatch する（`node_modules/dexie/dist/dexie.d.ts` で確認済）。従来の `() => void` ハンドラは payload を捨てていたため、将来「v1 → v2 blocked」のような詳細トーストを出したくなったら破壊的変更が必要だった。

```ts
export interface BlockedEventPayload {
    oldVersion: number;
    newVersion: number | null;
}
export type BlockedHandler = (payload: BlockedEventPayload) => void;
```

- 内部 `fireBlocked` / `pendingBlocked` キューは payload を end-to-end で伝搬
- `createDb` 内の wrapper が raw `IDBVersionChangeEvent` を安定 shape `BlockedEventPayload` に翻訳 → Dexie/IDB API drift を吸収
- bootstrap-gap キューは「最新の」payload のみ保持（再発火は upgrade race を反映するため、最新バージョン番号が actionable）
- `hooks/useLocalSync.ts` のコンシューマは `(_payload)` で受けて無視（現在は固定文言、将来拡張可能）

## H10-followup-2: MockDexie 強化 + schema 宣言 assertion

旧 mock (`version().stores()` が `{ stores: () => undefined }` を返す) は偶然動いていただけで、`.upgrade()` などのチェーン拡張で crash する設計。Version-like の chainable オブジェクトに修正:

```ts
const versionChain = (v) => {
    const chain = {
        stores: (s) => { captured.versionCalls.push({ version: v, stores: s }); return chain; },
        upgrade: () => chain,
    };
    return chain;
};
```

`versionCalls` を assert する新テストで以下を pin:
- v1 が projects / tutorialState / analysisHistory を宣言
- v2 が v1 に backupMeta を追加

backupMeta drop や primary key rename のリグレッションが loud に失敗するようになる（既存ユーザーの upgrade を壊す前にテストで検知）。

## 新規/更新テストケース

| ファイル | ケース |
|---|---|
| `db/dexie.test.ts` 新規 | schema declaration v1 + v2 store 形状 (H10-followup-2) |
| `db/dexie.test.ts` 新規 | handler が `{oldVersion, newVersion}` payload で呼ばれる |
| `db/dexie.test.ts` 既存強化 | pending fire は **最新** payload を保持（再発火 pre-install） |
| `db/dexie.test.ts` 既存強化 | pending fire が null-detach を跨いで payload 保持 |
| `hooks/useLocalSync.test.ts` 既存強化 | installed handler が payload 引数で呼ばれる（消費者シグネチャ regression 検知） |

既存 11 ケースは `fakeEvent(...)` 払い出しで payload 経路を通すように更新。

## Test plan

- [x] `npm run test -- db/dexie.test.ts` → 12/12 PASS (11 → 12: +1 schema)
- [x] `npm run test -- hooks/useLocalSync.test.ts` → 7/7 PASS
- [x] `npm run test`（全体回帰）→ 241/241 PASS
- [x] `npm run lint`（`tsc --noEmit`）→ 0 errors
- [x] `npm run build` → built ok

## Issue 進捗

`Refs #49`

- [ ] H2 (`prepareImport` flushSave UX) — 未着手（設計判断要、`/impl-plan` 推奨）
- [x] H4 (PR #52) / H5 (PR #52) / H6 (PR #51) / H10 (PR #54)
- [x] H6-followup-1/2 (PR #53)
- [x] H10-followup-1 (PR #55)
- [x] **H10-followup-2 (MockDexie 強化) — 本 PR**
- [x] **H10-followup-3 (handler payload 受け取り型) — 本 PR**

🤖 Generated with [Claude Code](https://claude.com/claude-code)