### PR TITLE
fix(m7): useGlobalErrorHandlers.test.ts の CI fragility 解消

### DIFF
--- a/hooks/useGlobalErrorHandlers.test.ts
+++ b/hooks/useGlobalErrorHandlers.test.ts
@@ -1,10 +1,22 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import {
+
+// `useGlobalErrorHandlers.ts` は top-level で `useStore` を import し、その import
+// チェーンは `authSlice.ts` → `firebaseClient.ts` (VITE_FIREBASE_* env 必須) まで到達する。
+// CI 環境 (.env なし) でモジュール load 時に throw する経路を遮断するため、
+// vi.mock で `../store/index` を stub する。本テストは buildHandlers の引数注入版を
+// 検証する設計のため、useStore の実体は使わない。
+vi.mock('../store/index', () => ({
+    useStore: {
+        getState: () => ({ showToast: () => {} }),
+    },
+}));
+
+const {
     GLOBAL_ERROR_MESSAGE,
     UNHANDLED_REJECTION_MESSAGE,
     buildHandlers,
     registerGlobalErrorHandlers,
-} from './useGlobalErrorHandlers';
+} = await import('./useGlobalErrorHandlers');
 
 // `useGlobalErrorHandlers` は React hook のため node 環境では実 render 不可。
 // 純粋関数の `registerGlobalErrorHandlers` (window event listener の登録/解放) を


### PR DESCRIPTION
## Summary

PR #62 (PR-C) で導入した `hooks/useGlobalErrorHandlers.test.ts` が CI で FAIL する問題の hotfix。

## 問題

CI 失敗ログ (run 25053978926):
\`\`\`
Error: Firebase config missing required VITE_FIREBASE_* env: apiKey, authDomain, projectId, appId.
 ❯ firebaseClient.ts:18:11
 ❯ apiClient.ts:3:31
\`\`\`

- ローカルでは \`.env\` があるため PASS、CI で FAIL のクラシックパターン
- 原因: \`useGlobalErrorHandlers.ts\` の top-level \`useStore\` import が \`authSlice → firebaseClient\` まで到達

## 修正

\`vi.mock('../store/index', ...)\` を test 冒頭に追加し、import チェーンを遮断。本テストは \`buildHandlers\` の引数注入版を検証する設計のため、\`useStore\` 実体は使わない。他の FE テストはすでに同等パターンで対応済 (\`authSlice.test.ts\` / \`apiClient.test.ts\` / \`useLocalSync.test.ts\`)。

## Test plan

- [x] ローカルで CI 環境再現 (env を空に設定して \`npm run test\`) → 315/315 PASS
- [x] tsc --noEmit 0 errors
- [ ] 本 PR merge 後の Cloud Run deploy CI が success することを確認

## 関連

- 失敗 CI: run 25053978926 (PR #64 push 由来、main で deploy 失敗)
- 起源: PR #62 (PR-C) の test ファイル

🤖 Generated with [Claude Code](https://claude.com/claude-code)