### PR TITLE
docs(m7): ADR-0001 M7-α 完了反映 + CLAUDE.md に refreshCurrentTermsVersion / shared/termsCodes 追記

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ Browser → fetch(/api/*) → server/routes/ → server/services/ → Vertex AI 
 - **usage クォータ**: `server/services/usageService.ts` (reserve/commit/cancel + transaction 予約 + requestId 冪等)、`server/middleware/withUsageQuota.ts` (高階関数ラップ)、`server/services/usageConfig.ts` (Tier 1=月 100 円 + route 別 sen)。詳細は `docs/spec/m3/usage-cost-config.md`
 - **エラー分類**: `server/middleware/errorHandler.ts` の `handleApiError(error, fn, context: 'ai' | 'firestore' | 'usage')` で文言と分類戦略を context 別に切替（M3 PR-F で table-driven 化、context 必須）
 - **フロントエンドAPI**: ルート直下の `*Api.ts` はfetchラッパー（`apiClient.ts`経由）。`apiClient.ts` が Bearer 自動付与 + `requestId` 自動生成 + 401/429/503/409 を `AuthGateErrorCode` 列挙でユーザー向け文言に分類（M3 PR-G）。Project の永続化 API（旧 `projectApi.ts`）は M2 PR-A で削除済み
-- **FE/BE 共有定数**: `shared/termsCodes.ts` — `TERMS_VERSION_MISMATCH_CODE = 'TERMS_VERSION_MISMATCH'` + `TermsVersionMismatchCode` 型を export（M7-α PR-D-2、`server/services/termsConfig.ts` は `shared/` から re-export）。FE/BE が直接 import することで stringly-typed リテラルの drift を排除し、同コードの双方向 pin テストで保証
+- **FE/BE 共有定数**: `shared/termsCodes.ts` — `TERMS_VERSION_MISMATCH_CODE = 'TERMS_VERSION_MISMATCH'` + `TermsVersionMismatchCode` 型を export（M7-α PR-D-2、`server/services/termsConfig.ts` は `shared/` から re-export）。FE/BE が直接 import することで stringly-typed リテラルの drift を排除し、`shared/termsCodes.test.ts` の literal-value pin テストで FE/BE 双方の参照先を保証
 - **同意 UI**: `components/modals/TermsConsentModal.tsx` — `role="alertdialog"` + ModalManager 先頭分岐 (`needsTermsAccept && !isTermsDevBypass()`) で他モーダルより優先 mount。`isTermsDevBypass()` は dev-only `?skip-terms=1` query 評価（PROD ガード + SSR-safe ガード）。M7-α PR-D-2 で導入。Footer 3 link (`legalDocs.ts` の LEGAL_DOCS) は Desktop / ProjectSelection / Mobile 全 view に配置
 
 ### 状態管理（Zustand slices pattern）

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,8 @@ Browser → fetch(/api/*) → server/routes/ → server/services/ → Vertex AI 
 - **usage クォータ**: `server/services/usageService.ts` (reserve/commit/cancel + transaction 予約 + requestId 冪等)、`server/middleware/withUsageQuota.ts` (高階関数ラップ)、`server/services/usageConfig.ts` (Tier 1=月 100 円 + route 別 sen)。詳細は `docs/spec/m3/usage-cost-config.md`
 - **エラー分類**: `server/middleware/errorHandler.ts` の `handleApiError(error, fn, context: 'ai' | 'firestore' | 'usage')` で文言と分類戦略を context 別に切替（M3 PR-F で table-driven 化、context 必須）
 - **フロントエンドAPI**: ルート直下の `*Api.ts` はfetchラッパー（`apiClient.ts`経由）。`apiClient.ts` が Bearer 自動付与 + `requestId` 自動生成 + 401/429/503/409 を `AuthGateErrorCode` 列挙でユーザー向け文言に分類（M3 PR-G）。Project の永続化 API（旧 `projectApi.ts`）は M2 PR-A で削除済み
+- **FE/BE 共有定数**: `shared/termsCodes.ts` — `TERMS_VERSION_MISMATCH_CODE = 'TERMS_VERSION_MISMATCH'` + `TermsVersionMismatchCode` 型を export（M7-α PR-D-2、`server/services/termsConfig.ts` は `shared/` から re-export）。FE/BE が直接 import することで stringly-typed リテラルの drift を排除し、同コードの双方向 pin テストで保証
+- **同意 UI**: `components/modals/TermsConsentModal.tsx` — `role="alertdialog"` + ModalManager 先頭分岐 (`needsTermsAccept && !isTermsDevBypass()`) で他モーダルより優先 mount。`isTermsDevBypass()` は dev-only `?skip-terms=1` query 評価（PROD ガード + SSR-safe ガード）。M7-α PR-D-2 で導入。Footer 3 link (`legalDocs.ts` の LEGAL_DOCS) は Desktop / ProjectSelection / Mobile 全 view に配置
 
 ### 状態管理（Zustand slices pattern）
 
@@ -74,7 +76,7 @@ Browser → fetch(/api/*) → server/routes/ → server/services/ → Vertex AI 
 | tutorialSlice | 5種チュートリアルの進捗（IndexedDB の `tutorialState` ストア） |
 | analysisHistorySlice | テキストインポート分析の履歴（IndexedDB の `analysisHistory` ストア） |
 | formSlice | フォーム状態 |
-| authSlice | Firebase Auth 状態（`currentUser` / `authStatus: 'initializing' \| 'unauthenticated' \| 'authenticated'` / `authError` / `needsUserInit` / `retryUserInit()`、M7-α PR-D-1 で `termsAcceptedAt` / `termsVersion` / `currentTermsVersion` / `needsTermsAccept` (派生) / `termsAccepting` / `acceptTerms()` 追加、IndexedDB は uid に紐付けない設計、M2 PR-B で導入、M3 PR-G で users/init transient retry signal 追加） |
+| authSlice | Firebase Auth 状態（`currentUser` / `authStatus: 'initializing' \| 'unauthenticated' \| 'authenticated'` / `authError` / `needsUserInit` / `retryUserInit()`、M7-α PR-D-1 で `termsAcceptedAt` / `termsVersion` / `currentTermsVersion` / `needsTermsAccept` (派生) / `termsAccepting` / `acceptTerms()` 追加、PR-D-2 で `refreshCurrentTermsVersion()` (TERMS_VERSION_MISMATCH 時に users/init を再 fetch して `currentTermsVersion` のみ更新、`needsUserInit` には触れない) + `isTermsVersionMismatch(error)` helper を追加、IndexedDB は uid に紐付けない設計、M2 PR-B で導入、M3 PR-G で users/init transient retry signal 追加） |
 | backupSlice | 全データバックアップ (`exportAllData` / `prepareImport` / `executeImport` / `cancelImport` / `setImportResolution` / `isBackupStale`)、`lastExportedAt` + `backupMetaStatus: 'unknown' \| 'loaded'` sentinel、`importPlan: { backup: BackupV1, conflicts: ImportConflict[] }`、M4 で導入 |
 
 ### バックアップ層 (M4)

--- a/docs/adr/0001-local-first-architecture.md
+++ b/docs/adr/0001-local-first-architecture.md
@@ -91,7 +91,7 @@
 | M4 | Export/Import + バックアップ警告 UI | ✅ 完了（PR #48 2026-04-28） |
 | M5 | Stripe Subscription + Webhook + 法務 Tier 2 | ⏳ |
 | M6 | E2EE 暗号化バックアップ（任意機能、後回し可） | ⏳ |
-| M7-α | 公開準備 (Tier 0/1 法務 stub + 観測性 + エラー報告動線、Stripe 不要範囲) | 🚧 進行中 (2026-04-28 着手、`docs/spec/m7/tasks.md` 参照) |
+| M7-α | 公開準備 (Tier 0/1 法務 stub + 観測性 + エラー報告動線、Stripe 不要範囲) | ✅ 完了 (PR-A 観測性 / PR-B エラー報告 / PR-C 法務 stub / PR-D-1 BE accept-terms / PR-D-2 同意 UI、PR #67 で 2026-04-28 締め、本番公開前法務確認 MUST) |
 | M7-β | 公開最終チェック (Tier 2 規約節 + 特商法本文確定、M5 完了後) | ⏳ |
 
 詳細は `docs/spec/m1/tasks.md` 以降を参照。


### PR DESCRIPTION
## Summary

PR #67 (PR-D-2 同意 UI) merge により M7-α (P4) コードベース 100% 完了。`docs/handoff/LATEST.md` L129-130 が指示するドキュメント同期を実行。

- **ADR-0001 Implementation Roadmap**: M7-α 行を 🚧 進行中 → ✅ 完了 に更新（PR-A 観測性 / PR-B エラー報告 / PR-C 法務 stub / PR-D-1 BE accept-terms / PR-D-2 同意 UI、本番公開前法務確認 MUST 注記）
- **CLAUDE.md authSlice 行**: PR-D-2 で追加された `refreshCurrentTermsVersion()` action と `isTermsVersionMismatch(error)` helper を追記
- **CLAUDE.md API 層**: `shared/termsCodes.ts` (FE/BE 共有定数 + 双方向 pin テスト) と `TermsConsentModal` (ModalManager 先頭分岐 + dev bypass 関数化、Footer 配置) を独立項目として追加

## Test plan

設定/ドキュメントのみの PR (CLAUDE.md L7 規定の構文検証＋次セッション確認で可):

- [x] `npm run lint` (tsc --noEmit) → 0 errors
- [x] git diff レビュー (4 行追加 / 2 行修正、機能変更なし)
- [ ] 次セッションの `/catchup` で ADR-0001 / CLAUDE.md の整合性が保たれていることを確認
- [ ] merge 後、Cloud Run deploy CI が成功すること（ドキュメントのみのため build/test は影響なしの想定）

## Issue Net 変化

- Close: 0 件
- 起票: 0 件
- **Net: 0 件**

🤖 Generated with [Claude Code](https://claude.com/claude-code)