### PR TITLE
refactor(m7): hasNumericStatus helper 抽出で type guard 重複解消 (Issue #49 D2-followup-3)

### DIFF
--- a/store/authSlice.ts
+++ b/store/authSlice.ts
@@ -79,8 +79,14 @@ export interface UserInitError extends Error {
     status: number;
 }
 
-const isUserInitError = (e: unknown): e is UserInitError =>
+// Shared predicate for Error-with-numeric-status carriers (UserInitError /
+// AcceptTermsError). Pulled out so the two wrappers stay literally identical
+// and `isTermsVersionMismatch` can layer code-checks directly on top without
+// indirecting through a near-empty wrapper.
+const hasNumericStatus = <T extends Error>(e: unknown): e is T & { status: number } =>
     e instanceof Error && typeof (e as { status?: unknown }).status === 'number';
+
+const isUserInitError = (e: unknown): e is UserInitError => hasNumericStatus<UserInitError>(e);
 
 const makeUserInitError = (message: string, status: number): UserInitError => {
     const err = new Error(message) as UserInitError;
@@ -174,11 +180,8 @@ export interface AcceptTermsError extends Error {
     code?: string;
 }
 
-const isAcceptTermsError = (e: unknown): e is AcceptTermsError =>
-    e instanceof Error && typeof (e as { status?: unknown }).status === 'number';
-
 export const isTermsVersionMismatch = (error: unknown): boolean =>
-    isAcceptTermsError(error)
+    hasNumericStatus<AcceptTermsError>(error)
     && error.status === 409
     && error.code === TERMS_VERSION_MISMATCH_CODE;
 

--- a/store/authSlice.ts
+++ b/store/authSlice.ts
@@ -79,10 +79,6 @@ export interface UserInitError extends Error {
     status: number;
 }
 
-// Shared predicate for Error-with-numeric-status carriers (UserInitError /
-// AcceptTermsError). Pulled out so the two wrappers stay literally identical
-// and `isTermsVersionMismatch` can layer code-checks directly on top without
-// indirecting through a near-empty wrapper.
 const hasNumericStatus = <T extends Error>(e: unknown): e is T & { status: number } =>
     e instanceof Error && typeof (e as { status?: unknown }).status === 'number';
 


### PR DESCRIPTION
## Summary

Issue #49 (M4 follow-up umbrella) の **D2-followup-3** (rating 7、code-simplifier) を解消。

`isUserInitError` / `isAcceptTermsError` の predicate 本体が `e instanceof Error && typeof (e as { status?: unknown }).status === 'number'` で完全同型だった重複を、generic helper `hasNumericStatus<T extends Error>` に統合。

## 変更内容

- `hasNumericStatus<T extends Error>(e: unknown): e is T & { status: number }` を新設
- `isUserInitError` は thin wrapper として残置（call sites L302/L340 が semantic に「users/init error?」を問う形のため）
- `isAcceptTermsError` は唯一の caller である `isTermsVersionMismatch` 内に inline。`isTermsVersionMismatch` が直接 `hasNumericStatus<AcceptTermsError>` の上に code 判定を重ねる形となり、near-empty wrapper の indirection を削除

## 設計判断

**意図明確化を優先**: Issue は「`isTermsVersionMismatch` が hasNumericStatus の上に code 判定を重ねる形」を求めており、`isAcceptTermsError` のローカル wrapper は意味を持たないため inline。一方 `isUserInitError` は 2 箇所の transient retry 経路で意味的に名乗る価値があるため wrapper として残置。

挙動変更なし。Type narrowing も同等 (`T & { status: number }` で UserInitError / AcceptTermsError の status 必須が保たれる)。

## Test plan

- [x] `npm run lint` (tsc --noEmit) → 0 errors
- [x] `npx vitest run store/authSlice` → 24/24 PASS（type guard 経路の TERMS_VERSION_MISMATCH / transient retry / in-flight Promise pattern を網羅）
- [x] `npm test` (全スイート) → 339/339 PASS（回帰なし）
- [ ] 次セッションの `/catchup` で Issue #49 のステータス再確認、D2-followup-1/2 残課題として認識

## Issue Net 変化

- Close: 0 件（Issue #49 は H2-followup / H10-followup / D2-followup-1/2 が残るため open 維持）
- 起票: 0 件
- **Net: 0 件**

## 関連 PR / Issue

- Issue #49（M4 + M7 follow-up umbrella）コメント参照
- 元指摘: PR #67 review (code-simplifier rating 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)