### PR TITLE
feat(m4): prepareImport で flushSave 失敗時 retry + 中断 (H2)

### DIFF
--- a/store/backupSlice.test.ts
+++ b/store/backupSlice.test.ts
@@ -217,6 +217,73 @@ describe('prepareImport / executeImport (AC-3, AC-5)', () => {
         expect(fake.state.isImporting).toBe(false);
     });
 
+    // H2: prepareImport must not silently proceed when flushSave fails — a
+    // stale on-disk snapshot would let the user's unsaved edits be silently
+    // overwritten by a subsequent overwrite resolution. Retry once; if both
+    // attempts fail, abort with a toast + BackupValidationError so the
+    // importPlan is never seeded against stale state.
+    describe('H2 flushSave failure handling', () => {
+        const minimalRaw = JSON.stringify({
+            schemaVersion: 1,
+            exportedAt: '2026-04-28T00:00:00.000Z',
+            appVersion: '0.0.0',
+            projects: [makeProject({ id: 'p-new' })],
+            tutorialState: {},
+            analysisHistory: [],
+        });
+
+        it('retries flushSave once and proceeds when the retry succeeds', async () => {
+            readSnapshot.mockResolvedValue({ projects: [], tutorialState: {}, analysisHistory: [] });
+            const flushSave = vi.fn()
+                .mockRejectedValueOnce(new Error('IDB locked'))
+                .mockResolvedValueOnce(undefined);
+            const fake = createFakeStore();
+            fake.set({ flushSave });
+
+            const plan = await fake.state.prepareImport(minimalRaw);
+
+            // Retry actually happened (2 attempts), the import proceeded
+            // (plan is seeded), and we did NOT toast — a transient blip
+            // recovered should not nag the user.
+            expect(flushSave).toHaveBeenCalledTimes(2);
+            expect(plan.backup.projects).toHaveLength(1);
+            expect(fake.state.importPlan).not.toBeNull();
+            expect((fake.state.showToast as any)).not.toHaveBeenCalled();
+        });
+
+        it('aborts with a toast + BackupValidationError when both attempts fail', async () => {
+            const flushSave = vi.fn()
+                .mockRejectedValueOnce(new Error('IDB locked (1)'))
+                .mockRejectedValueOnce(new Error('IDB locked (2)'));
+            const fake = createFakeStore();
+            fake.set({ flushSave });
+
+            await expect(fake.state.prepareImport(minimalRaw)).rejects.toThrow(/インポートを中止/);
+
+            expect(flushSave).toHaveBeenCalledTimes(2);
+            // readSnapshot must NOT have been called — aborting before
+            // touching the disk snapshot is the whole point.
+            expect(readSnapshot).not.toHaveBeenCalled();
+            expect(fake.state.importPlan).toBeNull();
+            expect((fake.state.showToast as any)).toHaveBeenCalledOnce();
+            const [message, kind] = (fake.state.showToast as any).mock.calls[0];
+            expect(message).toMatch(/IDB locked \(2\)/);
+            expect(kind).toBe('error');
+        });
+
+        it('proceeds normally when no flushSave is wired (legacy/test environment)', async () => {
+            // Existing behavior must hold: backupSlice runs in tests and
+            // legacy contexts where flushSave isn't injected. The retry
+            // logic must not insist on its presence.
+            readSnapshot.mockResolvedValue({ projects: [], tutorialState: {}, analysisHistory: [] });
+            const fake = createFakeStore();
+            // no flushSave on the fake state
+            const plan = await fake.state.prepareImport(minimalRaw);
+            expect(plan.backup.projects).toHaveLength(1);
+            expect(fake.state.importPlan).not.toBeNull();
+        });
+    });
+
     // H4: full prepareImport → setImportResolution → executeImport flow.
     // Existing tests cover the default-overwrite path; this block exercises
     // resolution mutation (skip / duplicate / mixed) so per-conflict resolutions

--- a/store/backupSlice.ts
+++ b/store/backupSlice.ts
@@ -158,13 +158,38 @@ export const createBackupSlice = (set, get): BackupSlice => ({
 
     prepareImport: async (raw: string) => {
         // Flush in-memory edits to IndexedDB first so that conflict detection
-        // sees the user's latest unsaved work and overwrite/skip choices apply
-        // to the actual on-disk state. Without this, a project that the user
-        // is currently editing would not appear in conflicts.
-        try {
-            await (get() as WithFlushSave).flushSave?.();
-        } catch (e) {
-            console.error('flushSave before prepareImport failed:', e);
+        // sees the user's latest unsaved work and overwrite/skip choices
+        // apply to the actual on-disk state. Without this, a project that
+        // the user is currently editing would not appear in conflicts —
+        // and a subsequent overwrite resolution would silently drop the
+        // unsaved edit.
+        //
+        // H2 (Issue #49): a single transient failure (IDB quota/lock,
+        // tab race, Dexie open conflict) used to be swallowed via
+        // `console.error` and the import continued against a stale disk
+        // snapshot. Retry once before giving up, and on a second failure
+        // abort the import with an explicit toast — never proceed past
+        // a failed flush, because doing so is the silent edit-loss path.
+        const flushSave = (get() as WithFlushSave).flushSave;
+        if (flushSave) {
+            try {
+                await flushSave();
+            } catch (firstError) {
+                console.error('flushSave before prepareImport failed (1st):', firstError);
+                try {
+                    await flushSave();
+                } catch (secondError) {
+                    console.error('flushSave before prepareImport failed (2nd, aborting):', secondError);
+                    const detail = errorMessage(secondError);
+                    (get() as WithToast).showToast?.(
+                        `未保存の編集が IndexedDB に書き込めませんでした（${detail}）。インポートを中止しました。自動再試行後にもう一度お試しください。`,
+                        'error',
+                    );
+                    throw new BackupValidationError(
+                        `未保存の編集の保存に失敗したためインポートを中止しました: ${detail}`,
+                    );
+                }
+            }
         }
         const backup = parseBackup(raw);
         const snapshot = await readSnapshot();


### PR DESCRIPTION
## Summary

- Issue #49 H2 (rating 7) の対応
- `prepareImport` の `flushSave` 失敗を silent に扱っていたために編集喪失リスクがあった経路を閉鎖
- 2 ファイル変更: `store/backupSlice.ts` (+32/-7) / `store/backupSlice.test.ts` (+67)

## Problem (silent edit-loss path)

`prepareImport` は `flushSave()` を呼んで conflict detection が最新の編集を見るようにしていた。従来は失敗を `console.error` だけで silent に続行 → 以下のシナリオで編集喪失:

1. ユーザーがプロジェクト A を編集中（IDB は古い）
2. ユーザーが A を含むバックアップを Import
3. `flushSave` が IDB quota / Dexie open race / cross-tab lock 等で失敗
4. silent に続行、stale な disk snapshot で conflict 検出
5. modal で A が conflict 表示、default `overwrite` で confirm
6. IDB が import data で上書きされ、未保存編集が消える

UI で何も警告が出なかった。

## Fix (Option D from impl plan)

| 挙動 | 動作 |
|---|---|
| `flushSave()` 1 回目失敗 | 1 回 retry |
| retry 成功 | `prepareImport` 続行、toast 出さない |
| retry も失敗 | toast + `BackupValidationError`、`readSnapshot` を呼ばず `importPlan` は null のまま |
| `flushSave` 未注入 | 既存挙動維持（旧 test/legacy 経路保持） |

`syncSlice` 側で 5 秒後の自動 retry が走るため、ユーザーは toast 後に少し待ってから再度 Import すれば解決可能。

## 設計判断（採用しなかった代替）

| 案 | 却下理由 |
|---|---|
| A (no retry, abort immediately) | transient blip に対して過剰 |
| B (confirm modal) | import flow にモーダル追加、common case (retry 成功) で UX 悪化 |
| C (warn toast + proceed) | toast 見落とし時の編集喪失窓口が残る |

## 新規テスト (3 ケース)

| ケース | 検証 |
|---|---|
| retry 成功 | flushSave 2 回呼ばれる、plan seeded、toast 出ない |
| 両方失敗 | flushSave 2 回、`readSnapshot` 呼ばれない、`importPlan` null 維持、toast に 2 回目エラーメッセージ含む、`BackupValidationError` throw |
| flushSave 未注入 | parseBackup → readSnapshot へ通常通り進む（既存挙動保持） |

## Test plan

- [x] `npm run test -- store/backupSlice.test.ts` → 32/32 PASS（29 → 32: +3）
- [x] `npm run test`（全体回帰）→ 247/247 PASS
- [x] `npm run lint`（`tsc --noEmit`）→ 0 errors
- [x] `npm run build` → built ok
- [ ] 手動検証（マージ後ユーザー側）: dev server で IDB 強制 locked にして Import → toast + 中止を観測

## Issue 進捗

`Refs #49`

- [x] **H2 (`prepareImport` flushSave UX) — 本 PR**
- [x] H4 (PR #52) / H5 (PR #52) / H6 (PR #51) / H10 (PR #54)
- [x] H6-followup-1/2 (PR #53)
- [x] H10-followup-1 (PR #55)
- [x] H10-followup-2/3 (PR #56)
- [ ] H10-followup-4/5/6 (rating ≤ 6、別 PR で監視)

これで Issue #49 の rating ≥ 7 項目はすべて消化、close 候補状態になります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)