### PR TITLE
docs(m6): M6 E2EE 暗号化バックアップ spec 起こし + ADR Roadmap M6/M6.5 分割

### DIFF
--- a/docs/adr/0001-local-first-architecture.md
+++ b/docs/adr/0001-local-first-architecture.md
@@ -90,9 +90,14 @@
 | M3 | AI 認証ゲート + クォータ | ✅ 完了（PR-D テスト基盤 + 持越 #1/#4/#5 PR #37 / PR-E BE 認証ゲート + 起動 probe + handleApiError 共通化 + 持越 #3 PR #39 / PR-F usage クォータ + 持越 + Issue #40 PR #45 / PR-G FE 統合 + Cloud Run public 化 + 持越 #2 2026-04-27） |
 | M4 | Export/Import + バックアップ警告 UI | ✅ 完了（PR #48 2026-04-28） |
 | M5 | Stripe Subscription + Webhook + 法務 Tier 2 | ⏳ |
-| M6 | E2EE 暗号化バックアップ（任意機能、後回し可） | ⏳ |
+| M6 | E2EE 暗号化バックアップ・ローカルファイル範囲（クライアント側 AES-GCM + パスフレーズ派生 + `.enc.json` Export/Import） | 🚧 着手中（2026-04-29 spec PR-A） |
+| M6.5 | E2EE 暗号化バックアップ・Cloud Storage 連携（signed URL upload/download + uid scope + Tier 2 ゲート、M5 完了後） | ⏳ |
 | M7-α | 公開準備 (Tier 0/1 法務 stub + 観測性 + エラー報告動線、Stripe 不要範囲) | ✅ 完了 (PR-A 観測性 / PR-B エラー報告 / PR-C 法務 stub / PR-D-1 BE accept-terms / PR-D-2 同意 UI、PR #67 で 2026-04-28 締め、本番公開前法務確認 MUST) |
 | M7-β | 公開最終チェック (Tier 2 規約節 + 特商法本文確定、M5 完了後) | ⏳ |
+
+### M6 / M6.5 分割の経緯（2026-04-29）
+
+ADR 当初は M6 を「E2EE 暗号化バックアップ（任意機能、後回し可）」として一括計画していたが、M7-α 完了 + 法務確認待機の隙間で技術的 cleanup として着手するにあたり、M5 (Stripe) 未完了で Tier 2 ゲートが組めない事情を受け、Cloud Storage 連携を **M6.5** に分離した。M6 範囲はクライアント側 AES-GCM + パスフレーズ派生 + ローカルファイル `.enc.json` の Export/Import で、Tier 1 でも使える機能として実装。鍵管理はパスフレーズ派生（PBKDF2-SHA256, 600,000 iterations）を採用し、サーバ側に escrow を残さない。M5 完了後に Cloud Storage 連携 (M6.5) で Tier 2 ゲートを後付けする seam を残す。詳細は `docs/spec/m6/tasks.md` 参照。
 
 詳細は `docs/spec/m1/tasks.md` 以降を参照。
 

--- a/docs/spec/m6/acceptance-criteria.md
+++ b/docs/spec/m6/acceptance-criteria.md
@@ -1,0 +1,267 @@
+# M6 Acceptance Criteria
+
+- Related: [tasks.md](./tasks.md)
+- Status: 🚧 PR-A 着手時点で AC 確定 (実装は PR-B〜D で順次達成)
+
+各基準は第三者が機械的に検証可能であること。曖昧な基準（「正しく動作する」「セキュアに暗号化される」等）は禁止。
+
+## AC 一覧
+
+### AC-1: 暗号化 Export round-trip
+
+**Given**: 非空の平文 `BackupV1`（projects / tutorialState / analysisHistory が全て 1 件以上含まれる）
+**When**: `encryptBackup(plaintext, passphrase='test-1234')` の出力を `decryptBackup(envelope, 'test-1234')` で復号
+**Then**: 元の `BackupV1` と deep-equal な平文が復元される
+
+**検証方法**: vitest (`utils/backupCrypto.test.ts`)
+
+```typescript
+const plaintext: BackupV1 = buildSampleBackup();
+const envelope = await encryptBackup(plaintext, 'test-1234', '1.0.0');
+const decrypted = await decryptBackup(envelope, 'test-1234');
+// JSON 経由で正規化（key ordering / Date 等の差を吸収）して比較
+expect(JSON.parse(JSON.stringify(decrypted))).toEqual(JSON.parse(JSON.stringify(plaintext)));
+```
+
+---
+
+### AC-2: 誤りパスフレーズ拒否
+
+**Given**: AC-1 で生成した暗号化 envelope
+**When**: 異なるパスフレーズ (`'wrong-passphrase'`) で `decryptBackup` を試行
+**Then**: `BackupValidationError` が throw され、メッセージは「パスフレーズが正しくないか、ファイルが壊れています」（auth tag 失敗と改竄検知を区別しない）
+
+**検証方法**: vitest
+
+```typescript
+await expect(decryptBackup(envelope, 'wrong-passphrase')).rejects.toThrow(BackupValidationError);
+await expect(decryptBackup(envelope, 'wrong-passphrase')).rejects.toThrow(
+  /パスフレーズが正しくないか/
+);
+```
+
+---
+
+### AC-3: IV 一意性
+
+**Given**: 暗号化操作で生成される IV (12 byte, AES-GCM 推奨長)
+**When**: IV 生成器を 100 回呼ぶ（`crypto.getRandomValues(new Uint8Array(12))` 直接 or KDF をキャッシュした内部 helper）
+**Then**: 100 回の IV を base64 化して Set に格納し `Set.size === 100`（全 IV が異なる）
+
+**検証方法**: vitest（`crypto.getRandomValues` 使用、決定性 mock せず実 random）
+
+```typescript
+// IV 生成は KDF と独立した経路でテスト（KDF 600,000 it. を 100 回回す
+// と CI コストが膨れるため、IV 生成器を export して直接呼ぶ）
+import { generateIv } from '../utils/backupCrypto';
+const ivs = new Set<string>();
+for (let i = 0; i < 100; i++) {
+  ivs.add(toBase64(generateIv()));
+}
+expect(ivs.size).toBe(100);
+
+// + 統合テストとして KDF を経由した encryptBackup を 3 回だけ回し、
+//   各 envelope の iv field が異なることも確認（KDF コスト対策で件数を絞る）
+```
+
+---
+
+### AC-4: EncryptedBackupV1 envelope schema
+
+**Given**: `encryptBackup(plaintext, passphrase)` の出力
+**When**: JSON.stringify → JSON.parse → 型 narrow
+**Then**: 以下の field が全て期待型で存在する
+
+```typescript
+interface EncryptedBackupV1 {
+    schemaVersion: 1;
+    encrypted: true;          // discriminator
+    algorithm: 'AES-GCM-256';
+    kdf: 'PBKDF2-SHA256';
+    kdfParams: {
+        salt: string;          // base64, 16 bytes
+        iterations: number;    // PBKDF2、現状値は constant PBKDF2_ITERATIONS で管理
+    };
+    iv: string;                // base64, 12 bytes for GCM
+    ciphertext: string;        // base64
+    appVersion: string;
+    encryptedAt: string;       // ISO 8601
+}
+```
+
+注: `iterations` は `number` 型として定義し、現在値（PBKDF2 600,000）は `utils/backupCrypto.ts` 内の constant `PBKDF2_ITERATIONS` で管理する。将来 OWASP 推奨値が引き上がった際、constant 更新で済み、過去に暗号化した envelope の復号時は envelope に保存された iterations を使用する（後方互換性）。
+
+**検証方法**: vitest + `ts-expect-error` pin
+
+```typescript
+import { PBKDF2_ITERATIONS } from '../utils/backupCrypto';
+const env = await encryptBackup(plaintext, 'pwd', '1.0.0');
+expect(env.schemaVersion).toBe(1);
+expect(env.encrypted).toBe(true);
+expect(env.algorithm).toBe('AES-GCM-256');
+expect(env.kdf).toBe('PBKDF2-SHA256');
+expect(env.kdfParams.iterations).toBe(PBKDF2_ITERATIONS);
+expect(env.iv).toMatch(/^[A-Za-z0-9+/=]+$/); // base64
+```
+
+---
+
+### AC-5: Export 動線統合（UI 含む）
+
+**Given**: Header から「全データバックアップ」を開く
+**When**:
+1. 「暗号化する」チェックボックス ON
+2. ExportEncryptModal でパスフレーズ 2 回入力（一致、最低 8 文字）
+3. 「暗号化してダウンロード」押下
+
+**Then**:
+- 拡張子 `.enc.json` のファイルが download される
+- ファイル内容を JSON.parse すると `{ encrypted: true, schemaVersion: 1, algorithm: 'AES-GCM-256', ... }` を満たす
+- トースト「暗号化バックアップを作成しました」が表示
+- パスフレーズ不一致 / 8 文字未満で「暗号化してダウンロード」ボタンが disabled
+
+**検証方法**:
+- slice 層: vitest (`store/backupSlice.test.ts`)
+- UI 層: manual E2E（dev サーバ、download ファイルの先頭バイトを確認）
+
+---
+
+### AC-6: Import 動線統合（UI 含む）
+
+**Given**: AC-5 で download した `.enc.json` ファイル
+**When**:
+1. 「データ復元」で同ファイル選択
+2. ImportPassphraseModal でパスフレーズ入力
+3. 「復号する」押下
+
+**Then**:
+- 既存 ImportConflictModal が開く（既存 project と衝突する場合）、または直接 import 成功トースト
+- 誤りパスフレーズ入力時はエラー文言が ImportPassphraseModal 内に表示され、再入力可能
+- キャンセル動線で modal を閉じられる
+
+**検証方法**:
+- slice 層: vitest (`store/backupSlice.test.ts`)
+- UI 層: manual E2E
+
+---
+
+### AC-7: 改竄検知
+
+**Given**: 暗号化 envelope の `ciphertext` を base64 decode → 末尾 1 byte を XOR 0xFF で改竄 → 再 base64 encode
+**When**: 正しいパスフレーズで `decryptBackup` を試行
+**Then**: AES-GCM auth tag 検証失敗で `BackupValidationError` が throw される。メッセージは AC-2 と同一（「パスフレーズが正しくないか、ファイルが壊れています」）
+
+**検証方法**: vitest
+
+```typescript
+// テスト helper の sketch（PR-B 実装側で同等の関数を test util に置く）
+const tamperLastByte = (b64: string): string => {
+    const bytes = base64Decode(b64);
+    bytes[bytes.length - 1] = bytes[bytes.length - 1] ^ 0xff;
+    return base64Encode(bytes);
+};
+
+const env = await encryptBackup(plaintext, 'pwd', '1.0.0');
+const tampered = {
+    ...env,
+    ciphertext: tamperLastByte(env.ciphertext),
+};
+await expect(decryptBackup(tampered, 'pwd')).rejects.toThrow(BackupValidationError);
+```
+
+---
+
+### AC-8: 既存平文 BackupV1 後方互換
+
+**Given**: M4 で生成した平文 BackupV1 ファイル（`encrypted` field なし、`schemaVersion: 1`）
+**When**: `parseBackup` (またはラッパー) に渡す
+**Then**:
+- 既存挙動と完全同一: passphrase modal が出ない、conflict 検出フローに直接合流
+- 既存 vitest (`utils/backupSchema.test.ts`) が全 PASS（regression なし）
+- legacy bare-project / `{project: {...}}` envelope も従前通り読み込める
+
+**検証方法**: vitest（既存 backupSchema test に regression assertion 追加）
+
+```typescript
+const v1: BackupV1 = { /* M4 形式 */ };
+const raw = JSON.stringify(v1);
+const result = parseBackup(raw); // 既存関数、encrypted 分岐なし
+expect(result).toEqual(v1);
+```
+
+---
+
+### AC-9: a11y / セキュリティ UI 文言
+
+**Given**: ExportEncryptModal / ImportPassphraseModal が表示された状態
+**When**: キーボード操作 / 画面読み上げ / セキュリティ文言の確認
+**Then**:
+- `role="dialog"` または `role="alertdialog"` 属性が付与
+- Tab キーで modal 内 focus 移動可能、modal 外への漏れなし
+- ExportEncryptModal にパスフレーズ忘却警告文言が含まれる（例: 「パスフレーズを忘れるとデータを復元できません」）
+- ImportPassphraseModal の誤りパスフレーズエラー文言は AC-2/AC-7 と同一文面（fingerprinting 防止）
+- `<input type="password">` でパスフレーズが画面に表示されない
+
+**検証方法**: manual E2E（dev サーバ + VoiceOver / NVDA）
+
+---
+
+### AC-10: 大容量データの round-trip 性能（Node 環境）
+
+**Given**: 10 MB 相当の平文 BackupV1（projects 50 件、各 200 KB の novelChunks）
+**When**: `encryptBackup` → `decryptBackup` を Node 20+ の `globalThis.crypto.subtle` で実行
+**Then**: encrypt + decrypt 合計 < 10 秒（PBKDF2 600k it. を 2 回含む、Node 環境基準）
+
+**検証方法**: vitest (`environment: 'node'`, `performance.now` で計測)
+
+```typescript
+const plaintext: BackupV1 = buildLargeBackup(50, 200_000);
+const t0 = performance.now();
+const env = await encryptBackup(plaintext, 'pwd', '1.0.0');
+const dec = await decryptBackup(env, 'pwd');
+const elapsed = performance.now() - t0;
+expect(elapsed).toBeLessThan(10_000);
+```
+
+注:
+- PBKDF2 はキー派生 1 回 (encrypt) + 1 回 (decrypt) で計 2 回回るため、600,000 iterations × 2 で実時間が増える。600,000 は OWASP 推奨値（2023）に準拠
+- Node 環境とブラウザ環境で `crypto.subtle` の性能特性が異なるため、本 AC は **Node 環境のみ**を保証対象とする。ブラウザ実機での体感性能は manual E2E (AC-5/6) で確認
+- メモリ使用量上限は AC として設定しない（vitest = Node では信頼性ある計測手段がなく、`performance.memory` は Chrome 限定の非標準 API。ブラウザでの過大メモリ消費は manual E2E で別途観察）
+
+---
+
+## AC 達成マッピング
+
+| AC | PR で達成 | 検証層 |
+|---|---|---|
+| AC-1 | PR-B | vitest |
+| AC-2 | PR-B | vitest |
+| AC-3 | PR-B | vitest |
+| AC-4 | PR-B | vitest + ts-expect-error |
+| AC-5 | PR-C (slice) + PR-D (UI) | vitest + manual E2E |
+| AC-6 | PR-C (slice) + PR-D (UI) | vitest + manual E2E |
+| AC-7 | PR-B | vitest |
+| AC-8 | PR-B | vitest (regression) |
+| AC-9 | PR-D | manual E2E |
+| AC-10 | PR-B | vitest (performance) |
+
+---
+
+## 非対象（M6 では検証しない）
+
+- **Cloud Storage upload/download** → M6.5 で別 AC
+- **Tier 2 ゲート** → M6.5 で別 AC
+- **複数端末間の鍵共有** → ADR-0001「複数端末同期は実装しない」を踏襲、永久に非対象
+- **パスフレーズ recovery / escrow** → 設計判断 1 で「忘却即データ喪失」を採用、永久に非対象
+- **zxcvbn ベースのパスフレーズ強度判定** → MVP では length-only、将来 enhancement
+
+---
+
+## ADR-0001 との整合性
+
+| ADR-0001 §Decision 記述 | M6 での実装 | 整合 |
+|---|---|---|
+| 「Cloud Storage = opt-in 暗号化バックアップ」 | M6 ではローカルファイルのみ、Cloud Storage は M6.5 | ⚠️ Roadmap で M6/M6.5 分割を反映 |
+| 「クライアント側 AES-GCM、E2EE」 | AES-GCM-256 + PBKDF2-SHA256 600k it. | ✅ |
+| 「XSS 時に鍵・平文ともに流出（設計上の限界）」 | spec で明示再掲、UI の警告文言にも反映 | ✅ |
+| 「複数端末同期は実装しない」 | 鍵共有なし、ファイル持ち歩き前提 | ✅ |

--- a/docs/spec/m6/acceptance-criteria.md
+++ b/docs/spec/m6/acceptance-criteria.md
@@ -5,13 +5,24 @@
 
 各基準は第三者が機械的に検証可能であること。曖昧な基準（「正しく動作する」「セキュアに暗号化される」等）は禁止。
 
+## 用語と命名規則
+
+- **envelope**: 暗号化ファイル全体 (`EncryptedBackupV1`)
+- **payload**: envelope の中身、復号後に得られる平文 (`BackupV1`)
+- **envelopeVersion**: envelope 形状自体のバージョン (crypto metadata layout の version)
+- **payload version (= `BackupV1.schemaVersion`)**: payload の version。envelope と payload は **独立した version 軸**で進行する
+- 規則: payload を v2 化しても envelope を v2 化する必要はない（envelope shape が変わらなければ envelope は v1 のまま）。詳細は `### envelope / payload version の独立性` 節参照
+
 ## AC 一覧
 
 ### AC-1: 暗号化 Export round-trip
 
 **Given**: 非空の平文 `BackupV1`（projects / tutorialState / analysisHistory が全て 1 件以上含まれる）
 **When**: `encryptBackup(plaintext, passphrase='test-1234')` の出力を `decryptBackup(envelope, 'test-1234')` で復号
-**Then**: 元の `BackupV1` と deep-equal な平文が復元される
+**Then**:
+- 元の `BackupV1` と deep-equal な payload が復元される
+- 直接 field check として `decrypted.exportedAt === plaintext.exportedAt` / `decrypted.projects.length === plaintext.projects.length` / `decrypted.projects[0].id === plaintext.projects[0].id` も成立する（type-loss 検出）
+- KDF 決定性: 同じ `(passphrase, salt, iterations)` で `deriveKey` を呼ぶと同じ AES key bytes が得られる（**ただし** `extractable: false` のため key bytes は直接比較できないので、同 salt/iv/passphrase で encrypt 結果の ciphertext が byte-equal を assert）
 
 **検証方法**: vitest (`utils/backupCrypto.test.ts`)
 
@@ -19,8 +30,9 @@
 const plaintext: BackupV1 = buildSampleBackup();
 const envelope = await encryptBackup(plaintext, 'test-1234', '1.0.0');
 const decrypted = await decryptBackup(envelope, 'test-1234');
-// JSON 経由で正規化（key ordering / Date 等の差を吸収）して比較
 expect(JSON.parse(JSON.stringify(decrypted))).toEqual(JSON.parse(JSON.stringify(plaintext)));
+expect(decrypted.exportedAt).toBe(plaintext.exportedAt);
+expect(decrypted.projects.length).toBe(plaintext.projects.length);
 ```
 
 ---
@@ -29,79 +41,128 @@ expect(JSON.parse(JSON.stringify(decrypted))).toEqual(JSON.parse(JSON.stringify(
 
 **Given**: AC-1 で生成した暗号化 envelope
 **When**: 異なるパスフレーズ (`'wrong-passphrase'`) で `decryptBackup` を試行
-**Then**: `BackupValidationError` が throw され、メッセージは「パスフレーズが正しくないか、ファイルが壊れています」（auth tag 失敗と改竄検知を区別しない）
+**Then**:
+- `BackupValidationError` が throw される
+- UI 向け `error.message` は constant `DECRYPT_FAILURE_MESSAGE` （「パスフレーズが正しくないか、ファイルが壊れています」）と完全一致
+- 内部 triage 用に `error.cause === { kind: 'auth-tag-mismatch' }` が設定される（**UI 層は cause を読まない**規律。AC-9 で別途固定）
+- `logger.warn('M6_DECRYPT_AUTH_TAG_FAILED', { envelopeVersion, algorithm, kdf, iterations, encryptedAt })` が呼ばれる（**passphrase / plaintext / derived key / salt / ciphertext は絶対に log に含めない**）
 
 **検証方法**: vitest
 
 ```typescript
-await expect(decryptBackup(envelope, 'wrong-passphrase')).rejects.toThrow(BackupValidationError);
-await expect(decryptBackup(envelope, 'wrong-passphrase')).rejects.toThrow(
-  /パスフレーズが正しくないか/
+import { DECRYPT_FAILURE_MESSAGE } from '../utils/backupCrypto';
+await expect(decryptBackup(envelope, 'wrong-passphrase'))
+  .rejects.toMatchObject({
+    name: 'BackupValidationError',
+    message: DECRYPT_FAILURE_MESSAGE,
+    cause: { kind: 'auth-tag-mismatch' },
+  });
+expect(loggerMock.warn).toHaveBeenCalledWith(
+  'M6_DECRYPT_AUTH_TAG_FAILED',
+  expect.not.objectContaining({ passphrase: expect.anything() }),
 );
 ```
 
 ---
 
-### AC-3: IV 一意性
+### AC-3: IV 一意性 + KDF salt 一意性 (regression smoke test)
 
-**Given**: 暗号化操作で生成される IV (12 byte, AES-GCM 推奨長)
-**When**: IV 生成器を 100 回呼ぶ（`crypto.getRandomValues(new Uint8Array(12))` 直接 or KDF をキャッシュした内部 helper）
-**Then**: 100 回の IV を base64 化して Set に格納し `Set.size === 100`（全 IV が異なる）
+**Given**: 暗号化操作で生成される IV (12 byte, AES-GCM 標準) と salt (16 byte, PBKDF2)
+**When**: 内部 helper `randomBytes(len)` を介して IV / salt を 100 回生成
+**Then**:
+- 100 回の IV を base64 化して Set に格納し `Set.size === 100`（衝突なし）
+- 100 回の salt も同様に `Set.size === 100`
+- 注: 本 AC は「実装が定数 IV / 単調 counter ではないこと」の sanity check (regression smoke test)。暗号学的な一意性保証は `crypto.getRandomValues` の CSPRNG 性質に委譲する
 
 **検証方法**: vitest（`crypto.getRandomValues` 使用、決定性 mock せず実 random）
 
 ```typescript
-// IV 生成は KDF と独立した経路でテスト（KDF 600,000 it. を 100 回回す
-// と CI コストが膨れるため、IV 生成器を export して直接呼ぶ）
-import { generateIv } from '../utils/backupCrypto';
+import { randomBytes } from '../utils/backupCrypto';
 const ivs = new Set<string>();
+const salts = new Set<string>();
 for (let i = 0; i < 100; i++) {
-  ivs.add(toBase64(generateIv()));
+  ivs.add(toBase64(randomBytes(12)));
+  salts.add(toBase64(randomBytes(16)));
 }
 expect(ivs.size).toBe(100);
+expect(salts.size).toBe(100);
 
-// + 統合テストとして KDF を経由した encryptBackup を 3 回だけ回し、
-//   各 envelope の iv field が異なることも確認（KDF コスト対策で件数を絞る）
+// 統合テスト: KDF を経由した encryptBackup を 3 回回し iv / kdfParams.salt が異なることを確認
+//（KDF コスト対策で件数を絞る）
+const envelopes = await Promise.all([
+  encryptBackup(plaintext, 'pwd', '1.0.0'),
+  encryptBackup(plaintext, 'pwd', '1.0.0'),
+  encryptBackup(plaintext, 'pwd', '1.0.0'),
+]);
+expect(new Set(envelopes.map(e => e.iv)).size).toBe(3);
+expect(new Set(envelopes.map(e => e.kdfParams.salt)).size).toBe(3);
 ```
+
+注: `randomBytes` は PR-B で internal helper として実装するが、test util から import 可能な公開ポジションに置く（`__testOnly__` namespace ではなく通常 export、ただし production caller も使う前提の単純 wrapper）。
 
 ---
 
-### AC-4: EncryptedBackupV1 envelope schema
+### AC-4: EncryptedBackupV1 envelope schema + parse-time validation
 
-**Given**: `encryptBackup(plaintext, passphrase)` の出力
-**When**: JSON.stringify → JSON.parse → 型 narrow
-**Then**: 以下の field が全て期待型で存在する
+**Given**: `encryptBackup(plaintext, passphrase, appVersion)` の出力
+**When**: JSON.stringify → JSON.parse → `parseEncryptedEnvelope` 通過
+**Then**: 以下の field が全て期待型で存在し、parse-time の境界条件を満たす
 
 ```typescript
 interface EncryptedBackupV1 {
-    schemaVersion: 1;
-    encrypted: true;          // discriminator
-    algorithm: 'AES-GCM-256';
-    kdf: 'PBKDF2-SHA256';
+    envelopeVersion: 1;       // envelope shape のバージョン (payload version と独立)
+    encrypted: true;          // discriminator (AND 結合の一要素、AC-8 参照)
+    algorithm: 'AES-GCM-256'; // literal、parse 時に !== 'AES-GCM-256' なら reject
+    kdf: 'PBKDF2-SHA256';     // literal、parse 時に !== 'PBKDF2-SHA256' なら reject
     kdfParams: {
-        salt: string;          // base64, 16 bytes
-        iterations: number;    // PBKDF2、現状値は constant PBKDF2_ITERATIONS で管理
+        salt: string;          // base64、decode 後に **正確に 16 bytes**、外れたら reject
+        iterations: number;    // PBKDF2、現状値は constant `PBKDF2_ITERATIONS = 600_000`
     };
-    iv: string;                // base64, 12 bytes for GCM
-    ciphertext: string;        // base64
+    iv: string;                // base64、decode 後に **正確に 12 bytes** (AES-GCM)、外れたら reject
+    ciphertext: string;        // base64、非空、AES-GCM 出力形式 (auth tag は ciphertext 末尾 16 bytes に concat、別 field にしない)
     appVersion: string;
-    encryptedAt: string;       // ISO 8601
+    encryptedAt: string;       // ISO 8601、parse 失敗時は `new Date().toISOString()` で fallback (既存 parseBackup の exportedAt と同じパターン)
 }
 ```
 
-注: `iterations` は `number` 型として定義し、現在値（PBKDF2 600,000）は `utils/backupCrypto.ts` 内の constant `PBKDF2_ITERATIONS` で管理する。将来 OWASP 推奨値が引き上がった際、constant 更新で済み、過去に暗号化した envelope の復号時は envelope に保存された iterations を使用する（後方互換性）。
+注:
+- `iterations` は `number` 型として定義し、現在値（`PBKDF2_ITERATIONS = 600_000`）は `utils/backupCrypto.ts` 内の constant で管理。将来 OWASP 推奨値が引き上がった際、constant 更新で済み、過去に暗号化した envelope の復号時は envelope に保存された iterations を使用する（後方互換性）
+- `MIN_ACCEPTED_ITERATIONS = 100_000` (parse 時の floor、これ未満は reject、downgrade 攻撃対策)
+- `MAX_ACCEPTED_ITERATIONS = 10_000_000` (parse 時の ceiling、これ超は reject、import DoS 対策)
+- `MAX_CIPHERTEXT_BYTES = 100 * 1024 * 1024` (decode 後 100 MB ceiling、import DoS 対策、現実的なバックアップサイズの 10 倍程度)
+- `MAX_ENVELOPE_FILE_BYTES = 150 * 1024 * 1024` (生 JSON 文字列の上限、base64 inflate 込み)
+- AES-GCM ciphertext は Web Crypto 仕様で auth tag (16 bytes) を末尾に concat 形式で出力する。本 envelope は **別 `tag` field を持たず**、`ciphertext` 末尾 16 bytes が auth tag
 
 **検証方法**: vitest + `ts-expect-error` pin
 
 ```typescript
-import { PBKDF2_ITERATIONS } from '../utils/backupCrypto';
+import {
+    PBKDF2_ITERATIONS,
+    MIN_ACCEPTED_ITERATIONS,
+    MAX_ACCEPTED_ITERATIONS,
+    MAX_CIPHERTEXT_BYTES,
+    MAX_ENVELOPE_FILE_BYTES,
+} from '../utils/backupCrypto';
+
 const env = await encryptBackup(plaintext, 'pwd', '1.0.0');
-expect(env.schemaVersion).toBe(1);
+expect(env.envelopeVersion).toBe(1);
 expect(env.encrypted).toBe(true);
 expect(env.algorithm).toBe('AES-GCM-256');
 expect(env.kdf).toBe('PBKDF2-SHA256');
 expect(env.kdfParams.iterations).toBe(PBKDF2_ITERATIONS);
-expect(env.iv).toMatch(/^[A-Za-z0-9+/=]+$/); // base64
+expect(base64Decode(env.kdfParams.salt).length).toBe(16);
+expect(base64Decode(env.iv).length).toBe(12);
+expect(env.iv).toMatch(/^[A-Za-z0-9+/=]+$/);
+
+// parse-time reject の境界
+await expect(parseEncryptedEnvelope({ ...env, algorithm: 'AES-GCM-256-FUTURE' }))
+  .rejects.toThrow(BackupValidationError);
+await expect(parseEncryptedEnvelope({ ...env, kdf: 'Argon2id' }))
+  .rejects.toThrow(BackupValidationError);
+await expect(parseEncryptedEnvelope({ ...env, kdfParams: { ...env.kdfParams, iterations: MIN_ACCEPTED_ITERATIONS - 1 } }))
+  .rejects.toThrow(/iterations/);
+await expect(parseEncryptedEnvelope({ ...env, kdfParams: { ...env.kdfParams, iterations: MAX_ACCEPTED_ITERATIONS + 1 } }))
+  .rejects.toThrow(/iterations/);
 ```
 
 ---
@@ -111,22 +172,26 @@ expect(env.iv).toMatch(/^[A-Za-z0-9+/=]+$/); // base64
 **Given**: Header から「全データバックアップ」を開く
 **When**:
 1. 「暗号化する」チェックボックス ON
-2. ExportEncryptModal でパスフレーズ 2 回入力（一致、最低 8 文字）
+2. ExportEncryptModal でパスフレーズ 2 回入力（一致、最低 12 文字）
 3. 「暗号化してダウンロード」押下
 
 **Then**:
 - 拡張子 `.enc.json` のファイルが download される
-- ファイル内容を JSON.parse すると `{ encrypted: true, schemaVersion: 1, algorithm: 'AES-GCM-256', ... }` を満たす
+- ファイル内容を JSON.parse すると `{ encrypted: true, envelopeVersion: 1, algorithm: 'AES-GCM-256', ... }` を満たす
 - トースト「暗号化バックアップを作成しました」が表示
-- パスフレーズ不一致 / 8 文字未満で「暗号化してダウンロード」ボタンが disabled
+- パスフレーズ不一致 / 12 文字未満で「暗号化してダウンロード」ボタンが disabled
+- **暗号化失敗時の cleanup invariant**: `encryptBackup` throw 時は Blob 未生成 → ダウンロード対話ダイアログ発生せず、トースト「暗号化に失敗しました」表示。Blob 生成後 `anchor.click` 前 throw の場合は finally で `URL.revokeObjectURL` 実行
+- **暗号化成功後**: ExportEncryptModal の React state `setPassphrase('')` で memory 滞留時間最小化
 
 **検証方法**:
 - slice 層: vitest (`store/backupSlice.test.ts`)
 - UI 層: manual E2E（dev サーバ、download ファイルの先頭バイトを確認）
 
+注: パスフレーズ最低長を **12 文字**に引き上げ（M6 のローカルだけなら 8 でも実用的だが、M6.5 で Cloud Storage に保管された envelope は offline 攻撃対象になる。spec 段階で 12 文字に固定し M6.5 で再緩和しない方針を pin）。
+
 ---
 
-### AC-6: Import 動線統合（UI 含む）
+### AC-6: Import 動線統合（UI 含む） + state-machine 規律
 
 **Given**: AC-5 で download した `.enc.json` ファイル
 **When**:
@@ -136,97 +201,270 @@ expect(env.iv).toMatch(/^[A-Za-z0-9+/=]+$/); // base64
 
 **Then**:
 - 既存 ImportConflictModal が開く（既存 project と衝突する場合）、または直接 import 成功トースト
-- 誤りパスフレーズ入力時はエラー文言が ImportPassphraseModal 内に表示され、再入力可能
-- キャンセル動線で modal を閉じられる
+- 誤りパスフレーズ入力時はエラー文言が ImportPassphraseModal 内に表示され、再入力可能（最大 5 回まで、超過時は modal 強制 close + トースト「再試行回数の上限に達しました」）
+- キャンセル動線で modal を閉じられる、`AbortController.abort()` を呼んで in-flight な KDF を中断、state を初期化
+- **state-machine 規律**:
+  - `decryptAndPrepareImport(passphrase)` が `pendingDecryption === null` 状態で呼ばれた場合、`BackupValidationError ({ cause: { kind: 'no-pending-decryption' } })` を throw、state は変更しない
+  - `prepareImport(secondEncryptedFile)` が `pendingDecryption` 既存時に呼ばれた場合、最初の `pendingDecryption` を `cancelPendingDecryption` で確定的にクリアしてから second を set する（**race-free 上書き禁止**、cancel→set の順序を pin）
+  - `cancelPendingDecryption` は abort signal 発火後に state 初期化、後追いで完了する KDF promise は signal.aborted check で state 更新を skip
+- **復号成功・失敗どちらの場合も**: ImportPassphraseModal の React state `setPassphrase('')` で memory 滞留時間最小化
 
 **検証方法**:
-- slice 層: vitest (`store/backupSlice.test.ts`)
+- slice 層: vitest (`store/backupSlice.test.ts`、state machine transition test 含む)
 - UI 層: manual E2E
 
 ---
 
-### AC-7: 改竄検知
+### AC-7: 改竄検知 + catch 範囲分類
 
 **Given**: 暗号化 envelope の `ciphertext` を base64 decode → 末尾 1 byte を XOR 0xFF で改竄 → 再 base64 encode
 **When**: 正しいパスフレーズで `decryptBackup` を試行
-**Then**: AES-GCM auth tag 検証失敗で `BackupValidationError` が throw される。メッセージは AC-2 と同一（「パスフレーズが正しくないか、ファイルが壊れています」）
+**Then**:
+- `BackupValidationError` が throw される
+- UI 向け `error.message` は AC-2 と同一の constant `DECRYPT_FAILURE_MESSAGE` (fingerprinting 防止)
+- 内部 `error.cause.kind` は **catch 範囲に応じて 4 分類**:
+  1. `'auth-tag-mismatch'`: AES-GCM `OperationError` (パスフレーズ違い + 改竄の両方を含む)
+  2. `'plaintext-corrupted'`: base64 decode 後の `JSON.parse` 失敗 (auth tag は通ったが内部構造異常 = 攻撃痕跡候補)
+  3. `'schema-invalid'`: 復号後 BackupV1 schema validation 失敗
+  4. `'kdf-import-failed'`: `crypto.subtle.importKey` / `deriveKey` 失敗 (KDF パラメータ不正、`NotSupportedError` 等)
+- 上記いずれにも該当しない catch-all は **禁止** (再 throw、CLAUDE.md「empty catch / 広い catch 禁止」準拠)
+- 各 cause に対応する `logger.warn` が呼ばれる: `M6_DECRYPT_AUTH_TAG_FAILED` / `M6_DECRYPT_PLAINTEXT_CORRUPTED` / `M6_DECRYPT_SCHEMA_INVALID` / `M6_DECRYPT_KDF_FAILED`
 
 **検証方法**: vitest
 
 ```typescript
-// テスト helper の sketch（PR-B 実装側で同等の関数を test util に置く）
 const tamperLastByte = (b64: string): string => {
     const bytes = base64Decode(b64);
     bytes[bytes.length - 1] = bytes[bytes.length - 1] ^ 0xff;
     return base64Encode(bytes);
 };
-
-const env = await encryptBackup(plaintext, 'pwd', '1.0.0');
-const tampered = {
-    ...env,
-    ciphertext: tamperLastByte(env.ciphertext),
-};
-await expect(decryptBackup(tampered, 'pwd')).rejects.toThrow(BackupValidationError);
+const env = await encryptBackup(plaintext, 'pwd-12-chars-ok', '1.0.0');
+const tampered = { ...env, ciphertext: tamperLastByte(env.ciphertext) };
+await expect(decryptBackup(tampered, 'pwd-12-chars-ok'))
+  .rejects.toMatchObject({
+    message: DECRYPT_FAILURE_MESSAGE,
+    cause: { kind: 'auth-tag-mismatch' },
+  });
 ```
 
 ---
 
-### AC-8: 既存平文 BackupV1 後方互換
+### AC-8: 既存平文 BackupV1 後方互換 + isEncryptedBackup AND 結合判定
 
 **Given**: M4 で生成した平文 BackupV1 ファイル（`encrypted` field なし、`schemaVersion: 1`）
-**When**: `parseBackup` (またはラッパー) に渡す
+**When**: `parseAnyBackup` (新設、`BackupV1 | EncryptedBackupV1` を返す) または既存 `parseBackup` (`BackupV1` のみ) に渡す
 **Then**:
-- 既存挙動と完全同一: passphrase modal が出ない、conflict 検出フローに直接合流
-- 既存 vitest (`utils/backupSchema.test.ts`) が全 PASS（regression なし）
-- legacy bare-project / `{project: {...}}` envelope も従前通り読み込める
+- `parseBackup` (既存、`BackupV1` を返す) は M4 と完全互換: legacy bare-project / `{project: {...}}` envelope unwrap も従前通り
+- `parseAnyBackup` (新設、union 戻り値) は encrypted detection を行い、平文の場合は `BackupV1` を返す
+- **`isEncryptedBackup(json)` の AND 結合判定** (どれか欠けたら `false` を返し平文扱い):
+  - `typeof json.encrypted === 'boolean' && json.encrypted === true`
+  - `typeof json.algorithm === 'string'`
+  - `typeof json.kdf === 'string'`
+  - `typeof json.iv === 'string'`
+  - `typeof json.ciphertext === 'string'`
+  - `json.kdfParams && typeof json.kdfParams.salt === 'string'`
+- **半壊 envelope** (`encrypted: true` だが他 field 欠落) は `parseAnyBackup` 内で `parseEncryptedEnvelope` を呼んで `BackupValidationError ({ cause: { kind: 'envelope-incomplete' } })` を throw（**silent fallback to plaintext path 禁止**）
+- **既存 vitest regression assertion**: `utils/backupSchema.test.ts` の以下のケースは PR-B 後も全て同じエラーメッセージで throw する:
+  - schemaVersion 999 reject
+  - project index error
+  - malformed JSON
+  - empty file
+  - legacy bare-project unwrap
+  - `{project: {...}}` envelope unwrap
+  - tutorialState 非 boolean drop
+  - analysisHistory filter
+- `parseBackup` (既存関数) の戻り値型は **不変** (`BackupV1` のまま、union 化しない)。新規分岐は `parseAnyBackup` に分離
 
 **検証方法**: vitest（既存 backupSchema test に regression assertion 追加）
 
 ```typescript
-const v1: BackupV1 = { /* M4 形式 */ };
+// 後方互換
+const v1: BackupV1 = buildSampleBackup();
 const raw = JSON.stringify(v1);
-const result = parseBackup(raw); // 既存関数、encrypted 分岐なし
-expect(result).toEqual(v1);
+expect(parseBackup(raw)).toEqual(v1); // 既存関数、戻り値型 BackupV1 不変
+expect(parseAnyBackup(raw)).toEqual(v1); // 新設、平文の場合は BackupV1
+
+// 半壊 envelope reject
+const halfEnvelope = JSON.stringify({ encrypted: true, schemaVersion: 1 });
+expect(() => parseAnyBackup(halfEnvelope))
+  .toThrow(/envelope/);
 ```
 
 ---
 
-### AC-9: a11y / セキュリティ UI 文言
+### AC-9: a11y / セキュリティ UI 文言 + cause 利用規律
 
 **Given**: ExportEncryptModal / ImportPassphraseModal が表示された状態
-**When**: キーボード操作 / 画面読み上げ / セキュリティ文言の確認
+**When**: キーボード操作 / 画面読み上げ / セキュリティ文言の確認 / コード grep
 **Then**:
 - `role="dialog"` または `role="alertdialog"` 属性が付与
 - Tab キーで modal 内 focus 移動可能、modal 外への漏れなし
-- ExportEncryptModal にパスフレーズ忘却警告文言が含まれる（例: 「パスフレーズを忘れるとデータを復元できません」）
-- ImportPassphraseModal の誤りパスフレーズエラー文言は AC-2/AC-7 と同一文面（fingerprinting 防止）
+- ExportEncryptModal にパスフレーズ忘却警告文言が含まれる (例: 「パスフレーズを忘れるとデータを復元できません」)
+- ExportEncryptModal にパスフレーズ強度説明文言が含まれる (例: 「12 文字以上、英数字記号を組み合わせると強度が上がります。生成されたバックアップファイルがクラウドに保管された場合のオフライン攻撃に備えてください」)
+- ImportPassphraseModal の誤りパスフレーズエラー文言は constant `DECRYPT_FAILURE_MESSAGE` と完全一致 (fingerprinting 防止)
 - `<input type="password">` でパスフレーズが画面に表示されない
+- `autocomplete="new-password"` 指定 (パスフレーズマネージャ連携の hint)
+- パスフレーズ入力フィールドに `oncopy` / `oncut` handler を仕掛けて `preventDefault` (フィールドからのコピーを阻止、貼り付けはそのまま許可)
+- **cause 利用規律**: `components/` 配下のソースコードを grep して `error.cause` への参照がゼロであること (UI 層は cause を読まず、`error.message` のみを表示。fingerprinting 防止の機械的 enforcement)
 
-**検証方法**: manual E2E（dev サーバ + VoiceOver / NVDA）
+**検証方法**:
+- a11y: manual E2E（dev サーバ + VoiceOver / NVDA）
+- cause grep: vitest (`tests/static/no-error-cause-in-components.test.ts`、`grep -r "error.cause" components/` の戻り値を空 assert)
 
 ---
 
-### AC-10: 大容量データの round-trip 性能（Node 環境）
+### AC-10: 大容量データの round-trip 性能（Node 環境、CI 緩和）
 
 **Given**: 10 MB 相当の平文 BackupV1（projects 50 件、各 200 KB の novelChunks）
 **When**: `encryptBackup` → `decryptBackup` を Node 20+ の `globalThis.crypto.subtle` で実行
-**Then**: encrypt + decrypt 合計 < 10 秒（PBKDF2 600k it. を 2 回含む、Node 環境基準）
+**Then**:
+- ローカル開発環境で encrypt + decrypt 合計 < 10 秒 (PBKDF2 600k iter. を 2 回含む)
+- CI (GitHub Actions ubuntu-latest) 環境では < 15 秒に閾値緩和（環境変数 `CI=true` で判定）
+- メモリ使用量基準は AC として設定しない（vitest = Node では信頼性ある計測手段なし、ブラウザでの過大メモリ消費は manual E2E で別途観察）
 
 **検証方法**: vitest (`environment: 'node'`, `performance.now` で計測)
 
 ```typescript
 const plaintext: BackupV1 = buildLargeBackup(50, 200_000);
 const t0 = performance.now();
-const env = await encryptBackup(plaintext, 'pwd', '1.0.0');
-const dec = await decryptBackup(env, 'pwd');
+const env = await encryptBackup(plaintext, 'pwd-12-chars-ok', '1.0.0');
+const dec = await decryptBackup(env, 'pwd-12-chars-ok');
 const elapsed = performance.now() - t0;
-expect(elapsed).toBeLessThan(10_000);
+const limit = process.env.CI === 'true' ? 15_000 : 10_000;
+expect(elapsed).toBeLessThan(limit);
 ```
 
 注:
 - PBKDF2 はキー派生 1 回 (encrypt) + 1 回 (decrypt) で計 2 回回るため、600,000 iterations × 2 で実時間が増える。600,000 は OWASP 推奨値（2023）に準拠
 - Node 環境とブラウザ環境で `crypto.subtle` の性能特性が異なるため、本 AC は **Node 環境のみ**を保証対象とする。ブラウザ実機での体感性能は manual E2E (AC-5/6) で確認
-- メモリ使用量上限は AC として設定しない（vitest = Node では信頼性ある計測手段がなく、`performance.memory` は Chrome 限定の非標準 API。ブラウザでの過大メモリ消費は manual E2E で別途観察）
+
+---
+
+### AC-11: AbortSignal 対応 + UI timeout
+
+**Given**: `encryptBackup` / `decryptBackup` の long-running 操作（PBKDF2 + AES-GCM）
+**When**: `AbortSignal` を option として渡し、KDF 中に `controller.abort()` を呼ぶ
+**Then**:
+- `encryptBackup({ signal })` / `decryptBackup({ signal })` が `'AbortError'` DOMException で reject
+- abort 時に Blob 未生成 (export) / pendingDecryption state 未更新 (import) の invariant 維持
+- UI 層は **30 秒経過時に強制 abort** + トースト「暗号化に時間がかかっています。デバイス性能を確認するか、データ量を減らしてください」+ cancel ボタン
+- mobile Safari の background throttle (15 秒以上) に対しては、abort 後の再試行を許可（state を「再試行可能」に戻す）
+
+**検証方法**: vitest
+
+```typescript
+const controller = new AbortController();
+const promise = encryptBackup(plaintext, 'pwd-12-chars-ok', '1.0.0', { signal: controller.signal });
+controller.abort();
+await expect(promise).rejects.toThrow(/AbortError|aborted/);
+```
+
+---
+
+### AC-12: Unicode passphrase normalization policy
+
+**Given**: 同じユーザーが NFC 形式 `'é'` (é precomposed) と NFD 形式 `'é'` (e + combining acute) を別端末でタイプ
+**When**: 一方で encrypt、もう一方で decrypt
+**Then**:
+- **採用 policy**: パスフレーズは `passphrase.normalize('NFC')` で正規化してから `TextEncoder.encode('utf-8')` する。これにより端末依存の合成形式差を吸収
+- 上記 policy の **forward-locking** : 一度 shipped したら変更不可（既存 envelope 全 invalidate のため）。本 AC で固定し ADR-0001 にも記録
+- 非 ASCII passphrase の round-trip テスト (絵文字 / CJK / accented Latin) が PASS
+- パスフレーズ最低長判定は **コードポイント単位ではなく `[...passphrase].length`** で行う（surrogate pair 対応、`'🔑🔑🔑🔑'.length === 8` ではなく `[...'🔑🔑🔑🔑'].length === 4` を採用）
+
+**検証方法**: vitest
+
+```typescript
+const nfc = 'é' + 'rest12chars';      // é precomposed (12 chars)
+const nfd = 'é' + 'rest12chars'; // é decomposed (13 code units, 12 graphemes 相当)
+const env = await encryptBackup(plain, nfc, '1.0.0');
+// NFC 正規化により nfd でも decrypt 成功する
+expect(await decryptBackup(env, nfd)).toEqual(plain);
+
+// 絵文字 4 つ = grapheme 単位 4 → 12 文字未満で reject
+expect([...'🔑🔑🔑🔑'].length).toBe(4);
+await expect(validatePassphraseLength('🔑🔑🔑🔑'))
+  .toThrow(/12 文字/);
+
+// CJK round-trip
+const cjk = '日本語パスワード長め文字列';
+const env2 = await encryptBackup(plain, cjk, '1.0.0');
+expect(await decryptBackup(env2, cjk)).toEqual(plain);
+
+// 空 / トリム
+await expect(encryptBackup(plain, '', '1.0.0')).rejects.toThrow(/パスフレーズ/);
+```
+
+---
+
+### AC-13: AES-GCM AAD で envelope metadata 認証
+
+**Given**: `encryptBackup` 実行時に envelope metadata（algorithm / kdf / kdfParams / iv / appVersion / encryptedAt / envelopeVersion）が確定
+**When**: `crypto.subtle.encrypt({ name: 'AES-GCM', iv, additionalData: aadBytes }, key, plaintextBytes)` を呼ぶ
+**Then**:
+- `aadBytes` は metadata の **canonical 形式**（key sorted JSON.stringify → TextEncoder.encode）
+- AAD に含む field: `envelopeVersion`, `algorithm`, `kdf`, `kdfParams`, `iv`, `appVersion`, `encryptedAt`
+- AAD に含まない field: `ciphertext` (それ自体が encrypt 出力), `encrypted: true` discriminator (judgmental)
+- `decryptBackup` 時に同じ canonical 形式で AAD を再構築し、`crypto.subtle.decrypt` の `additionalData` に渡す
+- 改竄テスト: envelope metadata の任意 1 byte を改竄したら auth tag 失敗で reject (現状の AC-7 が ciphertext 末尾 byte 改竄のみ対象だったのを metadata にも拡張)
+
+**検証方法**: vitest
+
+```typescript
+const env = await encryptBackup(plain, 'pwd-12-chars-ok', '1.0.0');
+const tamperedMeta = { ...env, appVersion: 'malicious-1.0.0' }; // ciphertext は変えない
+await expect(decryptBackup(tamperedMeta, 'pwd-12-chars-ok'))
+  .rejects.toMatchObject({ cause: { kind: 'auth-tag-mismatch' } });
+
+// algorithm 改竄 (まずは isEncryptedBackup で reject されるが、AAD でも保護される二重防御)
+const tamperedAlg = { ...env, algorithm: 'AES-GCM-256' as const, kdf: 'PBKDF2-SHA256' as const };
+// 同じ literal なら通るが、別 literal だと parseEncryptedEnvelope で先に reject される
+```
+
+注: AAD 採用により将来 algorithm agility (M7+ で ChaCha20-Poly1305 等を追加) する際、algorithm 偽装 (downgrade attack) を auth tag で機械的に防げる。
+
+---
+
+### AC-14: deriveKey の extractable=false + memory 滞留最小化
+
+**Given**: `deriveKey(passphrase, salt, iterations)` の実装
+**When**: `crypto.subtle.deriveKey` を呼ぶ
+**Then**:
+- `extractable: false` で固定（`crypto.subtle.exportKey` で raw key bytes を取り出せない）
+- `usages: ['encrypt', 'decrypt']` に限定（`['wrapKey', 'unwrapKey']` 等は付けない）
+- `utils/backupCrypto.ts` から `crypto.subtle.exportKey` を export しない（grep で確認、export 経路を機械的に閉じる）
+- `encryptBackup` / `decryptBackup` の implementation:
+  - 平文 plaintext を保持する `Uint8Array` は関数 scope を最小化、`try/finally` で encrypt/decrypt 結果の Uint8Array に `.fill(0)` 実施（best-effort zeroize、JS では完全 wipe 不可）
+  - `passphrase: string` は immutable で wipe 不可 → UI 層側で AC-9 の規律に従い React state を即クリア
+
+**検証方法**: vitest + grep
+
+```typescript
+const env = await encryptBackup(plain, 'pwd-12-chars-ok', '1.0.0');
+// internal CryptoKey は test では直接観察不能だが、deriveKey の呼び出し引数を mock spy
+expect(deriveKeyMock).toHaveBeenCalledWith(
+  expect.anything(),
+  expect.objectContaining({ extractable: false, usages: ['encrypt', 'decrypt'] }),
+);
+```
+
+```bash
+# CI script
+! grep -r "exportKey" utils/backupCrypto.ts
+```
+
+---
+
+## envelope / payload version の独立性
+
+| 軸 | 現状 | 将来の bump 規則 |
+|---|---|---|
+| envelope version (`EncryptedBackupV1.envelopeVersion`) | 1 | envelope 自体の shape が変わったとき (新 field 追加 / 既存 field 削除 / AAD 形式変更) |
+| payload version (`BackupV1.schemaVersion`) | 1 | payload (BackupV1) の shape が変わったとき (新 project field 追加等) |
+
+**規則**:
+- `EncryptedBackupV1` (envelope v1) の中身は将来 `BackupV2` (payload v2) でも構わない（envelope 解読 → payload を `parseBackup` の table-driven parser に渡す seam）
+- 逆に、envelope 自体の shape が変わったら `EncryptedBackupV2` を新設し、`isEncryptedBackup` の AND 結合に `envelopeVersion` 判定を追加して dispatch
+- payload v2 化のタイミングで envelope を bump する必要は **無い**
 
 ---
 
@@ -235,25 +473,36 @@ expect(elapsed).toBeLessThan(10_000);
 | AC | PR で達成 | 検証層 |
 |---|---|---|
 | AC-1 | PR-B | vitest |
-| AC-2 | PR-B | vitest |
+| AC-2 | PR-B | vitest + logger mock |
 | AC-3 | PR-B | vitest |
 | AC-4 | PR-B | vitest + ts-expect-error |
 | AC-5 | PR-C (slice) + PR-D (UI) | vitest + manual E2E |
-| AC-6 | PR-C (slice) + PR-D (UI) | vitest + manual E2E |
+| AC-6 | PR-C (slice) + PR-D (UI) | vitest (state machine) + manual E2E |
 | AC-7 | PR-B | vitest |
 | AC-8 | PR-B | vitest (regression) |
-| AC-9 | PR-D | manual E2E |
+| AC-9 | PR-D | manual E2E + grep test |
 | AC-10 | PR-B | vitest (performance) |
+| AC-11 | PR-B (signature) + PR-C/D (UI 統合) | vitest |
+| AC-12 | PR-B | vitest |
+| AC-13 | PR-B | vitest |
+| AC-14 | PR-B | vitest + grep |
 
 ---
 
 ## 非対象（M6 では検証しない）
 
 - **Cloud Storage upload/download** → M6.5 で別 AC
-- **Tier 2 ゲート** → M6.5 で別 AC
+- **Cloud rollback/replay protection** → M6.5 で freshness mechanism (server-side timestamp / generation number) を別 AC 化
+- **Tier 2 ゲート** → M6.5 で Cloud Storage 側にのみ Tier 2 適用、ローカルファイル機能は M6.5 後も Tier 1 のまま
 - **複数端末間の鍵共有** → ADR-0001「複数端末同期は実装しない」を踏襲、永久に非対象
 - **パスフレーズ recovery / escrow** → 設計判断 1 で「忘却即データ喪失」を採用、永久に非対象
-- **zxcvbn ベースのパスフレーズ強度判定** → MVP では length-only、将来 enhancement
+- **zxcvbn ベースのパスフレーズ強度判定** → MVP では length-only (12 文字) + grapheme count、将来 enhancement
+- **paste 禁止 (clipboard 経由パスフレーズ流出対策)** → UX 重視で許可、`oncopy`/`oncut` の preventDefault のみ実施 (AC-9)
+- **完全 memory wipe** → JavaScript で実現不能、best-effort zeroize のみ (AC-14)
+- **副チャネル攻撃 (timing / cache) 対策** → Web Crypto に委譲、ユーザーランドで防御不能
+- **量子計算機耐性 (post-quantum)** → AES-GCM-256 は量子計算機に対して鍵長半分の影響を受ける (Grover) が、本 M6 範囲では非対象。将来の post-quantum 対応は別 ADR
+- **IndexedDB の at-rest 暗号化** → IndexedDB は引き続き平文。M6 は「Export ファイル」「(M6.5 で) Cloud Storage 上の blob」のみ暗号化。UI 文言で誤読を避ける (AC-9)
+- **共有 PC での cold-boot / browser cache / IndexedDB residue 経由の漏洩** → 攻撃者が OS / browser profile にアクセス可能な場合の対策は spec 範囲外。ADR-0001 §Consequences の XSS 限界の延長線上で「OS-level threat は対象外」と明示
 
 ---
 
@@ -262,6 +511,6 @@ expect(elapsed).toBeLessThan(10_000);
 | ADR-0001 §Decision 記述 | M6 での実装 | 整合 |
 |---|---|---|
 | 「Cloud Storage = opt-in 暗号化バックアップ」 | M6 ではローカルファイルのみ、Cloud Storage は M6.5 | ⚠️ Roadmap で M6/M6.5 分割を反映 |
-| 「クライアント側 AES-GCM、E2EE」 | AES-GCM-256 + PBKDF2-SHA256 600k it. | ✅ |
-| 「XSS 時に鍵・平文ともに流出（設計上の限界）」 | spec で明示再掲、UI の警告文言にも反映 | ✅ |
+| 「クライアント側 AES-GCM、E2EE」 | AES-GCM-256 + PBKDF2-SHA256 600k it. + AAD で metadata 認証 | ✅ |
+| 「XSS 時に鍵・平文ともに流出（設計上の限界）」 | spec で明示再掲、UI の警告文言にも反映、`extractable=false` で機械的に取れる範囲は閉じる | ✅ |
 | 「複数端末同期は実装しない」 | 鍵共有なし、ファイル持ち歩き前提 | ✅ |

--- a/docs/spec/m6/tasks.md
+++ b/docs/spec/m6/tasks.md
@@ -85,29 +85,43 @@ ADR-0001 Roadmap では M6 を「E2EE 暗号化バックアップ（任意機能
 ### タスク
 
 - [ ] `utils/backupCrypto.ts` 新設
-  - [ ] `deriveKey(passphrase: string, salt: Uint8Array, iterations: number): Promise<CryptoKey>` (PBKDF2-SHA256)
-  - [ ] `encryptBackup(plaintext: BackupV1, passphrase: string, appVersion: string, now?: Date): Promise<EncryptedBackupV1>`
-  - [ ] `decryptBackup(envelope: EncryptedBackupV1, passphrase: string): Promise<BackupV1>`
-  - [ ] 内部 helper: `randomBytes(len: number): Uint8Array` (`crypto.getRandomValues` ラッパー)
-  - [ ] base64 encode/decode helper
+  - [ ] **constant**: `PBKDF2_ITERATIONS = 600_000` / `MIN_ACCEPTED_ITERATIONS = 100_000` / `MAX_ACCEPTED_ITERATIONS = 10_000_000` / `MAX_CIPHERTEXT_BYTES = 100 * 1024 * 1024` / `MAX_ENVELOPE_FILE_BYTES = 150 * 1024 * 1024` / `DECRYPT_FAILURE_MESSAGE = 'パスフレーズが正しくないか、ファイルが壊れています。'` / `MIN_PASSPHRASE_GRAPHEMES = 12`
+  - [ ] **API**:
+    - [ ] `randomBytes(len: number): Uint8Array` (`crypto.getRandomValues` ラッパー、test util から import 可能、`exportKey` 経路は持たない)
+    - [ ] `deriveKey(passphrase: string, salt: Uint8Array, iterations: number): Promise<CryptoKey>` (PBKDF2-SHA256, **`extractable: false`** + **`usages: ['encrypt', 'decrypt']`**)
+    - [ ] `encryptBackup(plaintext: BackupV1, passphrase: string, appVersion: string, opts?: { signal?: AbortSignal; now?: Date }): Promise<EncryptedBackupV1>` (AAD で envelope metadata 認証)
+    - [ ] `decryptBackup(envelope: EncryptedBackupV1, passphrase: string, opts?: { signal?: AbortSignal }): Promise<BackupV1>` (catch を 4 cause に分類、broad catch 禁止)
+    - [ ] `validatePassphraseLength(p: string): void` (grapheme 単位で `[...p].length >= MIN_PASSPHRASE_GRAPHEMES`、不足で BackupValidationError)
+    - [ ] base64 encode/decode helper (test util から import 可能)
+  - [ ] **regularization**: passphrase は `passphrase.normalize('NFC')` してから `TextEncoder.encode` (AC-12)
+  - [ ] **AAD**: `buildAad(meta): Uint8Array` (key-sorted JSON.stringify → encode、含む field は AC-13 参照)
+  - [ ] **try/finally で best-effort zeroize**: encrypt/decrypt 中の `Uint8Array` を `.fill(0)` (AC-14)
+  - [ ] **`crypto.subtle.exportKey` を export しない** (CI grep で検証、AC-14)
 - [ ] `utils/backupSchema.ts` 拡張
-  - [ ] `EncryptedBackupV1` 型定義（types.ts に export）
-  - [ ] `isEncryptedBackup(json: Record<string, unknown>): boolean` (discriminator chk)
-  - [ ] `parseEncryptedEnvelope(json: Record<string, unknown>): EncryptedBackupV1` (validation + sanitize)
-  - [ ] `parseBackup` chain に encrypted 分岐追加（復号は backupSlice 側で実施するため、parseBackup 自体は envelope を返す型へ拡張 or 別関数 `parseBackupOrEnvelope` を追加）
+  - [ ] `EncryptedBackupV1` 型定義（types.ts に export、`envelopeVersion: 1` field を `schemaVersion` の代わりに採用）
+  - [ ] `isEncryptedBackup(json: Record<string, unknown>): json is { encrypted: true; ... }` (AC-8 の AND 結合判定、type guard として宣言)
+  - [ ] `parseEncryptedEnvelope(json: Record<string, unknown>): EncryptedBackupV1` (parse-time validation: literal check / iterations floor & ceiling / salt 16 bytes / iv 12 bytes / ciphertext size limit、半壊 envelope は `BackupValidationError ({ cause: { kind: 'envelope-incomplete' } })` で reject)
+  - [ ] `parseAnyBackup(raw: string): BackupV1 | EncryptedBackupV1` 新設 (encrypted detection + 既存 parseBackup の平文 path に dispatch)
+  - [ ] `parseBackup` (既存関数) は **戻り値型 `BackupV1` 不変**、分岐は `parseAnyBackup` に分離 (AC-8 regression 保護)
 - [ ] `types.ts` に `EncryptedBackupV1` interface 追加
+- [ ] **`BackupValidationError` 拡張**: `cause: { kind: 'auth-tag-mismatch' | 'plaintext-corrupted' | 'schema-invalid' | 'kdf-import-failed' | 'envelope-incomplete' | 'no-pending-decryption' | ... }` を保持できる constructor (Error.cause native 使用)
+- [ ] **logger 経路**: `errorIds.ts` (or 新設 `loggerIds.ts`) に `M6_DECRYPT_AUTH_TAG_FAILED` / `M6_DECRYPT_PLAINTEXT_CORRUPTED` / `M6_DECRYPT_SCHEMA_INVALID` / `M6_DECRYPT_KDF_FAILED` を追加。`logger.warn(id, safe_metadata)` 呼出 (passphrase / plaintext / derived key / salt / ciphertext は絶対に含めない)
 - [ ] vitest 追加
-  - [ ] `utils/backupCrypto.test.ts`: encrypt/decrypt round-trip / 誤りパスフレーズ拒否 / IV 一意性 (100 回) / KDF 決定性 / 改竄検知
-  - [ ] `utils/backupSchema.test.ts` 拡張: encrypted envelope parse / 既存平文 BackupV1 後方互換 regression
-- [ ] CLAUDE.md MUST: 境界値テスト (パスフレーズ 0/1/最大長 / iterations 境界)
+  - [ ] `utils/backupCrypto.test.ts`: AC-1〜4, AC-7, AC-10, AC-11, AC-12, AC-13, AC-14 (合計 ~30 ケース)
+  - [ ] `utils/backupSchema.test.ts` 拡張: AC-8 (encrypted envelope parse / 既存平文 BackupV1 後方互換 regression / 半壊 envelope reject / 6 ケース fixture pin)
+  - [ ] `tests/static/no-error-cause-in-components.test.ts`: components 配下の `error.cause` 参照ゼロ assert (AC-9)
+  - [ ] `tests/static/no-export-key.test.ts`: backupCrypto から `exportKey` の export ゼロ assert (AC-14)
+- [ ] **test fixtures**: `buildSampleBackup()` / `buildLargeBackup(numProjects, perProjectBytes)` / `tamperLastByte(b64)` を `tests/fixtures/backup.ts` に集約 (AC-1, AC-7, AC-10 で再利用)
+- [ ] CLAUDE.md MUST: 境界値テスト (パスフレーズ 0/1/11/12/13/最大長 / iterations 境界 MIN-1, MIN, MAX, MAX+1)
 
 ### 完了条件 (DoD)
 
-- [ ] AC-1, AC-2, AC-3, AC-4, AC-7, AC-8 が vitest で PASS
+- [ ] AC-1, AC-2, AC-3, AC-4, AC-7, AC-8, AC-10, AC-11, AC-12, AC-13, AC-14 が vitest で PASS
 - [ ] `npm run lint` 0 errors
 - [ ] `npm test` 全 PASS
 - [ ] `/simplify` 3 並列 + `/safe-refactor` 通過
-- [ ] PR description にパスフレーズ忘却＝データ喪失の明示
+- [ ] **Evaluator 分離プロトコル発動** (新規機能のため、`rules/quality-gate.md` 準拠)
+- [ ] PR description にパスフレーズ忘却＝データ喪失 + Unicode NFC normalization の forward-locking を明示
 
 ---
 
@@ -115,19 +129,26 @@ ADR-0001 Roadmap では M6 を「E2EE 暗号化バックアップ（任意機能
 
 ### タスク
 
-- [ ] **PR-C 着手前 MUST**: `pendingDecryption` state 遷移図を `docs/spec/m6/state-diagram.md` に作成（CLAUDE.md MUST「statusフィールドで処理状態を管理する設計 → 状態遷移図を先に作成」準拠、`design-diagram` skill 利用）
+- [ ] **PR-C 着手前 MUST**: `pendingDecryption` state 遷移図を `docs/spec/m6/state-diagram.md` に作成（CLAUDE.md MUST「statusフィールドで処理状態を管理する設計 → 状態遷移図を先に作成」準拠、`design-diagram` skill 利用）。状態: `idle` / `pendingDecryption` / `decrypting` / `decrypted-conflict-resolution` / `error` / `cancelled` + 遷移条件と禁則
 - [ ] `store/backupSlice.ts` 拡張
-  - [ ] `exportAllData(opts?: { encrypt?: { passphrase: string } })` に encrypt option 追加（or 別 action `exportAllDataEncrypted`）
-  - [ ] `prepareImport` で `EncryptedBackupV1` 検出時に新規 state `pendingDecryption: { rawEnvelope: EncryptedBackupV1 }` を設定
-  - [ ] 新 action `decryptAndPrepareImport(passphrase: string)` 追加: 復号成功時に既存 conflict 検出フローへ合流
-  - [ ] 新 action `cancelPendingDecryption()` 追加
+  - [ ] `exportAllData(opts?: { encrypt?: { passphrase: string }; signal?: AbortSignal })` に encrypt option + AbortSignal 追加（or 別 action `exportAllDataEncrypted`）
+  - [ ] `prepareImport` で `EncryptedBackupV1` 検出時に新規 state `pendingDecryption: { rawEnvelope: EncryptedBackupV1; retryCount: number; abortController: AbortController }` を設定
+  - [ ] 新 action `decryptAndPrepareImport(passphrase: string)` 追加:
+    - [ ] 復号成功時に既存 conflict 検出フローへ合流
+    - [ ] 復号失敗時は `retryCount` を increment、5 回超で modal 強制 close + トースト (AC-6)
+    - [ ] `pendingDecryption === null` で呼ばれたら throw (`cause: { kind: 'no-pending-decryption' }`、AC-6)
+    - [ ] `signal.aborted` の場合は state 更新を skip (race-free)
+  - [ ] 新 action `cancelPendingDecryption()` 追加: `abortController.abort()` を呼んでから state 初期化
+  - [ ] `prepareImport` の二重呼び出し対策: 既存 `pendingDecryption` あり時は **先に `cancelPendingDecryption` を呼んでから** new state を set (AC-6 race-free 上書き禁止)
 - [ ] vitest 拡張
-  - [ ] `store/backupSlice.test.ts` 拡張: encrypted export round-trip / pendingDecryption state transition / decryptAndPrepareImport 成功・失敗 path / cancelPendingDecryption
+  - [ ] `store/backupSlice.test.ts` 拡張: encrypted export round-trip / pendingDecryption state transition (illegal transition reject / 二重 import / cancel race) / decryptAndPrepareImport 成功・失敗・retry / cancelPendingDecryption + AbortSignal 連動 / 5 回 retry 超過
 
 ### 完了条件 (DoD)
 
-- [ ] AC-5 (export 動線統合の slice 層) が vitest で PASS（UI 部分は PR-D）
-- [ ] AC-6 (import 動線統合の slice 層) が vitest で PASS
+- [ ] AC-5 (export 動線統合の slice 層、AbortSignal 含む) が vitest で PASS（UI 部分は PR-D）
+- [ ] AC-6 (import 動線統合 + state machine 規律) が vitest で PASS
+- [ ] AC-11 (AbortSignal 経路) の slice 層が vitest で PASS
+- [ ] state-diagram.md と AC-6 の transition table が一致
 - [ ] `npm run lint` 0 errors / `npm test` 全 PASS
 - [ ] `/simplify` 3 並列通過
 
@@ -138,26 +159,37 @@ ADR-0001 Roadmap では M6 を「E2EE 暗号化バックアップ（任意機能
 ### タスク
 
 - [ ] `components/modals/ExportEncryptModal.tsx` 新設
-  - [ ] パスフレーズ入力 + 確認再入力 + length-only 強度表示
-  - [ ] 「暗号化してダウンロード」ボタン（最低 8 文字 + 一致時のみ enable）
-  - [ ] パスフレーズ忘却警告文言
-  - [ ] `role="dialog"` + a11y 属性
+  - [ ] パスフレーズ入力 + 確認再入力 + grapheme count 強度表示
+  - [ ] 「暗号化してダウンロード」ボタン（**最低 12 grapheme** + 一致時のみ enable、AC-5）
+  - [ ] パスフレーズ忘却警告文言 + 強度ヒント文言（AC-9 参照）
+  - [ ] `<input type="password" autocomplete="new-password">` + `oncopy` / `oncut` の `preventDefault` (AC-9)
+  - [ ] 暗号化成功 / 失敗どちらでも passphrase state を `setPassphrase('')` クリア (AC-5, AC-14)
+  - [ ] 30 秒タイムアウト時の abort + トースト + cancel ボタン (AC-11)
+  - [ ] `role="dialog"` + Tab 内ループ + a11y 属性 (AC-9)
+  - [ ] Blob/URL.createObjectURL は try/finally で `URL.revokeObjectURL` cleanup (AC-5)
 - [ ] `components/modals/ImportPassphraseModal.tsx` 新設
   - [ ] パスフレーズ入力 + 「復号する」ボタン
-  - [ ] エラー文言「パスフレーズが正しくないかファイルが壊れています」（auth tag 失敗を fingerprinting しない）
-  - [ ] キャンセル動線
+  - [ ] エラー文言は constant `DECRYPT_FAILURE_MESSAGE` を直接使用 (auth tag 失敗を fingerprinting しない、AC-9)
+  - [ ] retry カウンタ表示 (現在 N/5 回)、5 回到達で強制 close + トースト (AC-6)
+  - [ ] キャンセル動線 (`cancelPendingDecryption` 経由、AC-6)
+  - [ ] 復号成功 / 失敗どちらでも passphrase state を即クリア (AC-9)
+  - [ ] 30 秒タイムアウト abort (AC-11)
+  - [ ] `<input type="password" autocomplete="off">` + `oncopy` / `oncut` の `preventDefault` (AC-9)
 - [ ] 既存 Export 動線拡張
   - [ ] 既存 Export 動線エントリポイント全箇所（`handleExportAllData` を呼ぶ全コンポーネント。grep で網羅確認）に「暗号化する」チェックボックスを追加
   - [ ] チェック ON で ExportEncryptModal を mount
 - [ ] 既存 Import 動線拡張
   - [ ] `prepareImport` で encrypted envelope 検出時に ImportPassphraseModal を mount
   - [ ] 復号成功時に既存 ImportConflictModal にバトンタッチ
-- [ ] `components/ModalManager.tsx` に新規 2 modal を統合（mount 順序: ExportEncryptModal / ImportPassphraseModal）
+- [ ] `components/ModalManager.tsx` に新規 2 modal を統合（mount 順序 + 競合時の優先順位を state-diagram.md に記載済の通り）
+- [ ] **CI 静的検査 (AC-9, AC-14)**:
+  - [ ] `tests/static/no-error-cause-in-components.test.ts` (components 配下の `error.cause` 参照ゼロ)
+  - [ ] `tests/static/no-export-key.test.ts` (utils/backupCrypto から exportKey export ゼロ)
 
 ### 完了条件 (DoD)
 
-- [ ] AC-5, AC-6 (UI 部分) が manual E2E で確認済（dev サーバ）
-- [ ] AC-9 (a11y / 改竄検知 UI 文言) が manual で確認済
+- [ ] AC-5, AC-6, AC-9, AC-11 (UI 部分) が manual E2E で確認済（dev サーバ）
+- [ ] CI 静的検査 (AC-9 cause grep + AC-14 exportKey grep) が PASS
 - [ ] `npm run lint` 0 errors / `npm test` 全 PASS
 - [ ] **Evaluator 分離プロトコル発動** (5 ファイル以上 **または** 新規機能、`rules/quality-gate.md` 準拠)
 - [ ] `/simplify` 3 並列 + `/review-pr` 6 並列 + 大規模なら `/codex review` セカンドオピニオン

--- a/docs/spec/m6/tasks.md
+++ b/docs/spec/m6/tasks.md
@@ -1,0 +1,170 @@
+# M6: E2EE 暗号化バックアップ タスク表
+
+- Status: 🚧 着手中（spec 起こし PR-A、2026-04-29）
+- Owner: yasushi-honda
+- Started: 2026-04-29
+- Related ADR: [ADR-0001](../../adr/0001-local-first-architecture.md) §Decision (Cloud Storage = opt-in 暗号化バックアップ) / §Consequences (XSS 時 E2EE 限界)
+
+## 背景: M6 と M6.5 の分割
+
+ADR-0001 Roadmap では M6 を「E2EE 暗号化バックアップ（任意機能、後回し可）」として記載していたが、M5 (Stripe) 未完了の状態で着手するため、Tier 2 ゲート不要で完結する範囲を **M6**、Cloud Storage 連携を **M6.5** に分割する。
+
+| マイルストーン | スコープ | M5 (Stripe) 依存 | 推定工数 |
+|---|---|---|---|
+| **M6 (本ドキュメントの主対象)** | クライアント側 AES-GCM + パスフレーズ派生 + ローカルファイル `.enc.json` の暗号化 Export/Import | なし | 6〜8 時間 |
+| M6.5 | Cloud Storage 連携（signed URL upload/download + uid scope + Tier 2 ゲート） | あり (M5 完了後) | 4〜6 時間 |
+
+## M6 ゴール
+
+1. **クライアント側 E2EE 機構を導入**: パスフレーズ派生 (PBKDF2-SHA256, 600,000 iterations) + AES-GCM-256 暗号化
+2. **`EncryptedBackupV1` envelope schema を確定**: 平文 `BackupV1` を JSON.stringify → AES-GCM 暗号化 → base64 でラップ
+3. **既存 M4 Export/Import 動線に統合**: 「暗号化する」option 追加、`.enc.json` 拡張子で download / 自動検出復号
+4. **既存平文 BackupV1 の後方互換維持**: M4 で生成したファイルは引き続き読み込める
+5. **改竄検知**: AES-GCM auth tag 検証失敗を「パスフレーズ誤り or ファイル破損」として区別なくエラー表示（fingerprinting 防止）
+
+## マイルストーン外スコープ（M6 ではやらないこと）
+
+- **Cloud Storage 連携**（M6.5、Stripe Tier 2 ゲート前提）
+- **鍵 escrow / 鍵 recovery**（パスフレーズ忘却 = データ喪失、ユーザー責任明示）
+- **Argon2id 派生**（PR の規模を抑えるため PBKDF2 で fix、将来の KDF 移行 seam は kdf field で残す）
+- **パスフレーズ強度の zxcvbn ベース判定**（length-only check で MVP、強度バーは将来 enhancement）
+- **`parseBackup` の table-driven parser 化**（Issue #49 「Schema v2 への seam」TODO は本 M6 では対象外、別 PR で実施）
+- **複数端末間の鍵共有**（ADR-0001「複数端末同期は実装しない」を踏襲）
+
+## 設計判断
+
+| 判断 | 採用 | 理由 |
+|---|---|---|
+| 鍵管理方式 | パスフレーズ派生 (PBKDF2-SHA256) | UX 軽量、サーバ側に escrow 残さない、ADR-0001「XSS 時 E2EE 限界」と整合 |
+| 保管先段階 | ローカルファイル暗号化のみ (M6)、Cloud Storage は M6.5 | M5 Stripe 未完了で Tier 2 ゲート組めない、独立した設計判断（signed URL / 容量制限 / 競合検知）を分離 |
+| Tier ゲート | M6 範囲は Tier 1 でも使える機能として実装。M6.5 の Cloud Storage 連携時点で Tier 2 ゲートを **Cloud Storage 側にのみ適用**、ローカルファイル機能は Tier 1 のまま維持 | M6 ではサーバコスト発生せず、Tier 制限する根拠が無い。M6.5 で初めて発生するクラウド保管コストに対して Tier 2 を適用 |
+| envelope schema | `EncryptedBackupV1` を新設（discriminator: `encrypted: true`） | 既存 `BackupV1` を平文 inner として保ち、後方互換性確保 |
+| UI 統合 | 既存 Export モーダルに「暗号化する」チェックボックス追加 | 動線統一、ユーザー選択可能 |
+
+## 前提と既存資産の利用
+
+- **`utils/backupSchema.ts` (M4 導入)**: `BackupV1` を平文 envelope として再利用、`parseBackup` の判定 chain に encrypted 分岐を追加
+- **`store/backupSlice.ts` (M4 導入)**: `exportAllData` / `prepareImport` / `executeImport` を「暗号化 ON/OFF」分岐
+- **`db/backupRepository.ts` (M4 導入)**: 変更なし（IndexedDB は平文しか書かない）
+- **`components/modals/ImportConflictModal.tsx` (M4 導入)**: 復号後の conflict 検出は既存フローに合流
+- **Web Crypto API (`globalThis.crypto.subtle`)**: ブラウザ標準 + Node 20+ で利用可能、追加依存なし
+
+## PR 構成
+
+| PR | 内容 | 規模 | 工数 | 状態 |
+|---|---|---|---|---|
+| **PR-A** | docs(m6) M6 仕様 + AC + ADR-0001 Roadmap 更新（M6 / M6.5 分割反映） | 小〜中 | 1〜1.5 時間 | 🚧 着手中 |
+| **PR-B** | feat(m6) `utils/backupCrypto.ts` 新設 (deriveKey/encrypt/decrypt) + `utils/backupSchema.ts` に EncryptedBackupV1 型 + parseBackup 分岐 + vitest 単体テスト | 中 | 2〜3 時間 | ⏳ |
+| **PR-C** | feat(m6) `store/backupSlice.ts` に encrypt/decrypt 経路統合 + 統合テスト | 中 | 1.5〜2 時間 | ⏳ |
+| **PR-D** | feat(m6) UI 実装 (ExportEncryptModal + ImportPassphraseModal + Export/Import 動線統合) | 大 | 2〜3 時間 | ⏳ |
+
+着手順序: **PR-A → PR-B → PR-C → PR-D**（逐次、各段階で merge 可能な状態を維持）
+
+---
+
+## PR-A: 仕様 + ADR 更新
+
+### タスク
+
+- [x] `docs/spec/m6/tasks.md` 起こし（本ファイル）
+- [x] `docs/spec/m6/acceptance-criteria.md` 起こし
+- [ ] `docs/adr/0001-local-first-architecture.md` Roadmap を M6 / M6.5 分割に更新
+- [ ] `CLAUDE.md` Architecture に M6 該当時の追記（PR-B 着手前にスケッチ、PR-D 完了時に最終化）
+
+### 完了条件 (DoD)
+
+- [x] tasks.md / acceptance-criteria.md がレビュー可能な完成度
+- [ ] ADR-0001 Roadmap が M6 / M6.5 分割に整合
+- [ ] PR description に「設計判断 5 件の確定内容」を再掲
+- [ ] code-reviewer + comment-analyzer の Quality Gate 通過
+
+---
+
+## PR-B: crypto core + schema 拡張
+
+### タスク
+
+- [ ] `utils/backupCrypto.ts` 新設
+  - [ ] `deriveKey(passphrase: string, salt: Uint8Array, iterations: number): Promise<CryptoKey>` (PBKDF2-SHA256)
+  - [ ] `encryptBackup(plaintext: BackupV1, passphrase: string, appVersion: string, now?: Date): Promise<EncryptedBackupV1>`
+  - [ ] `decryptBackup(envelope: EncryptedBackupV1, passphrase: string): Promise<BackupV1>`
+  - [ ] 内部 helper: `randomBytes(len: number): Uint8Array` (`crypto.getRandomValues` ラッパー)
+  - [ ] base64 encode/decode helper
+- [ ] `utils/backupSchema.ts` 拡張
+  - [ ] `EncryptedBackupV1` 型定義（types.ts に export）
+  - [ ] `isEncryptedBackup(json: Record<string, unknown>): boolean` (discriminator chk)
+  - [ ] `parseEncryptedEnvelope(json: Record<string, unknown>): EncryptedBackupV1` (validation + sanitize)
+  - [ ] `parseBackup` chain に encrypted 分岐追加（復号は backupSlice 側で実施するため、parseBackup 自体は envelope を返す型へ拡張 or 別関数 `parseBackupOrEnvelope` を追加）
+- [ ] `types.ts` に `EncryptedBackupV1` interface 追加
+- [ ] vitest 追加
+  - [ ] `utils/backupCrypto.test.ts`: encrypt/decrypt round-trip / 誤りパスフレーズ拒否 / IV 一意性 (100 回) / KDF 決定性 / 改竄検知
+  - [ ] `utils/backupSchema.test.ts` 拡張: encrypted envelope parse / 既存平文 BackupV1 後方互換 regression
+- [ ] CLAUDE.md MUST: 境界値テスト (パスフレーズ 0/1/最大長 / iterations 境界)
+
+### 完了条件 (DoD)
+
+- [ ] AC-1, AC-2, AC-3, AC-4, AC-7, AC-8 が vitest で PASS
+- [ ] `npm run lint` 0 errors
+- [ ] `npm test` 全 PASS
+- [ ] `/simplify` 3 並列 + `/safe-refactor` 通過
+- [ ] PR description にパスフレーズ忘却＝データ喪失の明示
+
+---
+
+## PR-C: backupSlice 統合
+
+### タスク
+
+- [ ] **PR-C 着手前 MUST**: `pendingDecryption` state 遷移図を `docs/spec/m6/state-diagram.md` に作成（CLAUDE.md MUST「statusフィールドで処理状態を管理する設計 → 状態遷移図を先に作成」準拠、`design-diagram` skill 利用）
+- [ ] `store/backupSlice.ts` 拡張
+  - [ ] `exportAllData(opts?: { encrypt?: { passphrase: string } })` に encrypt option 追加（or 別 action `exportAllDataEncrypted`）
+  - [ ] `prepareImport` で `EncryptedBackupV1` 検出時に新規 state `pendingDecryption: { rawEnvelope: EncryptedBackupV1 }` を設定
+  - [ ] 新 action `decryptAndPrepareImport(passphrase: string)` 追加: 復号成功時に既存 conflict 検出フローへ合流
+  - [ ] 新 action `cancelPendingDecryption()` 追加
+- [ ] vitest 拡張
+  - [ ] `store/backupSlice.test.ts` 拡張: encrypted export round-trip / pendingDecryption state transition / decryptAndPrepareImport 成功・失敗 path / cancelPendingDecryption
+
+### 完了条件 (DoD)
+
+- [ ] AC-5 (export 動線統合の slice 層) が vitest で PASS（UI 部分は PR-D）
+- [ ] AC-6 (import 動線統合の slice 層) が vitest で PASS
+- [ ] `npm run lint` 0 errors / `npm test` 全 PASS
+- [ ] `/simplify` 3 並列通過
+
+---
+
+## PR-D: UI 実装
+
+### タスク
+
+- [ ] `components/modals/ExportEncryptModal.tsx` 新設
+  - [ ] パスフレーズ入力 + 確認再入力 + length-only 強度表示
+  - [ ] 「暗号化してダウンロード」ボタン（最低 8 文字 + 一致時のみ enable）
+  - [ ] パスフレーズ忘却警告文言
+  - [ ] `role="dialog"` + a11y 属性
+- [ ] `components/modals/ImportPassphraseModal.tsx` 新設
+  - [ ] パスフレーズ入力 + 「復号する」ボタン
+  - [ ] エラー文言「パスフレーズが正しくないかファイルが壊れています」（auth tag 失敗を fingerprinting しない）
+  - [ ] キャンセル動線
+- [ ] 既存 Export 動線拡張
+  - [ ] 既存 Export 動線エントリポイント全箇所（`handleExportAllData` を呼ぶ全コンポーネント。grep で網羅確認）に「暗号化する」チェックボックスを追加
+  - [ ] チェック ON で ExportEncryptModal を mount
+- [ ] 既存 Import 動線拡張
+  - [ ] `prepareImport` で encrypted envelope 検出時に ImportPassphraseModal を mount
+  - [ ] 復号成功時に既存 ImportConflictModal にバトンタッチ
+- [ ] `components/ModalManager.tsx` に新規 2 modal を統合（mount 順序: ExportEncryptModal / ImportPassphraseModal）
+
+### 完了条件 (DoD)
+
+- [ ] AC-5, AC-6 (UI 部分) が manual E2E で確認済（dev サーバ）
+- [ ] AC-9 (a11y / 改竄検知 UI 文言) が manual で確認済
+- [ ] `npm run lint` 0 errors / `npm test` 全 PASS
+- [ ] **Evaluator 分離プロトコル発動** (5 ファイル以上 **または** 新規機能、`rules/quality-gate.md` 準拠)
+- [ ] `/simplify` 3 並列 + `/review-pr` 6 並列 + 大規模なら `/codex review` セカンドオピニオン
+- [ ] CLAUDE.md Architecture に M6 反映（最終化）
+
+---
+
+## M6 振り返り（PR-D merge 後に追記）
+
+（PR-D 完了時に handoff PR で追記）


### PR DESCRIPTION
## Summary

- M6 (E2EE 暗号化バックアップ・ローカルファイル範囲) の spec と AC を起こし、ADR-0001 Roadmap を M6 / M6.5 分割に更新する **doc-only PR-A**
- 本 PR では実装は行わない。続く PR-B (crypto core) / PR-C (slice 統合) / PR-D (UI) の前提を確定させる

## 変更ファイル

| File | Change |
|---|---|
| `docs/spec/m6/tasks.md` | 新規 — 設計判断 5 件 / PR 構成 (A/B/C/D) / DoD |
| `docs/spec/m6/acceptance-criteria.md` | 新規 — AC-1〜AC-14 (14 基準) |
| `docs/adr/0001-local-first-architecture.md` | Roadmap に M6 / M6.5 分割を反映、§M6/M6.5 分割の経緯セクション追加 |

## 設計判断の確定内容（2026-04-29 セッションで全 A 採用）

| 判断 | 採用 | 理由 |
|---|---|---|
| 鍵管理方式 | パスフレーズ派生 (PBKDF2-SHA256, 600,000 iter.) + NFC normalization | UX 軽量、サーバ側に escrow 残さない、ADR-0001「XSS 時 E2EE 限界」と整合 |
| 保管先段階 | M6 はローカルファイル `.enc.json` のみ、Cloud Storage は M6.5 | M5 (Stripe) 未完了で Tier 2 ゲート組めない、独立した設計判断（signed URL / 容量制限 / 競合検知）を分離 |
| Tier ゲート | M6 範囲は Tier 1 でも使える、M6.5 で Cloud Storage 側にのみ Tier 2 適用 | M6 ではサーバコスト発生せず、Tier 制限する根拠が無い |
| envelope schema | `EncryptedBackupV1` 新設、`envelopeVersion: 1` (payload `BackupV1.schemaVersion` と独立) + AES-GCM AAD で metadata 認証 | envelope と payload の version 軸を分離、metadata 改竄を auth tag で検知 |
| UI 統合 | 既存 Export モーダルに「暗号化する」チェックボックス追加 | 動線統一、ユーザー選択可能 |

## Quality Gate

CLAUDE.md MUST に従い 6 reviewer 並列 + Codex セカンドオピニオン実施:

### 第 1 段階 (code-reviewer + comment-analyzer): 重要指摘 7 件を反映
- AC-3 KDF コスト過大 → IV 生成器を直接呼ぶ smoke test 化
- AC-10 Node vs Browser 性能差 → Node 環境前提に書き換え + CI 緩和
- AC-1 byte-equivalence → JSON 経由 deep-equal
- I-1 ファイル行数固定削除
- I-3 caller 列挙抽象化
- I-7 Tier ゲート整合表現修正
- AC-4 literal 型 → number + constant

### 第 2 段階 (pr-test-analyzer + silent-failure-hunter + type-design-analyzer + codex): blocker 13 件を反映
- B1: PR-C pendingDecryption state-machine AC (illegal transition / 二重 import / cancel race) 追加
- B2: AC-8 regression assertion を 6 ケース fixture pin + parseBackup 戻り値型 invariance 明記
- B3: Unicode passphrase NFC normalization policy 確定 (forward-locking)
- B4: logger と UI 文言の分離 (errorIds.ts に M6_DECRYPT_* 4 種追加)
- B5: decryptBackup catch を 4 cause に分類 + broad catch 禁止
- B6: AC-11 (AbortSignal + 30 秒 UI timeout) 新設
- B7: extractable: false + Uint8Array zeroize + passphrase state クリア
- B8: isEncryptedBackup AND 結合 (encrypted + algorithm + kdf + iv + ciphertext + salt) + 半壊 envelope reject
- B9: MIN_ACCEPTED_ITERATIONS floor + MAX_ACCEPTED_ITERATIONS ceiling + MAX_CIPHERTEXT_BYTES 上限 (DoS 対策)
- B10: envelope schemaVersion → envelopeVersion rename + 独立 version 軸を用語規則で明示
- B11: BackupValidationError 単一 class + Error.cause で内部 triage (UI fingerprinting と debuggability 両立)
- B12: AC-13 (AES-GCM AAD で envelope metadata 認証) 新設
- B13: パスフレーズ最低長 8 → 12 grapheme に強化 (M6.5 Cloud Storage offline 攻撃対策、forward-locking)

CLAUDE.md MUST「statusフィールド管理時は状態遷移図を先に作成」に対応し、pendingDecryption state 遷移図作成を **PR-C 着手前 MUST** タスクとして tasks.md に追加。

### 暗号設計の確認 (codex)
- PBKDF2-HMAC-SHA256 600,000 iter. + AES-GCM-256 + IV 12B + salt 16B は OWASP 2023 準拠で適切
- AAD 未使用は将来の algorithm agility で error-prone → AC-13 で採用
- 8 文字最低長は M6.5 で弱い → 12 文字に強化

## 関連

- ADR-0001 §Decision「Cloud Storage = opt-in 暗号化バックアップ（クライアント側 AES-GCM、E2EE）」
- M4 (PR #48) で確定した BackupV1 schema を平文 inner として再利用
- Issue #49 「Schema v2 への seam」TODO は本 M6 では分離 (M6.5 / 別 Issue)

## Test plan

- [x] cat docs/spec/m6/tasks.md で構造確認（背景 / ゴール / 設計判断 / PR 構成 / DoD が揃う）
- [x] cat docs/spec/m6/acceptance-criteria.md で AC-1〜14 が Given/When/Then 形式
- [x] grep M6.5 docs/adr/0001-local-first-architecture.md で Roadmap 更新確認
- [x] code-reviewer + comment-analyzer + pr-test-analyzer + silent-failure-hunter + type-design-analyzer + codex review 全 6 通過
- [x] blocker 20 件 (7 + 13) 全反映
- [ ] (本 PR merge 後) PR-B 着手時に AC の実装可能性を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)