### PR TITLE
feat(m4): flushSaveBlocking + BackupPreflightError 再設計 (H2 redesign)

### DIFF
--- a/store/backupSlice.test.ts
+++ b/store/backupSlice.test.ts
@@ -217,6 +217,121 @@ describe('prepareImport / executeImport (AC-3, AC-5)', () => {
         expect(fake.state.isImporting).toBe(false);
     });
 
+    // H2: prepareImport must not silently proceed when flushSaveBlocking
+    // fails — a stale on-disk snapshot would let the user's unsaved edits
+    // be silently overwritten by a subsequent overwrite resolution.
+    //
+    // The redesign uses flushSaveBlocking (not flushSave) because the
+    // legacy flushSave silently returns when saveStatus === 'saving',
+    // which would let an in-flight save go un-awaited. flushSaveBlocking
+    // awaits the in-flight promise and throws on actual save failure.
+    describe('H2 flushSaveBlocking failure handling', () => {
+        const minimalRaw = JSON.stringify({
+            schemaVersion: 1,
+            exportedAt: '2026-04-28T00:00:00.000Z',
+            appVersion: '0.0.0',
+            projects: [makeProject({ id: 'p-new' })],
+            tutorialState: {},
+            analysisHistory: [],
+        });
+
+        it('1st-attempt success: proceeds without retry, no toast', async () => {
+            readSnapshot.mockResolvedValue({ projects: [], tutorialState: {}, analysisHistory: [] });
+            const flushSaveBlocking = vi.fn().mockResolvedValue(undefined);
+            const fake = createFakeStore();
+            fake.set({ flushSaveBlocking });
+
+            const plan = await fake.state.prepareImport(minimalRaw);
+
+            // Common case: no retry needed, no nag toast.
+            expect(flushSaveBlocking).toHaveBeenCalledOnce();
+            expect(plan.backup.projects).toHaveLength(1);
+            expect(fake.state.importPlan).not.toBeNull();
+            expect((fake.state.showToast as any)).not.toHaveBeenCalled();
+        });
+
+        it('retries flushSaveBlocking once and proceeds when the retry succeeds', async () => {
+            readSnapshot.mockResolvedValue({ projects: [], tutorialState: {}, analysisHistory: [] });
+            const flushSaveBlocking = vi.fn()
+                .mockRejectedValueOnce(new Error('IDB locked'))
+                .mockResolvedValueOnce(undefined);
+            const fake = createFakeStore();
+            fake.set({ flushSaveBlocking });
+
+            const plan = await fake.state.prepareImport(minimalRaw);
+
+            // Retry actually happened (2 attempts), the import proceeded
+            // (plan is seeded), and we did NOT toast — a transient blip
+            // recovered should not nag the user.
+            expect(flushSaveBlocking).toHaveBeenCalledTimes(2);
+            expect(plan.backup.projects).toHaveLength(1);
+            expect(fake.state.importPlan).not.toBeNull();
+            expect((fake.state.showToast as any)).not.toHaveBeenCalled();
+        });
+
+        it('aborts with a toast + BackupPreflightError when both attempts fail', async () => {
+            const flushSaveBlocking = vi.fn()
+                .mockRejectedValueOnce(new Error('IDB locked (1)'))
+                .mockRejectedValueOnce(new Error('IDB locked (2)'));
+            const fake = createFakeStore();
+            fake.set({ flushSaveBlocking });
+
+            await expect(fake.state.prepareImport(minimalRaw)).rejects.toThrow(/インポートを中止/);
+
+            expect(flushSaveBlocking).toHaveBeenCalledTimes(2);
+            // readSnapshot must NOT have been called — aborting before
+            // touching the disk snapshot is the whole point.
+            expect(readSnapshot).not.toHaveBeenCalled();
+            expect(fake.state.importPlan).toBeNull();
+            expect((fake.state.showToast as any)).toHaveBeenCalledOnce();
+            const [message, kind] = (fake.state.showToast as any).mock.calls[0];
+            expect(message).toMatch(/IDB locked \(2\)/);
+            expect(kind).toBe('error');
+        });
+
+        it('timeout from flushSaveBlocking is treated like any other rejection (retried, then aborted)', async () => {
+            // The slice doesn't distinguish timeout from logical save failure
+            // — both are flushSaveBlocking rejections. Pin that the message
+            // surfaces in the toast so the user can tell which mode we're in.
+            const flushSaveBlocking = vi.fn()
+                .mockRejectedValueOnce(new Error('flushSave timed out after 10000ms'))
+                .mockRejectedValueOnce(new Error('flushSave timed out after 10000ms'));
+            const fake = createFakeStore();
+            fake.set({ flushSaveBlocking });
+
+            await expect(fake.state.prepareImport(minimalRaw)).rejects.toThrow(/インポートを中止/);
+            expect(flushSaveBlocking).toHaveBeenCalledTimes(2);
+            const [message] = (fake.state.showToast as any).mock.calls[0];
+            expect(message).toMatch(/timed out/);
+        });
+
+        it('legacy fallback: when flushSaveBlocking is not wired, falls back to best-effort flushSave', async () => {
+            // Existing tests + production code paths that wire only
+            // flushSave (not flushSaveBlocking) must keep working. We
+            // tolerate the original swallow-on-failure behavior in this
+            // legacy branch because the consumer didn't opt into the
+            // stronger contract.
+            readSnapshot.mockResolvedValue({ projects: [], tutorialState: {}, analysisHistory: [] });
+            const flushSave = vi.fn().mockResolvedValue(undefined);
+            const fake = createFakeStore();
+            fake.set({ flushSave });
+            // No flushSaveBlocking on the fake store.
+
+            const plan = await fake.state.prepareImport(minimalRaw);
+            expect(flushSave).toHaveBeenCalledOnce();
+            expect(plan.backup.projects).toHaveLength(1);
+            expect(fake.state.importPlan).not.toBeNull();
+        });
+
+        it('proceeds normally when neither flushSaveBlocking nor flushSave is wired (test/legacy)', async () => {
+            readSnapshot.mockResolvedValue({ projects: [], tutorialState: {}, analysisHistory: [] });
+            const fake = createFakeStore();
+            // No flush API of any kind.
+            const plan = await fake.state.prepareImport(minimalRaw);
+            expect(plan.backup.projects).toHaveLength(1);
+        });
+    });
+
     // H4: full prepareImport → setImportResolution → executeImport flow.
     // Existing tests cover the default-overwrite path; this block exercises
     // resolution mutation (skip / duplicate / mixed) so per-conflict resolutions

--- a/store/backupSlice.ts
+++ b/store/backupSlice.ts
@@ -37,8 +37,6 @@ type WithFlushSave = { flushSave?: () => Promise<void> };
 type WithFlushSaveBlocking = { flushSaveBlocking?: (timeoutMs?: number) => Promise<void> };
 type WithCloseModal = { closeModal?: () => void };
 
-const FLUSH_SAVE_PREFLIGHT_TIMEOUT_MS = 10_000;
-
 const errorMessage = (e: unknown): string =>
     e instanceof Error ? e.message : String(e);
 
@@ -172,22 +170,24 @@ export const createBackupSlice = (set, get): BackupSlice => ({
         // flushSave silently early-returns when saveStatus === 'saving',
         // which would let a still-in-flight save go un-awaited and let
         // prepareImport see a stale snapshot. flushSaveBlocking awaits the
-        // in-flight promise, then retriggers the flush if dirty/error,
-        // and throws on actual save failure so we abort instead of
-        // silently proceeding past a missed write.
+        // in-flight promise (propagating its rejection), then retriggers
+        // the flush if dirty/error, and throws on actual save failure so
+        // we abort instead of silently proceeding past a missed write.
         //
-        // Retry once before giving up. The sync slice already schedules a
-        // 5-second background retry on its own; one immediate retry here
-        // catches fast-recovery cases (transient quota, brief Dexie open
-        // race) without doubling overall latency.
+        // Retry once before giving up. flushSaveBlocking deliberately does
+        // NOT retry inside a single call — it surfaces in-flight failures
+        // so each layer can decide retry policy. We retry once here to
+        // catch fast-recovery cases (transient quota, brief Dexie open
+        // race); the sync slice's own SAVE_RETRY_DELAY_MS background timer
+        // handles slower recoveries on its own.
         const flushSaveBlocking = (get() as WithFlushSaveBlocking).flushSaveBlocking;
         if (flushSaveBlocking) {
             try {
-                await flushSaveBlocking(FLUSH_SAVE_PREFLIGHT_TIMEOUT_MS);
+                await flushSaveBlocking();
             } catch (firstError) {
                 console.error('flushSaveBlocking before prepareImport failed (1st):', firstError);
                 try {
-                    await flushSaveBlocking(FLUSH_SAVE_PREFLIGHT_TIMEOUT_MS);
+                    await flushSaveBlocking();
                 } catch (secondError) {
                     console.error('flushSaveBlocking before prepareImport failed (2nd, aborting):', secondError);
                     const detail = errorMessage(secondError);

--- a/store/backupSlice.ts
+++ b/store/backupSlice.ts
@@ -6,6 +6,7 @@ import {
     Project,
 } from '../types';
 import {
+    BackupPreflightError,
     BackupValidationError,
     buildBackupFilename,
     buildBackupV1,
@@ -33,7 +34,10 @@ const APP_VERSION: string = typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSI
 // is built only in store/index.ts; mirror authSlice's typed-cast pattern.
 type WithToast = { showToast?: (m: string, t?: 'info' | 'success' | 'error') => void };
 type WithFlushSave = { flushSave?: () => Promise<void> };
+type WithFlushSaveBlocking = { flushSaveBlocking?: (timeoutMs?: number) => Promise<void> };
 type WithCloseModal = { closeModal?: () => void };
+
+const FLUSH_SAVE_PREFLIGHT_TIMEOUT_MS = 10_000;
 
 const errorMessage = (e: unknown): string =>
     e instanceof Error ? e.message : String(e);
@@ -158,13 +162,54 @@ export const createBackupSlice = (set, get): BackupSlice => ({
 
     prepareImport: async (raw: string) => {
         // Flush in-memory edits to IndexedDB first so that conflict detection
-        // sees the user's latest unsaved work and overwrite/skip choices apply
-        // to the actual on-disk state. Without this, a project that the user
-        // is currently editing would not appear in conflicts.
-        try {
-            await (get() as WithFlushSave).flushSave?.();
-        } catch (e) {
-            console.error('flushSave before prepareImport failed:', e);
+        // sees the user's latest unsaved work and overwrite/skip choices
+        // apply to the actual on-disk state. Without this, a project that
+        // the user is currently editing would not appear in conflicts —
+        // and a subsequent overwrite resolution would silently drop the
+        // unsaved edit.
+        //
+        // H2 (Issue #49): we must use flushSaveBlocking, not flushSave.
+        // flushSave silently early-returns when saveStatus === 'saving',
+        // which would let a still-in-flight save go un-awaited and let
+        // prepareImport see a stale snapshot. flushSaveBlocking awaits the
+        // in-flight promise, then retriggers the flush if dirty/error,
+        // and throws on actual save failure so we abort instead of
+        // silently proceeding past a missed write.
+        //
+        // Retry once before giving up. The sync slice already schedules a
+        // 5-second background retry on its own; one immediate retry here
+        // catches fast-recovery cases (transient quota, brief Dexie open
+        // race) without doubling overall latency.
+        const flushSaveBlocking = (get() as WithFlushSaveBlocking).flushSaveBlocking;
+        if (flushSaveBlocking) {
+            try {
+                await flushSaveBlocking(FLUSH_SAVE_PREFLIGHT_TIMEOUT_MS);
+            } catch (firstError) {
+                console.error('flushSaveBlocking before prepareImport failed (1st):', firstError);
+                try {
+                    await flushSaveBlocking(FLUSH_SAVE_PREFLIGHT_TIMEOUT_MS);
+                } catch (secondError) {
+                    console.error('flushSaveBlocking before prepareImport failed (2nd, aborting):', secondError);
+                    const detail = errorMessage(secondError);
+                    (get() as WithToast).showToast?.(
+                        `未保存の編集が IndexedDB に書き込めませんでした（${detail}）。インポートを中止しました。数秒待ってからもう一度お試しください。`,
+                        'error',
+                    );
+                    throw new BackupPreflightError(
+                        `未保存の編集の保存に失敗したためインポートを中止しました: ${detail}`,
+                    );
+                }
+            }
+        } else {
+            // Legacy / test environments without the blocking API: keep
+            // the original best-effort flushSave so callers that haven't
+            // wired the new method (or unit tests stubbing only flushSave)
+            // continue to work.
+            try {
+                await (get() as WithFlushSave).flushSave?.();
+            } catch (e) {
+                console.error('flushSave before prepareImport failed (legacy path):', e);
+            }
         }
         const backup = parseBackup(raw);
         const snapshot = await readSnapshot();

--- a/store/syncSlice.test.ts
+++ b/store/syncSlice.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createSyncSlice, type SyncSlice } from './syncSlice';
+
+// Mock the IndexedDB write so the slice can run in node without a real DB.
+const putProject = vi.fn<(p: any) => Promise<void>>();
+
+vi.mock('../db/projectRepository', () => ({
+    putProject: (...args: unknown[]) => putProject(...(args as [any])),
+}));
+
+interface FakeStore {
+    state: SyncSlice & {
+        activeProjectId: string;
+        allProjectsData: Record<string, any>;
+        showToast?: ReturnType<typeof vi.fn>;
+    };
+    set: (partial: any) => void;
+    get: () => FakeStore['state'];
+}
+
+const createFakeStore = (): FakeStore => {
+    const fake: FakeStore = { state: {} as any, set: () => {}, get: () => fake.state };
+    fake.set = (partial: any) => {
+        const next = typeof partial === 'function' ? partial(fake.state) : partial;
+        fake.state = { ...fake.state, ...next };
+    };
+    fake.get = () => fake.state;
+    fake.state = {
+        ...createSyncSlice(fake.set, fake.get),
+        activeProjectId: 'p-1',
+        allProjectsData: { 'p-1': { id: 'p-1', name: 'P' } },
+        showToast: vi.fn(),
+    } as any;
+    return fake;
+};
+
+beforeEach(() => {
+    putProject.mockReset();
+    vi.useFakeTimers();
+});
+afterEach(() => {
+    // syncSlice schedules a 5s retry timer on save failure. In tests that
+    // exercise the failure path, that timer is still pending when we
+    // switch back to real timers — it would fire later and re-invoke
+    // flushSave with stale captured state. Clear all pending timers
+    // first to avoid cross-test pollution.
+    vi.clearAllTimers();
+    vi.useRealTimers();
+});
+
+describe('flushSaveBlocking (H2 redesign)', () => {
+    it('synced state: returns immediately without calling putProject', async () => {
+        const fake = createFakeStore();
+        // Default state is 'synced' so a blocking flush has nothing to do.
+        await fake.state.flushSaveBlocking(1000);
+        expect(putProject).not.toHaveBeenCalled();
+    });
+
+    it('dirty state: triggers a fresh flush and resolves on success', async () => {
+        const fake = createFakeStore();
+        putProject.mockResolvedValue(undefined);
+        fake.set({ saveStatus: 'dirty' });
+
+        await fake.state.flushSaveBlocking(1000);
+
+        expect(putProject).toHaveBeenCalledOnce();
+        expect(fake.state.saveStatus).toBe('synced');
+    });
+
+    it('saving state: awaits the in-flight promise instead of early-returning', async () => {
+        // Reproduce H2 root cause: with the old flushSave, calling it while
+        // saveStatus === 'saving' silently early-returned (apparent success
+        // while putProject was still in flight). flushSaveBlocking must
+        // wait on _savingPromise until the underlying putProject finishes.
+        const fake = createFakeStore();
+        let resolvePut!: () => void;
+        putProject.mockImplementationOnce(
+            () => new Promise<void>((res) => { resolvePut = res; }),
+        );
+
+        // Kick off the in-flight save; do NOT await yet.
+        fake.set({ saveStatus: 'dirty' });
+        const inFlight = fake.state.flushSave();
+        // The slice should now be in 'saving' with _savingPromise set.
+        expect(fake.state.saveStatus).toBe('saving');
+        expect(fake.state._savingPromise).not.toBeNull();
+
+        // Concurrent caller invokes flushSaveBlocking. It must NOT return
+        // before the in-flight putProject resolves.
+        let blockingDone = false;
+        const blocking = fake.state.flushSaveBlocking(5000).then(() => {
+            blockingDone = true;
+        });
+        await Promise.resolve(); // micro-task tick
+        expect(blockingDone).toBe(false);
+
+        // Now finish the in-flight save. Both promises should settle.
+        resolvePut();
+        await inFlight;
+        await blocking;
+        expect(blockingDone).toBe(true);
+        expect(fake.state.saveStatus).toBe('synced');
+        expect(putProject).toHaveBeenCalledOnce(); // no double-flush
+    });
+
+    it('saving state: in-flight rejection propagates to flushSaveBlocking', async () => {
+        const fake = createFakeStore();
+        let rejectPut!: (e: Error) => void;
+        putProject.mockImplementationOnce(
+            () => new Promise<void>((_, rej) => { rejectPut = rej; }),
+        );
+
+        fake.set({ saveStatus: 'dirty' });
+        const inFlight = fake.state.flushSave();
+        const blocking = fake.state.flushSaveBlocking(5000);
+
+        rejectPut(new Error('IDB quota exceeded'));
+        // syncSlice swallows the rejection internally (converts to
+        // saveStatus='error' + toast + retry timer), but flushSaveBlocking
+        // MUST throw so prepareImport can abort.
+        await inFlight;
+        await expect(blocking).rejects.toThrow(/quota exceeded/);
+        expect(fake.state.saveStatus).toBe('error');
+    });
+
+    it('error state: flushSaveBlocking re-flushes and surfaces the new failure', async () => {
+        const fake = createFakeStore();
+        // Pre-existing error state with a remembered message.
+        fake.set({ saveStatus: 'error', lastSyncError: 'previous attempt failed' });
+        putProject.mockRejectedValue(new Error('IDB still locked'));
+
+        await expect(fake.state.flushSaveBlocking(5000)).rejects.toThrow(/IDB still locked/);
+        expect(fake.state.saveStatus).toBe('error');
+    });
+
+    it('timeout: rejects with a timeout error if the work never settles', async () => {
+        const fake = createFakeStore();
+        // putProject hangs forever — simulates a stuck IndexedDB.
+        putProject.mockImplementation(() => new Promise(() => {}));
+        fake.set({ saveStatus: 'dirty' });
+
+        const blocking = fake.state.flushSaveBlocking(50);
+        // Attach the rejection handler BEFORE advancing fake timers so the
+        // synthetic reject() in setTimeout is observed as handled. Without
+        // this, Node's microtask check sees a rejected promise with no
+        // attached .catch yet and reports it as unhandled, which Vitest
+        // surfaces as a test-runner error.
+        const settled = blocking.then(
+            () => ({ kind: 'fulfilled' as const }),
+            (err: unknown) => ({ kind: 'rejected' as const, err }),
+        );
+        await vi.advanceTimersByTimeAsync(50);
+        const result = await settled;
+        expect(result.kind).toBe('rejected');
+        if (result.kind === 'rejected') {
+            expect((result.err as Error).message).toMatch(/timed out after 50ms/);
+        }
+    });
+
+    it('default timeout is generous enough that a normal save resolves first', async () => {
+        const fake = createFakeStore();
+        putProject.mockResolvedValue(undefined);
+        fake.set({ saveStatus: 'dirty' });
+
+        // Use the default timeout (no argument). The save resolves on the
+        // next microtask, so the timeout (10s) never fires.
+        await fake.state.flushSaveBlocking();
+        expect(fake.state.saveStatus).toBe('synced');
+    });
+
+    it('no active project: flushSaveBlocking returns without trying to write', async () => {
+        const fake = createFakeStore();
+        fake.set({ activeProjectId: '', saveStatus: 'synced' });
+        await fake.state.flushSaveBlocking(1000);
+        expect(putProject).not.toHaveBeenCalled();
+    });
+
+    it('saving → dirty → re-flush: in-flight save with _pendingFlush triggers a second putProject', async () => {
+        // PR #57 root-cause regression: when an edit lands during an
+        // in-flight save (_pendingFlush is set true), the slice becomes
+        // 'dirty' again immediately after the save resolves. Without
+        // flushSaveBlocking's status-recheck branch, prepareImport would
+        // observe a stale on-disk snapshot. Pin all three phases here:
+        // wait for in-flight, see dirty, re-flush.
+        const fake = createFakeStore();
+        let resolveFirst!: () => void;
+        let resolveSecond!: () => void;
+        putProject
+            .mockImplementationOnce(() => new Promise<void>((res) => { resolveFirst = res; }))
+            .mockImplementationOnce(() => new Promise<void>((res) => { resolveSecond = res; }));
+
+        // Kick off the in-flight save.
+        fake.set({ saveStatus: 'dirty' });
+        const inFlight = fake.state.flushSave();
+        expect(fake.state.saveStatus).toBe('saving');
+        // Simulate an edit during the save → markDirty sets _pendingFlush.
+        fake.state.markDirty();
+        expect(fake.state._pendingFlush).toBe(true);
+
+        // Now flushSaveBlocking enters: waits for in-flight, sees the
+        // post-resolve 'dirty' status (because _pendingFlush triggers
+        // markDirty inside flushSave's resolve path), re-flushes.
+        const blocking = fake.state.flushSaveBlocking(5000);
+
+        // Resolve the first save. Inside flushSave's success branch, it
+        // sets synced + clears _pendingFlush + calls markDirty(), which
+        // schedules a debounced flush. flushSaveBlocking must observe
+        // 'dirty' and call flushSave again.
+        resolveFirst();
+        await inFlight;
+        // Drain pending microtasks so flushSaveBlocking's status check
+        // runs and the second flushSave is scheduled.
+        await Promise.resolve();
+        await Promise.resolve();
+
+        // Second putProject should be in-flight by now.
+        expect(putProject).toHaveBeenCalledTimes(2);
+
+        resolveSecond();
+        await blocking;
+        expect(fake.state.saveStatus).toBe('synced');
+    });
+});

--- a/store/syncSlice.ts
+++ b/store/syncSlice.ts
@@ -7,15 +7,35 @@ export interface SyncSlice {
     // Set by markDirty/flushSave when saveStatus === 'saving'. flushSave checks it
     // post-await so writes during the in-flight putProject are not lost.
     _pendingFlush: boolean;
+    /**
+     * Settles when the current putProject() completes (resolve on success,
+     * reject with the underlying error on failure). Null when no save is
+     * in flight. Consumers awaiting "true flush completion" must await
+     * this — flushSave() itself returns immediately when `saveStatus`
+     * was already 'saving' to avoid stacking writes.
+     */
+    _savingPromise: Promise<void> | null;
     markDirty: () => void;
     flushSave: () => Promise<void>;
+    /**
+     * Wait until the active project is fully persisted. Differs from
+     * flushSave(): if a save is in flight, waits for it; if dirty/error,
+     * triggers and waits for a fresh flush; if synced, returns immediately.
+     * Throws on save failure (the caller — e.g. prepareImport — needs to
+     * abort instead of silently using a stale on-disk snapshot). Times
+     * out after `timeoutMs` so a hung IndexedDB can't deadlock the UI.
+     */
+    flushSaveBlocking: (timeoutMs?: number) => Promise<void>;
 }
+
+const FLUSH_SAVE_BLOCKING_DEFAULT_TIMEOUT_MS = 10_000;
 
 export const createSyncSlice = (set, get): SyncSlice => ({
     saveStatus: 'synced',
     lastSyncError: null,
     _saveTimer: null,
     _pendingFlush: false,
+    _savingPromise: null,
 
     markDirty: () => {
         const { _saveTimer, saveStatus } = get();
@@ -39,16 +59,36 @@ export const createSyncSlice = (set, get): SyncSlice => ({
             return;
         }
 
-        set({ saveStatus: 'saving' as const, _saveTimer: null, _pendingFlush: false });
+        // Build an externally-resolvable promise so callers awaiting via
+        // flushSaveBlocking() can observe the actual disk-write completion
+        // (resolve) or failure (reject) — not the early-return resolve.
+        let resolveSavingPromise: () => void;
+        let rejectSavingPromise: (e: unknown) => void;
+        const savingPromise = new Promise<void>((res, rej) => {
+            resolveSavingPromise = res;
+            rejectSavingPromise = rej;
+        });
+        // Suppress unhandled rejection if no one awaits us — we still
+        // surface failure via saveStatus + toast in the catch block.
+        savingPromise.catch(() => {});
+
+        set({
+            saveStatus: 'saving' as const,
+            _saveTimer: null,
+            _pendingFlush: false,
+            _savingPromise: savingPromise,
+        });
 
         try {
             const project = allProjectsData[activeProjectId];
             await putProject(project);
             if (get()._pendingFlush) {
-                set({ saveStatus: 'synced' as const, lastSyncError: null, _pendingFlush: false });
+                set({ saveStatus: 'synced' as const, lastSyncError: null, _pendingFlush: false, _savingPromise: null });
+                resolveSavingPromise!();
                 get().markDirty();
             } else {
-                set({ saveStatus: 'synced' as const, lastSyncError: null });
+                set({ saveStatus: 'synced' as const, lastSyncError: null, _savingPromise: null });
+                resolveSavingPromise!();
             }
         } catch (error: any) {
             console.error('Failed to save project:', error);
@@ -60,11 +100,77 @@ export const createSyncSlice = (set, get): SyncSlice => ({
                 lastSyncError: error.message,
                 _pendingFlush: false,
                 _saveTimer: retryTimer,
+                _savingPromise: null,
             });
             (get() as any).showToast?.(
                 `保存に失敗しました（5秒後に自動再試行します）: ${error.message}`,
                 'error',
             );
+            rejectSavingPromise!(error);
         }
+    },
+
+    flushSaveBlocking: async (timeoutMs = FLUSH_SAVE_BLOCKING_DEFAULT_TIMEOUT_MS) => {
+        const work = async () => {
+            // 1. If a save is already in flight, wait for IT to finish first.
+            //    Without this, callers see a "synced" race where flushSave
+            //    short-circuits while putProject is still in flight on the
+            //    other branch.
+            const inFlight = get()._savingPromise;
+            if (inFlight) {
+                // The in-flight save's failure is the caller's failure —
+                // propagate it (the throw is caught by the outer
+                // .catch below).
+                await inFlight;
+            }
+            // 2. After waiting, the slice may be dirty (a markDirty fired
+            //    during the in-flight save — _pendingFlush=true path) or
+            //    error (the in-flight save rejected). Trigger a fresh
+            //    flush in either case.
+            //    Note: flushSave never throws — it converts failures into
+            //    saveStatus='error' + a 5s retry timer. We must re-check
+            //    saveStatus afterwards rather than relying on the await
+            //    to surface failure. activeProjectId-less stores leave
+            //    saveStatus untouched ('synced'), which is correctly
+            //    treated as nothing-to-do here.
+            const status = get().saveStatus;
+            if (status === 'dirty' || status === 'error') {
+                await get().flushSave();
+                if (get().saveStatus === 'error') {
+                    throw new Error(get().lastSyncError ?? 'save failed');
+                }
+            }
+            // 3. Otherwise the slice is already synced → nothing to do.
+        };
+
+        // Use a constructed Promise (not Promise.race + a separately
+        // constructed timeout Promise) so the timeout rejection is always
+        // owned by a settled-flag-guarded reject() call. Promise.race +
+        // a free-standing rejecting Promise leaves the loser's rejection
+        // un-awaited, which Node reports as an unhandled rejection in
+        // certain test runners.
+        return new Promise<void>((resolve, reject) => {
+            let settled = false;
+            const timer = setTimeout(() => {
+                if (settled) return;
+                settled = true;
+                reject(new Error(`flushSave timed out after ${timeoutMs}ms`));
+            }, timeoutMs);
+
+            work().then(
+                () => {
+                    if (settled) return;
+                    settled = true;
+                    clearTimeout(timer);
+                    resolve();
+                },
+                (err) => {
+                    if (settled) return;
+                    settled = true;
+                    clearTimeout(timer);
+                    reject(err);
+                },
+            );
+        });
     },
 });

--- a/store/syncSlice.ts
+++ b/store/syncSlice.ts
@@ -1,5 +1,20 @@
 import { putProject } from '../db/projectRepository';
 
+/**
+ * Delay before the auto-retry kicks in after a save failure. Single source
+ * of truth for both the timer (in flushSave's catch) and the user-facing
+ * toast text — a literal mismatch would lie to the user.
+ */
+export const SAVE_RETRY_DELAY_MS = 5_000;
+
+/**
+ * Default ceiling for flushSaveBlocking. A hung IndexedDB shouldn't be able
+ * to deadlock the UI for longer than this. prepareImport reuses this value
+ * directly; callers that genuinely need a different deadline should pass
+ * their own.
+ */
+export const FLUSH_SAVE_BLOCKING_DEFAULT_TIMEOUT_MS = 10_000;
+
 export interface SyncSlice {
     saveStatus: 'synced' | 'saving' | 'dirty' | 'error';
     lastSyncError: string | null;
@@ -13,22 +28,38 @@ export interface SyncSlice {
      * in flight. Consumers awaiting "true flush completion" must await
      * this — flushSave() itself returns immediately when `saveStatus`
      * was already 'saving' to avoid stacking writes.
+     *
+     * Internal — exposed on the interface only because Zustand slices
+     * can't use TypeScript `private`. External code MUST NOT mutate this
+     * directly; corrupting the field will break in-flight tracking and
+     * silently break flushSaveBlocking. The underscore prefix follows
+     * the existing internal-field convention (_saveTimer, _pendingFlush).
      */
     _savingPromise: Promise<void> | null;
     markDirty: () => void;
     flushSave: () => Promise<void>;
     /**
-     * Wait until the active project is fully persisted. Differs from
-     * flushSave(): if a save is in flight, waits for it; if dirty/error,
-     * triggers and waits for a fresh flush; if synced, returns immediately.
-     * Throws on save failure (the caller — e.g. prepareImport — needs to
-     * abort instead of silently using a stale on-disk snapshot). Times
-     * out after `timeoutMs` so a hung IndexedDB can't deadlock the UI.
+     * Wait until the active project is fully persisted, then resolve.
+     * Behavior:
+     * - synced: returns immediately (no-op).
+     * - saving (a putProject is in flight): awaits `_savingPromise`. If
+     *   that in-flight save **rejects**, this method rejects with the
+     *   same error — the caller decides whether to retry. We do NOT
+     *   silently retry inside the same call; doing so would obscure
+     *   transient failures and mask repeated cross-tab races.
+     * - dirty / error (no save in flight, but pending changes): triggers
+     *   a fresh flushSave() and awaits its outcome. flushSave never
+     *   throws (it converts failures into saveStatus='error'), so we
+     *   re-check saveStatus after the await and throw to surface a
+     *   real failure to the caller.
+     *
+     * Times out after `timeoutMs` (default
+     * `FLUSH_SAVE_BLOCKING_DEFAULT_TIMEOUT_MS`) so a hung IndexedDB
+     * can't deadlock the UI. The caller (e.g. prepareImport) is expected
+     * to retry once on rejection before giving up to the user.
      */
     flushSaveBlocking: (timeoutMs?: number) => Promise<void>;
 }
-
-const FLUSH_SAVE_BLOCKING_DEFAULT_TIMEOUT_MS = 10_000;
 
 export const createSyncSlice = (set, get): SyncSlice => ({
     saveStatus: 'synced',
@@ -94,7 +125,7 @@ export const createSyncSlice = (set, get): SyncSlice => ({
             console.error('Failed to save project:', error);
             // Schedule a retry so subsequent edits aren't stranded by a transient
             // failure (quota / DB closed by another tab / Dexie open race).
-            const retryTimer = setTimeout(() => get().flushSave(), 5000);
+            const retryTimer = setTimeout(() => get().flushSave(), SAVE_RETRY_DELAY_MS);
             set({
                 saveStatus: 'error' as const,
                 lastSyncError: error.message,
@@ -103,7 +134,7 @@ export const createSyncSlice = (set, get): SyncSlice => ({
                 _savingPromise: null,
             });
             (get() as any).showToast?.(
-                `保存に失敗しました（5秒後に自動再試行します）: ${error.message}`,
+                `保存に失敗しました（${SAVE_RETRY_DELAY_MS / 1000}秒後に自動再試行します）: ${error.message}`,
                 'error',
             );
             rejectSavingPromise!(error);
@@ -112,27 +143,30 @@ export const createSyncSlice = (set, get): SyncSlice => ({
 
     flushSaveBlocking: async (timeoutMs = FLUSH_SAVE_BLOCKING_DEFAULT_TIMEOUT_MS) => {
         const work = async () => {
-            // 1. If a save is already in flight, wait for IT to finish first.
-            //    Without this, callers see a "synced" race where flushSave
-            //    short-circuits while putProject is still in flight on the
-            //    other branch.
+            // 1. If a save is already in flight, wait for IT. If it rejects,
+            //    propagate the failure to the caller — DO NOT silently retry
+            //    inside this same call. Letting the caller see the rejection
+            //    keeps the contract clear (in-flight failure is the caller's
+            //    failure, not a hidden retry) and preserves their ability
+            //    to decide retry policy. prepareImport, for example, retries
+            //    once at its layer before alerting the user.
             const inFlight = get()._savingPromise;
             if (inFlight) {
-                // The in-flight save's failure is the caller's failure —
-                // propagate it (the throw is caught by the outer
-                // .catch below).
                 await inFlight;
+                // Successful in-flight save — the slice may now be 'dirty'
+                // because a markDirty during the save set _pendingFlush,
+                // which flushSave's success path translates back to dirty
+                // via markDirty(). Fall through to the dirty/error branch
+                // below so we re-flush.
             }
-            // 2. After waiting, the slice may be dirty (a markDirty fired
-            //    during the in-flight save — _pendingFlush=true path) or
-            //    error (the in-flight save rejected). Trigger a fresh
-            //    flush in either case.
-            //    Note: flushSave never throws — it converts failures into
-            //    saveStatus='error' + a 5s retry timer. We must re-check
-            //    saveStatus afterwards rather than relying on the await
-            //    to surface failure. activeProjectId-less stores leave
-            //    saveStatus untouched ('synced'), which is correctly
-            //    treated as nothing-to-do here.
+            // 2. dirty (markDirty fired during in-flight or unrelated edit)
+            //    or error (a previous failed flush parked here): trigger
+            //    a fresh flush. flushSave never throws — it converts
+            //    failures into saveStatus='error' + a SAVE_RETRY_DELAY_MS
+            //    retry timer. Re-check saveStatus afterwards rather than
+            //    relying on await to surface failure.
+            //    activeProjectId-less stores leave saveStatus untouched
+            //    ('synced'), which is correctly treated as nothing-to-do.
             const status = get().saveStatus;
             if (status === 'dirty' || status === 'error') {
                 await get().flushSave();

--- a/utils/backupSchema.ts
+++ b/utils/backupSchema.ts
@@ -14,6 +14,20 @@ export class BackupValidationError extends Error {
     }
 }
 
+/**
+ * Thrown by prepareImport when the *preflight* (flushSave-blocking)
+ * step fails — i.e. before any backup parsing happens. Distinct from
+ * BackupValidationError which is reserved for malformed backup files.
+ * Aborting at this layer prevents the silent edit-loss path where a
+ * stale on-disk snapshot would be used for conflict detection.
+ */
+export class BackupPreflightError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'BackupPreflightError';
+    }
+}
+
 const isObject = (v: unknown): v is Record<string, unknown> =>
     !!v && typeof v === 'object' && !Array.isArray(v);
 


### PR DESCRIPTION
## Summary

- Issue #49 H2 (rating 7) の再設計実装。**[closed PR #57](https://github.com/Yukina1116/novel-writer/pull/57) を置き換え**
- silent edit-loss path の真の閉鎖（`saveStatus === 'saving'` 中の `flushSave` silent resolve 経路を含む）
- 5 ファイル変更 → CLAUDE.md `Quality Gate` で **Evaluator 分離プロトコル発動**、Evaluator subagent **APPROVE** 判定取得済

## Why redesign (PR #57 closed)

PR #57 は `prepareImport` の `flushSave` rejection を catch して abort する設計だったが、`/review-pr` の silent-failure-hunter が致命的欠陥を指摘:

> 既存 `flushSave` は `saveStatus === 'saving'` 中に **throw せずに即 resolve**（`syncSlice.ts:37-40`）。`prepareImport` の catch wrapper は in-flight failure を観測できず、silent edit-loss path が残存。

→ `prepareImport` 単独で fix できず、`syncSlice` 側に「真の flush 完了を保証する API」が必要と判明、再設計。

## 変更内容

### `store/syncSlice.ts` (+108)

| 追加 | 役割 |
|---|---|
| `_savingPromise: Promise<void> \| null` | in-flight putProject の lifetime を表現する externally-resolvable promise。成功で resolve、失敗で reject |
| `flushSaveBlocking(timeoutMs = 10_000): Promise<void>` | 真の flush 完了を保証する新 API |

`flushSaveBlocking` の挙動:
1. `_savingPromise` 存在 → await（失敗を伝播）
2. await 後 saveStatus が `'dirty'` (`_pendingFlush` 経路) or `'error'` → 新 `flushSave()` 起動 → 結果再確認、`error` なら throw
3. `'synced'` → no-op

設計判断: `Promise.race` + 別構築 timeout Promise は fake timer 環境で unhandled rejection を起こすため、`Promise constructor + settled flag` 構造を採用。

### `utils/backupSchema.ts` (+14)

`BackupPreflightError` クラス新設。`BackupValidationError`（malformed backup file 用）と分離してセマンティクス明確化。

### `store/backupSlice.ts` (+59)

`prepareImport`:
- `flushSaveBlocking` 利用（10 秒 timeout）
- 1 回 retry → 再失敗で toast + `BackupPreflightError`、`readSnapshot` 呼ばず `importPlan` null 維持
- Legacy fallback: `flushSaveBlocking` 未注入時は best-effort `flushSave`（既存テスト + production 経路保護）

### `store/syncSlice.test.ts` (新規 +223、9 ケース)

| # | 検証 |
|---|---|
| 1 | synced → no-op |
| 2 | dirty → flush |
| 3 | **saving → in-flight 待機 (PR #57 根本原因)** |
| 4 | saving rejection 伝播 |
| 5 | error 再 flush |
| 6 | timeout |
| 7 | default timeout は通常 save で発火しない |
| 8 | no active project |
| 9 | **saving → dirty (`_pendingFlush`) → 再 flush (PR #57 深層シナリオ)** |

### `store/backupSlice.test.ts` (+115、H2 で +6 ケース)
1st-attempt 成功 / retry 成功 / 両方失敗（`readSnapshot` 未呼出 + toast + `BackupPreflightError` throw）/ timeout 経由 abort / legacy `flushSave` fallback / 完全 flush 未注入

## Quality Gate (Evaluator 分離プロトコル)

5 ファイル変更 + 新機能 → CLAUDE.md `~/.claude/rules/quality-gate.md` の発動条件達成。別コンテキストの **Evaluator subagent で第三者評価を実施**:

> **Verdict: APPROVE**. 全 AC (1-5) PASS、HIGH 問題なし。LOW 2 件（コメント不足、saving→dirty→再 flush 回帰テスト欠如）→ 本 PR で両方対応済。

## Test plan

- [x] `npm run test -- store/syncSlice.test.ts` → 9/9 PASS
- [x] `npm run test -- store/backupSlice.test.ts` → 35/35 PASS
- [x] `npm run test`（全体回帰）→ 259/259 PASS (12 → 13 files)
- [x] `npm run lint`（`tsc --noEmit`）→ 0 errors
- [x] `npm run build` → built ok
- [ ] **手動検証（マージ後ユーザー側）**: dev server で saving 中に Import → toast + 中止を観測

## Issue 進捗

`Refs #49`

- [x] **H2 (`prepareImport` flushSave UX、再設計) — 本 PR**
- [x] H4 (PR #52) / H5 (PR #52) / H6 (PR #51) / H10 (PR #54)
- [x] H6-followup-1/2 (PR #53)
- [x] H10-followup-1 (PR #55)
- [x] H10-followup-2/3 (PR #56)
- [ ] H10-followup-4/5/6 (rating ≤ 6、別 PR で監視)

これで Issue #49 の rating ≥ 7 項目はすべて消化、Issue close 候補状態になります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)