### PR TITLE
refactor(m7): LEGAL_DOCS.map ブロックを LegalLinkList に共通化 (Issue #49 D2-followup-2)

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,23 +1,13 @@
 import React from 'react';
-import { LEGAL_DOCS } from '../legalDocs';
+import { LegalLinkList } from './LegalLinkList';
 
 export const Footer: React.FC = () => {
     return (
         <footer className="flex-shrink-0 border-t border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900 px-4 py-2">
-            <ul className="flex flex-wrap gap-x-4 gap-y-1 justify-center text-xs text-gray-600 dark:text-gray-400">
-                {LEGAL_DOCS.map(doc => (
-                    <li key={doc.url}>
-                        <a
-                            href={doc.url}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="hover:text-indigo-600 dark:hover:text-indigo-400 hover:underline"
-                        >
-                            {doc.label}
-                        </a>
-                    </li>
-                ))}
-            </ul>
+            <LegalLinkList
+                containerClassName="flex flex-wrap gap-x-4 gap-y-1 justify-center text-xs text-gray-600 dark:text-gray-400"
+                linkClassName="hover:text-indigo-600 dark:hover:text-indigo-400 hover:underline"
+            />
         </footer>
     );
 };

--- a/components/LegalLinkList.tsx
+++ b/components/LegalLinkList.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { LEGAL_DOCS } from '../legalDocs';
+
+interface Props {
+    containerClassName: string;
+    linkClassName: string;
+}
+
+export const LegalLinkList: React.FC<Props> = ({ containerClassName, linkClassName }) => (
+    <ul className={containerClassName}>
+        {LEGAL_DOCS.map(doc => (
+            <li key={doc.url}>
+                <a
+                    href={doc.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className={linkClassName}
+                >
+                    {doc.label}
+                </a>
+            </li>
+        ))}
+    </ul>
+);

--- a/components/modals/TermsConsentModal.tsx
+++ b/components/modals/TermsConsentModal.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { useStore } from '../../store/index';
 import { isTermsVersionMismatch, type AcceptTermsError } from '../../store/authSlice';
-import { LEGAL_DOCS } from '../../legalDocs';
+import { LegalLinkList } from '../LegalLinkList';
 
 // dev bypass: prod では query を無視 (二重ガード)。SSR-safety: window 不在時は false。
 // 関数として export し ModalManager から render 時に評価することで test 環境の vi.stubEnv に追従する。
@@ -101,20 +101,10 @@ export const TermsConsentModal: React.FC = () => {
                     本サービスをご利用いただく前に、以下の文書をご確認のうえ同意してください。
                     各リンクは新しいタブで開きます。
                 </p>
-                <ul className="flex flex-col gap-2 text-sm">
-                    {LEGAL_DOCS.map(doc => (
-                        <li key={doc.url}>
-                            <a
-                                href={doc.url}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className="text-indigo-600 dark:text-indigo-400 hover:underline"
-                            >
-                                {doc.label}
-                            </a>
-                        </li>
-                    ))}
-                </ul>
+                <LegalLinkList
+                    containerClassName="flex flex-col gap-2 text-sm"
+                    linkClassName="text-indigo-600 dark:text-indigo-400 hover:underline"
+                />
                 {error?.kind === 'mismatch' && (
                     <p className="text-sm text-amber-700 dark:text-amber-400 bg-amber-50 dark:bg-amber-900/30 px-3 py-2 rounded">
                         規約が更新されました。最新版を確認のうえ、再度同意してください。


### PR DESCRIPTION
## Summary

Issue #49 (M4 follow-up umbrella) の **D2-followup-2** (rating 7、code-simplifier) を解消。

`Footer.tsx` と `TermsConsentModal.tsx` の同型 9 行ブロック (`<ul>{LEGAL_DOCS.map(doc => <li><a target=_blank rel=...>...</a></li>)}</ul>`) を `components/LegalLinkList.tsx` に抽出。差は外側 ul / 内側 a の className 2 props に集約。

## 変更内容

- **新規** `components/LegalLinkList.tsx` (24 行、pure presentational)
  - props: `containerClassName` / `linkClassName` (string)
  - `target="_blank"` / `rel="noopener noreferrer"` / `key={doc.url}` を pin
- `components/Footer.tsx`: 23 行 → 13 行
- `components/modals/TermsConsentModal.tsx`: -10 行 (`<ul>...</ul>` ブロック → `<LegalLinkList>` 1 タグ + LEGAL_DOCS import 削除)

挙動変更なし。LEGAL_DOCS データの不変条件は既存 `legalDocs.test.ts` (5 tests) で担保。LegalLinkList 自体は logic を持たない pure mapping wrapper のため、プロジェクト方針 (vitest config: `environment: 'node'` / `*.test.ts` のみ / 手動 E2E) に従い専用 unit test は追加せず。

## 設計判断

Issue 提案の API (`props: linkClassName / containerClassName`) をそのまま採用。`<ul>` を component 内側に持つ form A を選択 (caller の `<footer>` / modal 構造を変えず、`<ul>...</ul>` 単位で置換可能)。

## Test plan

- [x] `npm run lint` (tsc --noEmit) → 0 errors
- [x] `npm test` (全スイート) → 339/339 PASS（回帰なし、legalDocs.test 5/5 + TermsConsentModal isTermsDevBypass 5/5 含む）
- [ ] 次セッションの dev サーバー manual E2E (footer 3 link / TermsConsentModal の link 表示・hover 色・new tab 開閉が PR #67 と同一であること)

## Issue Net 変化

- Close: 0 件（Issue #49 は H2-followup / H10-followup / D2-followup-1 残留のため open 維持）
- 起票: 0 件
- **Net: 0 件**

## 関連 PR / Issue

- Issue #49（M4 + M7 follow-up umbrella）コメント参照
- 元指摘: PR #67 review (code-simplifier rating 7)
- 同一系列: PR #69 (D2-followup-3 hasNumericStatus、merged 2026-04-29)

🤖 Generated with [Claude Code](https://claude.com/claude-code)