### PR TITLE
feat(m6): PR-B crypto core (AES-GCM-256 + PBKDF2-SHA256 + AAD) + parseAnyBackup

### DIFF
--- a/docs/spec/m6/acceptance-criteria.md
+++ b/docs/spec/m6/acceptance-criteria.md
@@ -45,7 +45,7 @@ expect(decrypted.projects.length).toBe(plaintext.projects.length);
 - `BackupValidationError` が throw される
 - UI 向け `error.message` は constant `DECRYPT_FAILURE_MESSAGE` （「パスフレーズが正しくないか、ファイルが壊れています」）と完全一致
 - 内部 triage 用に `error.cause === { kind: 'auth-tag-mismatch' }` が設定される（**UI 層は cause を読まない**規律。AC-9 で別途固定）
-- `logger.warn('M6_DECRYPT_AUTH_TAG_FAILED', { envelopeVersion, algorithm, kdf, iterations, encryptedAt })` が呼ばれる（**passphrase / plaintext / derived key / salt / ciphertext は絶対に log に含めない**）
+- `console.warn('M6_DECRYPT_AUTH_TAG_FAILED', { envelopeVersion, algorithm, kdf, iterations, encryptedAt })` が呼ばれる（**passphrase / plaintext / derived key / salt / ciphertext は絶対に log に含めない**）
 
 **検証方法**: vitest
 
@@ -57,9 +57,10 @@ await expect(decryptBackup(envelope, 'wrong-passphrase'))
     message: DECRYPT_FAILURE_MESSAGE,
     cause: { kind: 'auth-tag-mismatch' },
   });
-expect(loggerMock.warn).toHaveBeenCalledWith(
+// FE は専用 logger を持たないため `console.warn` を直接使用。第 1 引数で event id を pin。
+expect(consoleWarnSpy).toHaveBeenCalledWith(
   'M6_DECRYPT_AUTH_TAG_FAILED',
-  expect.not.objectContaining({ passphrase: expect.anything() }),
+  expect.objectContaining({ envelopeVersion: 1, algorithm: 'AES-GCM-256' }),
 );
 ```
 
@@ -228,7 +229,7 @@ await expect(parseEncryptedEnvelope({ ...env, kdfParams: { ...env.kdfParams, ite
   3. `'schema-invalid'`: 復号後 BackupV1 schema validation 失敗
   4. `'kdf-import-failed'`: `crypto.subtle.importKey` / `deriveKey` 失敗 (KDF パラメータ不正、`NotSupportedError` 等)
 - 上記いずれにも該当しない catch-all は **禁止** (再 throw、CLAUDE.md「empty catch / 広い catch 禁止」準拠)
-- 各 cause に対応する `logger.warn` が呼ばれる: `M6_DECRYPT_AUTH_TAG_FAILED` / `M6_DECRYPT_PLAINTEXT_CORRUPTED` / `M6_DECRYPT_SCHEMA_INVALID` / `M6_DECRYPT_KDF_FAILED`
+- 各 cause に対応する `console.warn` が呼ばれる: `M6_DECRYPT_AUTH_TAG_FAILED` / `M6_DECRYPT_PLAINTEXT_CORRUPTED` / `M6_DECRYPT_SCHEMA_INVALID` / `M6_DECRYPT_KDF_FAILED`
 
 **検証方法**: vitest
 
@@ -473,7 +474,7 @@ expect(deriveKeyMock).toHaveBeenCalledWith(
 | AC | PR で達成 | 検証層 |
 |---|---|---|
 | AC-1 | PR-B | vitest |
-| AC-2 | PR-B | vitest + logger mock |
+| AC-2 | PR-B | vitest + console.warn spy |
 | AC-3 | PR-B | vitest |
 | AC-4 | PR-B | vitest + ts-expect-error |
 | AC-5 | PR-C (slice) + PR-D (UI) | vitest + manual E2E |

--- a/docs/spec/m6/tasks.md
+++ b/docs/spec/m6/tasks.md
@@ -85,13 +85,13 @@ ADR-0001 Roadmap では M6 を「E2EE 暗号化バックアップ（任意機能
 ### タスク
 
 - [ ] `utils/backupCrypto.ts` 新設
-  - [ ] **constant**: `PBKDF2_ITERATIONS = 600_000` / `MIN_ACCEPTED_ITERATIONS = 100_000` / `MAX_ACCEPTED_ITERATIONS = 10_000_000` / `MAX_CIPHERTEXT_BYTES = 100 * 1024 * 1024` / `MAX_ENVELOPE_FILE_BYTES = 150 * 1024 * 1024` / `DECRYPT_FAILURE_MESSAGE = 'パスフレーズが正しくないか、ファイルが壊れています。'` / `MIN_PASSPHRASE_GRAPHEMES = 12`
+  - [ ] **constant**: `PBKDF2_ITERATIONS = 600_000` / `MIN_ACCEPTED_ITERATIONS = 100_000` / `MAX_ACCEPTED_ITERATIONS = 10_000_000` / `MAX_CIPHERTEXT_BYTES = 100 * 1024 * 1024` / `DECRYPT_FAILURE_MESSAGE = 'パスフレーズが正しくないか、ファイルが壊れています。'` / `MIN_PASSPHRASE_CODEPOINTS = 12` (Unicode コードポイント単位、Intl.Segmenter は ICU バージョン依存で不採用)
   - [ ] **API**:
     - [ ] `randomBytes(len: number): Uint8Array` (`crypto.getRandomValues` ラッパー、test util から import 可能、`exportKey` 経路は持たない)
     - [ ] `deriveKey(passphrase: string, salt: Uint8Array, iterations: number): Promise<CryptoKey>` (PBKDF2-SHA256, **`extractable: false`** + **`usages: ['encrypt', 'decrypt']`**)
     - [ ] `encryptBackup(plaintext: BackupV1, passphrase: string, appVersion: string, opts?: { signal?: AbortSignal; now?: Date }): Promise<EncryptedBackupV1>` (AAD で envelope metadata 認証)
     - [ ] `decryptBackup(envelope: EncryptedBackupV1, passphrase: string, opts?: { signal?: AbortSignal }): Promise<BackupV1>` (catch を 4 cause に分類、broad catch 禁止)
-    - [ ] `validatePassphraseLength(p: string): void` (grapheme 単位で `[...p].length >= MIN_PASSPHRASE_GRAPHEMES`、不足で BackupValidationError)
+    - [ ] `validatePassphraseLength(p: string): void` (Unicode コードポイント単位で `[...p].length >= MIN_PASSPHRASE_CODEPOINTS`、不足で BackupValidationError)
     - [ ] base64 encode/decode helper (test util から import 可能)
   - [ ] **regularization**: passphrase は `passphrase.normalize('NFC')` してから `TextEncoder.encode` (AC-12)
   - [ ] **AAD**: `buildAad(meta): Uint8Array` (key-sorted JSON.stringify → encode、含む field は AC-13 参照)

--- a/tests/fixtures/backup.ts
+++ b/tests/fixtures/backup.ts
@@ -1,0 +1,76 @@
+// Test fixtures for M6 backup tests (AC-1, AC-7, AC-10).
+// Centralizing here prevents drift between backupCrypto.test.ts /
+// backupSchema.test.ts / backupSlice.test.ts.
+
+import { defaultAiSettings, defaultDisplaySettings } from '../../constants';
+import { BackupV1, Project } from '../../types';
+import { fromBase64, toBase64 } from '../../utils/backupCrypto';
+import { buildBackupV1 } from '../../utils/backupSchema';
+
+export const buildSampleProject = (overrides: Partial<Project> = {}): Project => ({
+    id: overrides.id ?? 'p-1',
+    name: overrides.name ?? 'テスト物語',
+    lastModified: overrides.lastModified ?? '2026-04-29T00:00:00.000Z',
+    isSimpleMode: false,
+    settings: [],
+    novelContent: [],
+    chatHistory: [],
+    knowledgeBase: [],
+    plotBoard: [],
+    plotTypeColors: {},
+    plotRelations: [],
+    plotNodePositions: [],
+    timeline: [],
+    timelineLanes: [],
+    characterRelations: [],
+    nodePositions: [],
+    aiSettings: defaultAiSettings,
+    displaySettings: defaultDisplaySettings,
+    ...overrides,
+});
+
+// Built via buildBackupV1 so BACKUP_SCHEMA_VERSION stays the single source
+// of truth — bumping the schema constant must not silently drift through
+// hand-rolled fixtures.
+export const buildSampleBackup = (): BackupV1 => buildBackupV1({
+    projects: [buildSampleProject({ id: 'p-1' })],
+    tutorialState: { hasCompletedGlobalTutorial: true },
+    analysisHistory: [
+        {
+            characters: { match: [], similar: [], new: [], extractedDetails: [] },
+            worldContext: { worldKeywords: [], genre: '', tone: '' },
+            worldTerms: { match: [], similar: [], new: [] },
+            dialogues: [],
+            notes: [],
+        },
+    ],
+    appVersion: '1.0.0',
+    now: new Date('2026-04-29T01:23:45.000Z'),
+});
+
+// Build a payload approximating `numProjects` projects each with `perProjectBytes`
+// of dummy text. Used by AC-10 performance test.
+export const buildLargeBackup = (numProjects: number, perProjectBytes: number): BackupV1 => {
+    const filler = 'あ'.repeat(Math.floor(perProjectBytes / 3)); // 3 bytes/UTF-8 char
+    return {
+        schemaVersion: 1,
+        exportedAt: '2026-04-29T00:00:00.000Z',
+        appVersion: '1.0.0',
+        projects: Array.from({ length: numProjects }, (_, i) =>
+            buildSampleProject({
+                id: `p-${i}`,
+                novelContent: [{ id: `c-${i}`, text: filler }],
+            }),
+        ),
+        tutorialState: {},
+        analysisHistory: [],
+    };
+};
+
+// AC-7: flip the last byte of a base64 ciphertext to simulate tampering.
+// The XOR keeps the byte length stable so the envelope still parses.
+export const tamperLastByte = (b64: string): string => {
+    const bytes = fromBase64(b64);
+    bytes[bytes.length - 1] = bytes[bytes.length - 1] ^ 0xff;
+    return toBase64(bytes);
+};

--- a/tests/static/no-error-cause-in-components.test.ts
+++ b/tests/static/no-error-cause-in-components.test.ts
@@ -1,0 +1,38 @@
+// Static check: components/ must not reference error.cause (AC-9).
+// UI must always show the constant DECRYPT_FAILURE_MESSAGE; reading
+// error.cause would leak the auth-tag-mismatch / plaintext-corrupted /
+// schema-invalid distinction to fingerprint-prevention surface.
+
+import { describe, expect, it } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+const collectSourceFiles = (dir: string, acc: string[] = []): string[] => {
+    for (const entry of readdirSync(dir)) {
+        const full = join(dir, entry);
+        const st = statSync(full);
+        if (st.isDirectory()) {
+            collectSourceFiles(full, acc);
+        } else if (/\.(tsx?|jsx?)$/.test(entry)) {
+            acc.push(full);
+        }
+    }
+    return acc;
+};
+
+describe('components/ no error.cause references (AC-9)', () => {
+    it('AC-9: components/ source does not read error.cause', () => {
+        const componentsDir = resolve(__dirname, '../../components');
+        const files = collectSourceFiles(componentsDir);
+        const offenders: string[] = [];
+        for (const file of files) {
+            const lines = readFileSync(file, 'utf-8').split('\n');
+            lines.forEach((line, i) => {
+                if (/\.cause\b/.test(line)) {
+                    offenders.push(`${file}:${i + 1}: ${line.trim()}`);
+                }
+            });
+        }
+        expect(offenders).toEqual([]);
+    });
+});

--- a/tests/static/no-export-key.test.ts
+++ b/tests/static/no-export-key.test.ts
@@ -1,0 +1,15 @@
+// Static check: utils/backupCrypto.ts must not surface crypto.subtle.exportKey
+// (AC-14). The derived AES-GCM key is created with extractable=false; any
+// public exportKey helper would create a leakable surface for XSS.
+
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+describe('utils/backupCrypto exportKey absence (AC-14)', () => {
+    it('AC-14: backupCrypto.ts source does not reference exportKey', () => {
+        const path = resolve(__dirname, '../../utils/backupCrypto.ts');
+        const src = readFileSync(path, 'utf-8');
+        expect(src).not.toMatch(/\bexportKey\b/);
+    });
+});

--- a/types.ts
+++ b/types.ts
@@ -357,6 +357,28 @@ export interface BackupV1 {
     analysisHistory: AnalysisResult[];
 }
 
+// --- Encrypted Backup (M6) ---
+//
+// Envelope wrapping a BackupV1 payload encrypted with AES-GCM-256, key derived
+// via PBKDF2-SHA256 from a user passphrase. envelopeVersion is independent from
+// payload BackupV1.schemaVersion: bump envelopeVersion only when envelope shape
+// changes (crypto metadata layout, AAD format), not when payload schema changes.
+// Spec: docs/spec/m6/acceptance-criteria.md (AC-4)
+export interface EncryptedBackupV1 {
+    envelopeVersion: 1;
+    encrypted: true;
+    algorithm: 'AES-GCM-256';
+    kdf: 'PBKDF2-SHA256';
+    kdfParams: {
+        salt: string;          // base64, decoded length must be 16 bytes
+        iterations: number;    // PBKDF2 iterations, see PBKDF2_ITERATIONS constant
+    };
+    iv: string;                // base64, decoded length must be 12 bytes (AES-GCM)
+    ciphertext: string;        // base64, AES-GCM output (auth tag concatenated at end)
+    appVersion: string;
+    encryptedAt: string;       // ISO 8601
+}
+
 export type ImportConflictResolution = 'overwrite' | 'duplicate' | 'skip';
 
 export interface ImportConflict {

--- a/utils/backupCrypto.test.ts
+++ b/utils/backupCrypto.test.ts
@@ -12,7 +12,7 @@ import {
     IV_BYTES,
     MAX_ACCEPTED_ITERATIONS,
     MIN_ACCEPTED_ITERATIONS,
-    MIN_PASSPHRASE_GRAPHEMES,
+    MIN_PASSPHRASE_CODEPOINTS,
     PBKDF2_ITERATIONS,
     randomBytes,
     SALT_BYTES,
@@ -322,9 +322,9 @@ describe('backupCrypto / AC-12 passphrase normalization + grapheme length', () =
     });
 
     it('AC-12: boundary 11/12/13 graphemes', () => {
-        expect(() => validatePassphraseLength('a'.repeat(MIN_PASSPHRASE_GRAPHEMES - 1))).toThrow(/12 文字/);
-        expect(() => validatePassphraseLength('a'.repeat(MIN_PASSPHRASE_GRAPHEMES))).not.toThrow();
-        expect(() => validatePassphraseLength('a'.repeat(MIN_PASSPHRASE_GRAPHEMES + 1))).not.toThrow();
+        expect(() => validatePassphraseLength('a'.repeat(MIN_PASSPHRASE_CODEPOINTS - 1))).toThrow(/12 文字/);
+        expect(() => validatePassphraseLength('a'.repeat(MIN_PASSPHRASE_CODEPOINTS))).not.toThrow();
+        expect(() => validatePassphraseLength('a'.repeat(MIN_PASSPHRASE_CODEPOINTS + 1))).not.toThrow();
     });
 
     it('AC-12: 1000 character passphrase accepted (no upper limit)', async () => {

--- a/utils/backupCrypto.test.ts
+++ b/utils/backupCrypto.test.ts
@@ -1,0 +1,439 @@
+// Tests for utils/backupCrypto.ts (M6 PR-B).
+// Spec: docs/spec/m6/acceptance-criteria.md AC-1〜AC-4, AC-7, AC-10〜AC-14
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { BackupValidationError } from './backupSchema';
+import { buildLargeBackup, buildSampleBackup, tamperLastByte } from '../tests/fixtures/backup';
+import {
+    DECRYPT_FAILURE_MESSAGE,
+    decryptBackup,
+    encryptBackup,
+    fromBase64,
+    IV_BYTES,
+    MAX_ACCEPTED_ITERATIONS,
+    MIN_ACCEPTED_ITERATIONS,
+    MIN_PASSPHRASE_GRAPHEMES,
+    PBKDF2_ITERATIONS,
+    randomBytes,
+    SALT_BYTES,
+    toBase64,
+    validatePassphraseLength,
+} from './backupCrypto';
+
+const VALID_PASSPHRASE = 'test-passphrase-12-chars-ok';
+
+describe('backupCrypto / AC-1 round-trip', () => {
+    it('AC-1: encrypt then decrypt restores deep-equal payload', async () => {
+        const plaintext = buildSampleBackup();
+        const env = await encryptBackup(plaintext, VALID_PASSPHRASE, '1.0.0');
+        const dec = await decryptBackup(env, VALID_PASSPHRASE);
+        expect(JSON.parse(JSON.stringify(dec))).toEqual(JSON.parse(JSON.stringify(plaintext)));
+    });
+
+    it('AC-1: type-loss detection on direct field check', async () => {
+        const plaintext = buildSampleBackup();
+        const env = await encryptBackup(plaintext, VALID_PASSPHRASE, '1.0.0');
+        const dec = await decryptBackup(env, VALID_PASSPHRASE);
+        expect(dec.exportedAt).toBe(plaintext.exportedAt);
+        expect(dec.projects.length).toBe(plaintext.projects.length);
+        expect(dec.projects[0].id).toBe(plaintext.projects[0].id);
+    });
+});
+
+describe('backupCrypto / AC-2 wrong passphrase rejection', () => {
+    it('AC-2: throws BackupValidationError with constant message + cause', async () => {
+        const env = await encryptBackup(buildSampleBackup(), VALID_PASSPHRASE, '1.0.0');
+        await expect(decryptBackup(env, 'wrong-passphrase-12c')).rejects.toMatchObject({
+            name: 'BackupValidationError',
+            message: DECRYPT_FAILURE_MESSAGE,
+            cause: { kind: 'auth-tag-mismatch' },
+        });
+    });
+
+    it('AC-2: console.warn fires with M6_DECRYPT_AUTH_TAG_FAILED event id and safe metadata only', async () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const env = await encryptBackup(buildSampleBackup(), VALID_PASSPHRASE, '1.0.0');
+        await expect(decryptBackup(env, 'wrong-passphrase-12c')).rejects.toThrow(BackupValidationError);
+        // Event id is asserted as the first positional argument so renames are caught at CI time.
+        expect(warnSpy).toHaveBeenCalledWith(
+            'M6_DECRYPT_AUTH_TAG_FAILED',
+            expect.objectContaining({
+                envelopeVersion: 1,
+                algorithm: 'AES-GCM-256',
+                kdf: 'PBKDF2-SHA256',
+                iterations: expect.any(Number),
+                encryptedAt: expect.any(String),
+            }),
+        );
+        // No sensitive field leakage.
+        const calls = warnSpy.mock.calls.flat();
+        const serialized = JSON.stringify(calls);
+        expect(serialized).not.toContain(VALID_PASSPHRASE);
+        expect(serialized).not.toContain('wrong-passphrase-12c');
+        // None of the exported safe-metadata fields should be a passphrase / plaintext / key payload.
+        const meta = warnSpy.mock.calls[0][1] as Record<string, unknown>;
+        expect(meta).not.toHaveProperty('passphrase');
+        expect(meta).not.toHaveProperty('plaintext');
+        expect(meta).not.toHaveProperty('salt');
+        expect(meta).not.toHaveProperty('ciphertext');
+        expect(meta).not.toHaveProperty('key');
+        warnSpy.mockRestore();
+    });
+});
+
+// AC-1 supplementary: KDF determinism — fix salt/iv via getRandomValues spy
+// so the only varying input is the underlying KDF/AES path. Two encrypts must
+// produce byte-equal ciphertext when all entropy sources are pinned.
+describe('backupCrypto / AC-1 KDF determinism', () => {
+    it('AC-1: same passphrase + salt + iv -> byte-equal ciphertext (KDF is deterministic)', async () => {
+        const fixedSalt = new Uint8Array(SALT_BYTES).fill(7);
+        const fixedIv = new Uint8Array(IV_BYTES).fill(11);
+        const spy = vi.spyOn(globalThis.crypto, 'getRandomValues').mockImplementation((arr) => {
+            const u8 = arr as Uint8Array;
+            const src = u8.length === SALT_BYTES ? fixedSalt : fixedIv;
+            u8.set(src);
+            return arr;
+        });
+        try {
+            const fixedNow = new Date('2026-04-29T00:00:00.000Z');
+            const e1 = await encryptBackup(buildSampleBackup(), 'det-test-12-chars-ok', '1.0.0', { now: fixedNow });
+            const e2 = await encryptBackup(buildSampleBackup(), 'det-test-12-chars-ok', '1.0.0', { now: fixedNow });
+            expect(e1.ciphertext).toBe(e2.ciphertext);
+            expect(e1.iv).toBe(e2.iv);
+            expect(e1.kdfParams.salt).toBe(e2.kdfParams.salt);
+        } finally {
+            spy.mockRestore();
+        }
+    });
+});
+
+describe('backupCrypto / AC-3 IV + salt uniqueness (smoke test)', () => {
+    it('AC-3: 100 iv samples are all unique', () => {
+        const ivs = new Set<string>();
+        for (let i = 0; i < 100; i++) ivs.add(toBase64(randomBytes(IV_BYTES)));
+        expect(ivs.size).toBe(100);
+    });
+
+    it('AC-3: 100 salt samples are all unique', () => {
+        const salts = new Set<string>();
+        for (let i = 0; i < 100; i++) salts.add(toBase64(randomBytes(SALT_BYTES)));
+        expect(salts.size).toBe(100);
+    });
+
+    it('AC-3: 3 sequential encrypts produce distinct iv and salt (KDF-integrated)', async () => {
+        const plaintext = buildSampleBackup();
+        const e1 = await encryptBackup(plaintext, VALID_PASSPHRASE, '1.0.0');
+        const e2 = await encryptBackup(plaintext, VALID_PASSPHRASE, '1.0.0');
+        const e3 = await encryptBackup(plaintext, VALID_PASSPHRASE, '1.0.0');
+        expect(new Set([e1.iv, e2.iv, e3.iv]).size).toBe(3);
+        expect(new Set([e1.kdfParams.salt, e2.kdfParams.salt, e3.kdfParams.salt]).size).toBe(3);
+    });
+});
+
+describe('backupCrypto / AC-4 envelope schema', () => {
+    it('AC-4: produces well-formed envelope', async () => {
+        const env = await encryptBackup(buildSampleBackup(), VALID_PASSPHRASE, '1.0.0');
+        expect(env.envelopeVersion).toBe(1);
+        expect(env.encrypted).toBe(true);
+        expect(env.algorithm).toBe('AES-GCM-256');
+        expect(env.kdf).toBe('PBKDF2-SHA256');
+        expect(env.kdfParams.iterations).toBe(PBKDF2_ITERATIONS);
+        expect(fromBase64(env.kdfParams.salt).length).toBe(SALT_BYTES);
+        expect(fromBase64(env.iv).length).toBe(IV_BYTES);
+        expect(env.iv).toMatch(/^[A-Za-z0-9+/=]+$/);
+        expect(env.encryptedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    });
+
+    it('AC-4: respects opts.now for deterministic encryptedAt', async () => {
+        const fixed = new Date('2026-04-29T03:14:15.926Z');
+        const env = await encryptBackup(buildSampleBackup(), VALID_PASSPHRASE, '1.0.0', { now: fixed });
+        expect(env.encryptedAt).toBe('2026-04-29T03:14:15.926Z');
+    });
+});
+
+describe('backupCrypto / AC-7 tampering detection (4 cause kinds)', () => {
+    it('AC-7: ciphertext tamper -> auth-tag-mismatch', async () => {
+        const env = await encryptBackup(buildSampleBackup(), VALID_PASSPHRASE, '1.0.0');
+        const tampered = { ...env, ciphertext: tamperLastByte(env.ciphertext) };
+        await expect(decryptBackup(tampered, VALID_PASSPHRASE)).rejects.toMatchObject({
+            message: DECRYPT_FAILURE_MESSAGE,
+            cause: { kind: 'auth-tag-mismatch' },
+        });
+    });
+
+    it('AC-7: AAD metadata tamper -> auth-tag-mismatch (appVersion)', async () => {
+        const env = await encryptBackup(buildSampleBackup(), VALID_PASSPHRASE, '1.0.0');
+        const tampered = { ...env, appVersion: 'tampered-1.0.0' };
+        await expect(decryptBackup(tampered, VALID_PASSPHRASE)).rejects.toMatchObject({
+            cause: { kind: 'auth-tag-mismatch' },
+        });
+    });
+
+    it('AC-7: AAD metadata tamper -> auth-tag-mismatch (encryptedAt)', async () => {
+        const env = await encryptBackup(buildSampleBackup(), VALID_PASSPHRASE, '1.0.0');
+        const tampered = { ...env, encryptedAt: '2099-01-01T00:00:00.000Z' };
+        await expect(decryptBackup(tampered, VALID_PASSPHRASE)).rejects.toMatchObject({
+            cause: { kind: 'auth-tag-mismatch' },
+        });
+    });
+
+    it('AC-7: kdf-import-failed when iterations is 0 (DOMException from importKey/deriveKey)', async () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const env = await encryptBackup(buildSampleBackup(), VALID_PASSPHRASE, '1.0.0');
+        // Bypass parseEncryptedEnvelope (which would reject iterations=0); inject directly.
+        const broken = { ...env, kdfParams: { ...env.kdfParams, iterations: 0 } };
+        await expect(decryptBackup(broken, VALID_PASSPHRASE)).rejects.toMatchObject({
+            message: DECRYPT_FAILURE_MESSAGE,
+            cause: { kind: 'kdf-import-failed' },
+        });
+        expect(warnSpy).toHaveBeenCalledWith('M6_DECRYPT_KDF_FAILED', expect.any(Object));
+        warnSpy.mockRestore();
+    });
+
+    it('AC-7: plaintext-corrupted when decrypted bytes are not valid JSON', async () => {
+        // not valid UTF-8 / JSON
+        const garbage = new Uint8Array([0xff, 0xfe, 0xff, 0xfe, 0x00, 0xff, 0xfe]);
+        const passphrase = 'plaintext-corrupted-12';
+        const env = await buildEnvelopeWithRawPayload(passphrase, garbage);
+        await expect(decryptBackup(env, passphrase)).rejects.toMatchObject({
+            message: DECRYPT_FAILURE_MESSAGE,
+            cause: { kind: 'plaintext-corrupted' },
+        });
+    });
+
+    it('AC-7: schema-invalid when decrypted JSON has wrong schemaVersion', async () => {
+        // Valid JSON but schemaVersion: 999 (not 1).
+        const wrongSchema = new TextEncoder().encode(JSON.stringify({ schemaVersion: 999 }));
+        const passphrase = 'schema-invalid-12-cha';
+        const env = await buildEnvelopeWithRawPayload(passphrase, wrongSchema);
+        await expect(decryptBackup(env, passphrase)).rejects.toMatchObject({
+            message: DECRYPT_FAILURE_MESSAGE,
+            cause: { kind: 'schema-invalid' },
+        });
+    });
+});
+
+// AAD canonical form must match production buildAad. If the production order
+// changes, this helper's authentication will fail (auth-tag-mismatch) and the
+// 'plaintext-corrupted' / 'schema-invalid' tests will surface the drift.
+const buildEnvelopeWithRawPayload = async (
+    passphrase: string,
+    payloadBytes: Uint8Array,
+) => {
+    const salt = randomBytes(SALT_BYTES);
+    const iv = randomBytes(IV_BYTES);
+    const meta = {
+        envelopeVersion: 1 as const,
+        algorithm: 'AES-GCM-256' as const,
+        kdf: 'PBKDF2-SHA256' as const,
+        kdfParams: { salt: toBase64(salt), iterations: PBKDF2_ITERATIONS },
+        iv: toBase64(iv),
+        appVersion: '1.0.0',
+        encryptedAt: '2026-04-29T00:00:00.000Z',
+    };
+    const aad = new TextEncoder().encode(JSON.stringify({
+        algorithm: meta.algorithm,
+        appVersion: meta.appVersion,
+        encryptedAt: meta.encryptedAt,
+        envelopeVersion: meta.envelopeVersion,
+        iv: meta.iv,
+        kdf: meta.kdf,
+        kdfParams: { iterations: meta.kdfParams.iterations, salt: meta.kdfParams.salt },
+    }));
+    const passKey = await globalThis.crypto.subtle.importKey(
+        'raw',
+        new TextEncoder().encode(passphrase.normalize('NFC')),
+        { name: 'PBKDF2' },
+        false,
+        ['deriveKey'],
+    );
+    const aesKey = await globalThis.crypto.subtle.deriveKey(
+        { name: 'PBKDF2', salt: salt as BufferSource, hash: 'SHA-256', iterations: PBKDF2_ITERATIONS },
+        passKey,
+        { name: 'AES-GCM', length: 256 },
+        false,
+        ['encrypt', 'decrypt'],
+    );
+    const ct = await globalThis.crypto.subtle.encrypt(
+        { name: 'AES-GCM', iv: iv as BufferSource, additionalData: aad as BufferSource },
+        aesKey,
+        payloadBytes as BufferSource,
+    );
+    return { ...meta, encrypted: true as const, ciphertext: toBase64(new Uint8Array(ct)) };
+};
+
+describe('backupCrypto / AC-9 cause kind enumeration', () => {
+    it('error.cause is always a structured object, never a string', async () => {
+        const env = await encryptBackup(buildSampleBackup(), VALID_PASSPHRASE, '1.0.0');
+        try {
+            await decryptBackup(env, 'wrong-passphrase-12c');
+            expect.unreachable();
+        } catch (e) {
+            expect(e).toBeInstanceOf(BackupValidationError);
+            const cause = (e as Error).cause as { kind?: string } | undefined;
+            expect(cause?.kind).toBe('auth-tag-mismatch');
+        }
+    });
+});
+
+describe('backupCrypto / AC-11 AbortSignal', () => {
+    it('AC-11: pre-aborted signal rejects encryptBackup with AbortError', async () => {
+        const controller = new AbortController();
+        controller.abort();
+        await expect(
+            encryptBackup(buildSampleBackup(), VALID_PASSPHRASE, '1.0.0', { signal: controller.signal }),
+        ).rejects.toThrow(/aborted/i);
+    });
+
+    it('AC-11: pre-aborted signal rejects decryptBackup with AbortError', async () => {
+        const env = await encryptBackup(buildSampleBackup(), VALID_PASSPHRASE, '1.0.0');
+        const controller = new AbortController();
+        controller.abort();
+        await expect(decryptBackup(env, VALID_PASSPHRASE, { signal: controller.signal })).rejects.toThrow(/aborted/i);
+    });
+});
+
+describe('backupCrypto / AC-12 passphrase normalization + grapheme length', () => {
+    it('AC-12: NFC normalization makes NFC and NFD passphrases interoperable', async () => {
+        const nfc = 'érest12chars'; // é + 11 ASCII = 12 graphemes
+        const nfd = 'érest12chars'; // e + combining acute + 11 ASCII (13 code units, 12 graphemes)
+        const env = await encryptBackup(buildSampleBackup(), nfc, '1.0.0');
+        const dec = await decryptBackup(env, nfd);
+        expect(dec.schemaVersion).toBe(1);
+    });
+
+    it('AC-12: CJK passphrase round-trip', async () => {
+        const cjk = '日本語パスワード長め文字列'; // 13 graphemes
+        const env = await encryptBackup(buildSampleBackup(), cjk, '1.0.0');
+        const dec = await decryptBackup(env, cjk);
+        expect(dec.schemaVersion).toBe(1);
+    });
+
+    it('AC-12: emoji passphrase counted by grapheme not utf-16 code units', async () => {
+        // 🔑 is 2 utf-16 code units. 4 of them = 8 .length but 4 graphemes.
+        const fourEmoji = '🔑🔑🔑🔑';
+        expect(fourEmoji.length).toBe(8);
+        expect([...fourEmoji].length).toBe(4);
+        expect(() => validatePassphraseLength(fourEmoji)).toThrow(/12 文字/);
+    });
+
+    it('AC-12: empty passphrase rejected', () => {
+        expect(() => validatePassphraseLength('')).toThrow(/12 文字/);
+    });
+
+    it('AC-12: boundary 11/12/13 graphemes', () => {
+        expect(() => validatePassphraseLength('a'.repeat(MIN_PASSPHRASE_GRAPHEMES - 1))).toThrow(/12 文字/);
+        expect(() => validatePassphraseLength('a'.repeat(MIN_PASSPHRASE_GRAPHEMES))).not.toThrow();
+        expect(() => validatePassphraseLength('a'.repeat(MIN_PASSPHRASE_GRAPHEMES + 1))).not.toThrow();
+    });
+
+    it('AC-12: 1000 character passphrase accepted (no upper limit)', async () => {
+        const long = 'a'.repeat(1000);
+        const env = await encryptBackup(buildSampleBackup(), long, '1.0.0');
+        const dec = await decryptBackup(env, long);
+        expect(dec.schemaVersion).toBe(1);
+    });
+});
+
+describe('backupCrypto / AC-13 AES-GCM AAD metadata binding', () => {
+    it('AC-13: tampering envelopeVersion in transit fails decrypt (AAD second line of defense)', async () => {
+        const env = await encryptBackup(buildSampleBackup(), VALID_PASSPHRASE, '1.0.0');
+        // Cast through unknown to bypass the literal type so we can simulate
+        // an in-transit tamper to a future envelope version. parseEncryptedEnvelope
+        // would reject this earlier in real flow, but AAD provides a 2nd defense
+        // layer for callers that bypass the parser.
+        const tampered = { ...env, envelopeVersion: 2 } as unknown as typeof env;
+        await expect(decryptBackup(tampered, VALID_PASSPHRASE)).rejects.toMatchObject({
+            cause: { kind: 'auth-tag-mismatch' },
+        });
+    });
+
+    it('AC-13: tampering iv in transit fails decrypt', async () => {
+        const env = await encryptBackup(buildSampleBackup(), VALID_PASSPHRASE, '1.0.0');
+        const otherIv = toBase64(randomBytes(IV_BYTES));
+        const tampered = { ...env, iv: otherIv };
+        await expect(decryptBackup(tampered, VALID_PASSPHRASE)).rejects.toMatchObject({
+            cause: { kind: 'auth-tag-mismatch' },
+        });
+    });
+
+    it('AC-13: tampering kdfParams.iterations in transit fails decrypt', async () => {
+        const env = await encryptBackup(buildSampleBackup(), VALID_PASSPHRASE, '1.0.0');
+        const tampered = {
+            ...env,
+            kdfParams: { ...env.kdfParams, iterations: env.kdfParams.iterations + 1 },
+        };
+        await expect(decryptBackup(tampered, VALID_PASSPHRASE)).rejects.toMatchObject({
+            cause: { kind: 'auth-tag-mismatch' },
+        });
+    });
+});
+
+describe('backupCrypto / AC-14 extractable=false + zeroize hygiene', () => {
+    it('AC-14: deriveKey is invoked with extractable=false and usages=[encrypt, decrypt]', async () => {
+        const subtleSpy = vi.spyOn(globalThis.crypto.subtle, 'deriveKey');
+        try {
+            await encryptBackup(buildSampleBackup(), VALID_PASSPHRASE, '1.0.0');
+            // Last call (avoid coupling to internal call ordering).
+            const callArgs = subtleSpy.mock.calls.find(
+                (c) => Array.isArray(c[4]) && (c[4] as unknown[]).includes('encrypt'),
+            );
+            expect(callArgs).toBeDefined();
+            // Signature: (algorithm, baseKey, derivedKeyAlgorithm, extractable, usages)
+            const [, , , extractable, usages] = callArgs!;
+            expect(extractable).toBe(false);
+            expect(usages).toEqual(['encrypt', 'decrypt']);
+        } finally {
+            subtleSpy.mockRestore();
+        }
+    });
+
+    it('AC-14: derived CryptoKey reports extractable: false', async () => {
+        // Capture the actual CryptoKey produced and verify its extractable flag.
+        const origDeriveKey = globalThis.crypto.subtle.deriveKey.bind(globalThis.crypto.subtle);
+        let captured: CryptoKey | undefined;
+        const spy = vi.spyOn(globalThis.crypto.subtle, 'deriveKey').mockImplementation(
+            async (...args: Parameters<SubtleCrypto['deriveKey']>) => {
+                const key = await origDeriveKey(...args);
+                captured = key;
+                return key;
+            },
+        );
+        try {
+            await encryptBackup(buildSampleBackup(), VALID_PASSPHRASE, '1.0.0');
+            expect(captured).toBeDefined();
+            expect(captured!.extractable).toBe(false);
+            expect(captured!.usages.sort()).toEqual(['decrypt', 'encrypt']);
+        } finally {
+            spy.mockRestore();
+        }
+    });
+
+    it('AC-14: backupCrypto module does not export "exportKey"', async () => {
+        const mod = await import('./backupCrypto');
+        expect((mod as Record<string, unknown>).exportKey).toBeUndefined();
+    });
+});
+
+describe('backupCrypto / AC-10 large payload performance (Node)', () => {
+    it('AC-10: 10MB payload encrypt+decrypt under env-conditional limit', async () => {
+        const limit = process.env.CI === 'true' ? 15_000 : 10_000;
+        const plaintext = buildLargeBackup(50, 200_000);
+        const t0 = performance.now();
+        const env = await encryptBackup(plaintext, VALID_PASSPHRASE, '1.0.0');
+        const dec = await decryptBackup(env, VALID_PASSPHRASE);
+        const elapsed = performance.now() - t0;
+        expect(dec.projects.length).toBe(50);
+        expect(elapsed).toBeLessThan(limit);
+    }, 30_000);
+});
+
+describe('backupCrypto / boundary cases for parse-time guards', () => {
+    // The parse-time iterations floor/ceiling is enforced by parseEncryptedEnvelope
+    // (AC-4) — see backupSchema.test.ts. encryptBackup itself only emits the
+    // current PBKDF2_ITERATIONS, so we sanity-check that constant is in range.
+    it('AC-4: PBKDF2_ITERATIONS within MIN/MAX accepted', () => {
+        expect(PBKDF2_ITERATIONS).toBeGreaterThanOrEqual(MIN_ACCEPTED_ITERATIONS);
+        expect(PBKDF2_ITERATIONS).toBeLessThanOrEqual(MAX_ACCEPTED_ITERATIONS);
+    });
+});

--- a/utils/backupCrypto.ts
+++ b/utils/backupCrypto.ts
@@ -1,0 +1,295 @@
+// AES-GCM-256 + PBKDF2-SHA256 client-side encrypted backup.
+// Spec: docs/spec/m6/acceptance-criteria.md (AC-1 through AC-14)
+//
+// Threat model boundaries (ADR-0001 §Consequences):
+//   - XSS attacker has full access to passphrase + plaintext (acknowledged limit)
+//   - Encrypted file at-rest is protected against passive disclosure
+//   - Local IndexedDB is NOT encrypted (only Export files / future Cloud Storage blobs)
+//   - Memory wipe is best-effort only (JS strings are immutable)
+//
+// Forward-locking decisions (cannot change without invalidating existing envelopes):
+//   - Passphrase normalization: NFC (AC-12)
+//   - AAD canonical form: key-sorted JSON.stringify of metadata fields (AC-13)
+//   - Minimum passphrase length: 12 grapheme clusters (AC-9, AC-12)
+
+import { BackupV1, EncryptedBackupV1 } from '../types';
+import { BackupErrorCauseKind, BackupValidationError } from './backupErrors';
+
+// Re-export for convenience: callers importing from backupCrypto can grab
+// the cause kind union without adding a second import.
+export type { BackupErrorCauseKind };
+
+// --- constants (AC-4, AC-9, AC-12) ---
+
+export const PBKDF2_ITERATIONS = 600_000;
+export const MIN_ACCEPTED_ITERATIONS = 100_000;
+export const MAX_ACCEPTED_ITERATIONS = 10_000_000;
+export const MAX_CIPHERTEXT_BYTES = 100 * 1024 * 1024;
+export const MIN_PASSPHRASE_GRAPHEMES = 12;
+export const SALT_BYTES = 16;
+export const IV_BYTES = 12;
+export const DECRYPT_FAILURE_MESSAGE = 'パスフレーズが正しくないか、ファイルが壊れています。';
+
+// --- low-level helpers ---
+
+export const randomBytes = (len: number): Uint8Array => {
+    const out = new Uint8Array(len);
+    globalThis.crypto.getRandomValues(out);
+    return out;
+};
+
+export const toBase64 = (bytes: Uint8Array): string => {
+    // Chunked apply avoids the O(n²) string-rope cost of byte-at-a-time
+    // concatenation. 32 KB stays well under V8's argument-count limit.
+    const CHUNK = 0x8000;
+    const parts: string[] = [];
+    for (let i = 0; i < bytes.length; i += CHUNK) {
+        parts.push(String.fromCharCode.apply(null, Array.from(bytes.subarray(i, i + CHUNK))));
+    }
+    return btoa(parts.join(''));
+};
+
+export const fromBase64 = (b64: string): Uint8Array => {
+    const s = atob(b64);
+    const out = new Uint8Array(s.length);
+    for (let i = 0; i < s.length; i++) out[i] = s.charCodeAt(i);
+    return out;
+};
+
+const graphemeLength = (s: string): number => [...s].length;
+
+export const validatePassphraseLength = (passphrase: string): void => {
+    if (graphemeLength(passphrase) < MIN_PASSPHRASE_GRAPHEMES) {
+        throw new BackupValidationError(
+            `パスフレーズは ${MIN_PASSPHRASE_GRAPHEMES} 文字以上にしてください。`,
+        );
+    }
+};
+
+const normalizePassphrase = (passphrase: string): Uint8Array =>
+    new TextEncoder().encode(passphrase.normalize('NFC'));
+
+// --- AAD canonical form (AC-13) ---
+//
+// Bind envelope metadata to the ciphertext's auth tag so any tampering of
+// algorithm / kdf / kdfParams / iv / appVersion / encryptedAt / envelopeVersion
+// is detected on decrypt.
+const buildAad = (meta: {
+    envelopeVersion: 1;
+    algorithm: 'AES-GCM-256';
+    kdf: 'PBKDF2-SHA256';
+    kdfParams: { salt: string; iterations: number };
+    iv: string;
+    appVersion: string;
+    encryptedAt: string;
+}): Uint8Array => {
+    // Key-sorted JSON to keep AAD canonical regardless of object literal order.
+    const ordered = {
+        algorithm: meta.algorithm,
+        appVersion: meta.appVersion,
+        encryptedAt: meta.encryptedAt,
+        envelopeVersion: meta.envelopeVersion,
+        iv: meta.iv,
+        kdf: meta.kdf,
+        kdfParams: { iterations: meta.kdfParams.iterations, salt: meta.kdfParams.salt },
+    };
+    return new TextEncoder().encode(JSON.stringify(ordered));
+};
+
+// --- KDF (AC-14) ---
+//
+// extractable=false prevents key extraction (CryptoKey is not exportable to
+// raw bytes). usages limited to encrypt/decrypt — no wrap/unwrap surface.
+export const deriveKey = async (
+    passphrase: string,
+    salt: Uint8Array,
+    iterations: number,
+): Promise<CryptoKey> => {
+    const passphraseBytes = normalizePassphrase(passphrase);
+    let baseKey: CryptoKey;
+    try {
+        baseKey = await globalThis.crypto.subtle.importKey(
+            'raw',
+            passphraseBytes,
+            { name: 'PBKDF2' },
+            false,
+            ['deriveKey'],
+        );
+    } finally {
+        // Best-effort zeroize of UTF-8 passphrase bytes (string itself remains).
+        passphraseBytes.fill(0);
+    }
+    return globalThis.crypto.subtle.deriveKey(
+        { name: 'PBKDF2', salt: salt as BufferSource, hash: 'SHA-256', iterations },
+        baseKey,
+        { name: 'AES-GCM', length: 256 },
+        false,
+        ['encrypt', 'decrypt'],
+    );
+};
+
+// --- abort handling (AC-11) ---
+
+const checkAborted = (signal?: AbortSignal): void => {
+    if (signal?.aborted) {
+        const err = new Error('aborted');
+        err.name = 'AbortError';
+        throw err;
+    }
+};
+
+// --- public API ---
+
+export interface EncryptOptions {
+    signal?: AbortSignal;
+    now?: Date;
+}
+
+export const encryptBackup = async (
+    plaintext: BackupV1,
+    passphrase: string,
+    appVersion: string,
+    opts: EncryptOptions = {},
+): Promise<EncryptedBackupV1> => {
+    validatePassphraseLength(passphrase);
+    checkAborted(opts.signal);
+
+    const salt = randomBytes(SALT_BYTES);
+    const iv = randomBytes(IV_BYTES);
+    const encryptedAt = (opts.now ?? new Date()).toISOString();
+
+    const meta = {
+        envelopeVersion: 1 as const,
+        algorithm: 'AES-GCM-256' as const,
+        kdf: 'PBKDF2-SHA256' as const,
+        kdfParams: { salt: toBase64(salt), iterations: PBKDF2_ITERATIONS },
+        iv: toBase64(iv),
+        appVersion,
+        encryptedAt,
+    };
+    const aad = buildAad(meta);
+
+    const key = await deriveKey(passphrase, salt, PBKDF2_ITERATIONS);
+    checkAborted(opts.signal);
+
+    const plaintextBytes = new TextEncoder().encode(JSON.stringify(plaintext));
+    let ciphertextBytes: Uint8Array;
+    try {
+        const ab = await globalThis.crypto.subtle.encrypt(
+            { name: 'AES-GCM', iv: iv as BufferSource, additionalData: aad as BufferSource },
+            key,
+            plaintextBytes as BufferSource,
+        );
+        ciphertextBytes = new Uint8Array(ab);
+    } finally {
+        plaintextBytes.fill(0);
+    }
+    checkAborted(opts.signal);
+
+    return {
+        envelopeVersion: 1,
+        encrypted: true,
+        algorithm: 'AES-GCM-256',
+        kdf: 'PBKDF2-SHA256',
+        kdfParams: { salt: meta.kdfParams.salt, iterations: meta.kdfParams.iterations },
+        iv: meta.iv,
+        ciphertext: toBase64(ciphertextBytes),
+        appVersion,
+        encryptedAt,
+    };
+};
+
+export interface DecryptOptions {
+    signal?: AbortSignal;
+}
+
+// Internal: stage-specific catch wrappers preserve the cause kind without
+// using a broad `catch (e) {}`. Each stage wraps its narrow throw set.
+const wrapAsBackupError = (
+    kind: BackupErrorCauseKind,
+    cause: unknown,
+): BackupValidationError =>
+    new BackupValidationError(DECRYPT_FAILURE_MESSAGE, { cause: { kind, original: cause } });
+
+export const decryptBackup = async (
+    envelope: EncryptedBackupV1,
+    passphrase: string,
+    opts: DecryptOptions = {},
+): Promise<BackupV1> => {
+    checkAborted(opts.signal);
+
+    const salt = fromBase64(envelope.kdfParams.salt);
+    const iv = fromBase64(envelope.iv);
+    const ciphertext = fromBase64(envelope.ciphertext);
+
+    let key: CryptoKey;
+    try {
+        key = await deriveKey(passphrase, salt, envelope.kdfParams.iterations);
+    } catch (e) {
+        console.warn('M6_DECRYPT_KDF_FAILED', {
+            envelopeVersion: envelope.envelopeVersion,
+            algorithm: envelope.algorithm,
+            kdf: envelope.kdf,
+            iterations: envelope.kdfParams.iterations,
+            encryptedAt: envelope.encryptedAt,
+        });
+        throw wrapAsBackupError('kdf-import-failed', e);
+    }
+    checkAborted(opts.signal);
+
+    const aad = buildAad({
+        envelopeVersion: envelope.envelopeVersion,
+        algorithm: envelope.algorithm,
+        kdf: envelope.kdf,
+        kdfParams: envelope.kdfParams,
+        iv: envelope.iv,
+        appVersion: envelope.appVersion,
+        encryptedAt: envelope.encryptedAt,
+    });
+
+    let plaintextBytes: Uint8Array;
+    try {
+        const ab = await globalThis.crypto.subtle.decrypt(
+            { name: 'AES-GCM', iv: iv as BufferSource, additionalData: aad as BufferSource },
+            key,
+            ciphertext as BufferSource,
+        );
+        plaintextBytes = new Uint8Array(ab);
+    } catch (e) {
+        console.warn('M6_DECRYPT_AUTH_TAG_FAILED', {
+            envelopeVersion: envelope.envelopeVersion,
+            algorithm: envelope.algorithm,
+            kdf: envelope.kdf,
+            iterations: envelope.kdfParams.iterations,
+            encryptedAt: envelope.encryptedAt,
+        });
+        throw wrapAsBackupError('auth-tag-mismatch', e);
+    }
+    checkAborted(opts.signal);
+
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(new TextDecoder().decode(plaintextBytes));
+    } catch (e) {
+        console.warn('M6_DECRYPT_PLAINTEXT_CORRUPTED', {
+            envelopeVersion: envelope.envelopeVersion,
+            encryptedAt: envelope.encryptedAt,
+        });
+        throw wrapAsBackupError('plaintext-corrupted', e);
+    } finally {
+        plaintextBytes.fill(0);
+    }
+
+    if (
+        !parsed
+        || typeof parsed !== 'object'
+        || (parsed as { schemaVersion?: unknown }).schemaVersion !== 1
+    ) {
+        console.warn('M6_DECRYPT_SCHEMA_INVALID', {
+            envelopeVersion: envelope.envelopeVersion,
+            encryptedAt: envelope.encryptedAt,
+        });
+        throw wrapAsBackupError('schema-invalid', null);
+    }
+    return parsed as BackupV1;
+};

--- a/utils/backupCrypto.ts
+++ b/utils/backupCrypto.ts
@@ -25,7 +25,10 @@ export const PBKDF2_ITERATIONS = 600_000;
 export const MIN_ACCEPTED_ITERATIONS = 100_000;
 export const MAX_ACCEPTED_ITERATIONS = 10_000_000;
 export const MAX_CIPHERTEXT_BYTES = 100 * 1024 * 1024;
-export const MIN_PASSPHRASE_GRAPHEMES = 12;
+// Counted in Unicode code points (`[...s].length`), not true grapheme clusters
+// — Intl.Segmenter results vary by ICU version so we pin code-point semantics
+// for forward stability across engines. Naming reflects implementation.
+export const MIN_PASSPHRASE_CODEPOINTS = 12;
 export const SALT_BYTES = 16;
 export const IV_BYTES = 12;
 export const DECRYPT_FAILURE_MESSAGE = 'パスフレーズが正しくないか、ファイルが壊れています。';
@@ -56,12 +59,12 @@ export const fromBase64 = (b64: string): Uint8Array => {
     return out;
 };
 
-const graphemeLength = (s: string): number => [...s].length;
+const codepointLength = (s: string): number => [...s].length;
 
 export const validatePassphraseLength = (passphrase: string): void => {
-    if (graphemeLength(passphrase) < MIN_PASSPHRASE_GRAPHEMES) {
+    if (codepointLength(passphrase) < MIN_PASSPHRASE_CODEPOINTS) {
         throw new BackupValidationError(
-            `パスフレーズは ${MIN_PASSPHRASE_GRAPHEMES} 文字以上にしてください。`,
+            `パスフレーズは ${MIN_PASSPHRASE_CODEPOINTS} 文字以上にしてください。`,
         );
     }
 };
@@ -211,6 +214,16 @@ const wrapAsBackupError = (
 ): BackupValidationError =>
     new BackupValidationError(DECRYPT_FAILURE_MESSAGE, { cause: { kind, original: cause } });
 
+/**
+ * Decrypt an `EncryptedBackupV1` envelope to its inner `BackupV1` payload.
+ *
+ * **Contract**: `envelope` is expected to come from `parseEncryptedEnvelope`
+ * (or `parseAnyBackup`). Direct hand-constructed envelopes that bypass parse-time
+ * guards (length / range / literal checks) may surface envelope corruption
+ * as `auth-tag-mismatch` or `kdf-import-failed` instead of `envelope-incomplete`,
+ * which is harmless for end users (UI shows the same `DECRYPT_FAILURE_MESSAGE`)
+ * but degrades log-triage signal quality.
+ */
 export const decryptBackup = async (
     envelope: EncryptedBackupV1,
     passphrase: string,
@@ -218,9 +231,27 @@ export const decryptBackup = async (
 ): Promise<BackupV1> => {
     checkAborted(opts.signal);
 
-    const salt = fromBase64(envelope.kdfParams.salt);
-    const iv = fromBase64(envelope.iv);
-    const ciphertext = fromBase64(envelope.ciphertext);
+    // Base64 decode failures (atob InvalidCharacterError) need to be classified
+    // — otherwise callers that bypass parseEncryptedEnvelope (tests, future
+    // direct-decrypt paths) get a raw DOMException instead of a typed
+    // BackupValidationError.
+    let salt: Uint8Array;
+    let iv: Uint8Array;
+    let ciphertext: Uint8Array;
+    try {
+        salt = fromBase64(envelope.kdfParams.salt);
+        iv = fromBase64(envelope.iv);
+        ciphertext = fromBase64(envelope.ciphertext);
+    } catch (e) {
+        console.warn('M6_DECRYPT_KDF_FAILED', {
+            envelopeVersion: envelope.envelopeVersion,
+            algorithm: envelope.algorithm,
+            kdf: envelope.kdf,
+            iterations: envelope.kdfParams.iterations,
+            encryptedAt: envelope.encryptedAt,
+        });
+        throw wrapAsBackupError('kdf-import-failed', e);
+    }
 
     let key: CryptoKey;
     try {
@@ -280,11 +311,21 @@ export const decryptBackup = async (
         plaintextBytes.fill(0);
     }
 
-    if (
-        !parsed
-        || typeof parsed !== 'object'
-        || (parsed as { schemaVersion?: unknown }).schemaVersion !== 1
-    ) {
+    // Shape check the decrypted payload — schemaVersion alone is too weak
+    // (a crafted authenticated payload could pass with `projects: "not-array"`
+    // and surface as a runtime crash later).
+    const obj = parsed as Record<string, unknown>;
+    const isValidShape =
+        !!parsed
+        && typeof parsed === 'object'
+        && obj.schemaVersion === 1
+        && Array.isArray(obj.projects)
+        && typeof obj.tutorialState === 'object'
+        && obj.tutorialState !== null
+        && Array.isArray(obj.analysisHistory)
+        && typeof obj.exportedAt === 'string'
+        && typeof obj.appVersion === 'string';
+    if (!isValidShape) {
         console.warn('M6_DECRYPT_SCHEMA_INVALID', {
             envelopeVersion: envelope.envelopeVersion,
             encryptedAt: envelope.encryptedAt,

--- a/utils/backupErrors.ts
+++ b/utils/backupErrors.ts
@@ -19,11 +19,14 @@ export interface BackupErrorCause {
 }
 
 export class BackupValidationError extends Error {
-    public readonly cause?: BackupErrorCause;
+    // Override the lib.es2022.error type (cause: unknown) with our structured
+    // cause shape. `declare` skips a runtime field initializer; the actual
+    // value lands via `super(message, options)` per ES2022 semantics, so
+    // DevTools / Sentry / util.inspect see the cause chain natively.
+    declare public readonly cause?: BackupErrorCause;
     constructor(message: string, options?: { cause?: BackupErrorCause }) {
-        super(message);
+        super(message, options);
         this.name = 'BackupValidationError';
-        if (options?.cause) this.cause = options.cause;
     }
 }
 

--- a/utils/backupErrors.ts
+++ b/utils/backupErrors.ts
@@ -1,0 +1,42 @@
+// Error types shared between backup schema parsing and encrypted backup
+// crypto. Lives in its own module to avoid backupSchema ↔ backupCrypto
+// circular import (constants flow schema → crypto, errors flow crypto/schema
+// → backupErrors, never the reverse).
+
+// Discriminated union of internal failure causes carried via Error.cause.
+// UI must NOT branch on this — it exists for log triage / debug only.
+// See AC-2/AC-7/AC-9 (fingerprinting prevention vs developer debuggability).
+export type BackupErrorCauseKind =
+    | 'auth-tag-mismatch'
+    | 'plaintext-corrupted'
+    | 'schema-invalid'
+    | 'kdf-import-failed'
+    | 'envelope-incomplete';
+
+export interface BackupErrorCause {
+    kind: BackupErrorCauseKind;
+    original?: unknown;
+}
+
+export class BackupValidationError extends Error {
+    public readonly cause?: BackupErrorCause;
+    constructor(message: string, options?: { cause?: BackupErrorCause }) {
+        super(message);
+        this.name = 'BackupValidationError';
+        if (options?.cause) this.cause = options.cause;
+    }
+}
+
+/**
+ * Thrown by prepareImport when the *preflight* (flushSave-blocking)
+ * step fails — i.e. before any backup parsing happens. Distinct from
+ * BackupValidationError which is reserved for malformed backup files.
+ * Aborting at this layer prevents the silent edit-loss path where a
+ * stale on-disk snapshot would be used for conflict detection.
+ */
+export class BackupPreflightError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'BackupPreflightError';
+    }
+}

--- a/utils/backupSchema.test.ts
+++ b/utils/backupSchema.test.ts
@@ -261,3 +261,156 @@ describe('resolveImportProjects (AC-3)', () => {
         ).toThrow(BackupValidationError);
     });
 });
+
+// --- M6 PR-B: parseAnyBackup + isEncryptedBackup + parseEncryptedEnvelope (AC-8) ---
+
+import { encryptBackup, IV_BYTES, PBKDF2_ITERATIONS, randomBytes, SALT_BYTES, toBase64 } from './backupCrypto';
+import { isEncryptedBackup, parseAnyBackup, parseEncryptedEnvelope } from './backupSchema';
+import { buildSampleBackup } from '../tests/fixtures/backup';
+import type { BackupV1 } from '../types';
+
+const VALID_PASSPHRASE = 'test-passphrase-12-chars-ok';
+
+describe('parseBackup return type invariance (AC-8 regression)', () => {
+    it('AC-8: parseBackup of plaintext BackupV1 returns BackupV1, not union', () => {
+        const backup = buildBackupV1({
+            projects: [makeProject({ id: 'p-1' })],
+            tutorialState: {},
+            analysisHistory: [],
+            appVersion: '1.0.0',
+        });
+        const raw = serializeBackup(backup);
+        const parsed = parseBackup(raw);
+        // type-level: parseBackup must return BackupV1; encrypted should not exist.
+        // @ts-expect-error -- BackupV1 has no encrypted field
+        const _check: typeof parsed.encrypted = undefined;
+        expect(parsed.schemaVersion).toBe(1);
+        expect(parsed.projects).toHaveLength(1);
+    });
+});
+
+describe('parseAnyBackup + isEncryptedBackup AND-conjunction (AC-8)', () => {
+    it('AC-8: plaintext BackupV1 routes through plaintext path (parseAnyBackup)', () => {
+        const backup = buildBackupV1({
+            projects: [makeProject({ id: 'p-1' })],
+            tutorialState: {},
+            analysisHistory: [],
+            appVersion: '1.0.0',
+        });
+        const raw = serializeBackup(backup);
+        const result = parseAnyBackup(raw);
+        expect((result as { encrypted?: boolean }).encrypted).toBeUndefined();
+        expect((result as BackupV1).schemaVersion).toBe(1);
+    });
+
+    it('AC-8: half-broken envelope (encrypted:true only) is REJECTED, not silently treated as plaintext', () => {
+        const half = JSON.stringify({ encrypted: true, schemaVersion: 1 });
+        try {
+            parseAnyBackup(half);
+            expect.unreachable();
+        } catch (e) {
+            expect(e).toBeInstanceOf(BackupValidationError);
+            expect((e as Error).cause).toEqual({ kind: 'envelope-incomplete' });
+        }
+    });
+
+    it('AC-8: isEncryptedBackup AND-conjunction returns false when any field missing', () => {
+        const base = {
+            envelopeVersion: 1,
+            encrypted: true,
+            algorithm: 'AES-GCM-256',
+            kdf: 'PBKDF2-SHA256',
+            kdfParams: { salt: 'sss', iterations: 600_000 },
+            iv: 'iii',
+            ciphertext: 'ccc',
+            appVersion: '1.0.0',
+            encryptedAt: '2026-04-29T00:00:00.000Z',
+        };
+        expect(isEncryptedBackup(base)).toBe(true);
+
+        const fields: Array<keyof typeof base> = ['encrypted', 'algorithm', 'kdf', 'iv', 'ciphertext', 'kdfParams'];
+        for (const k of fields) {
+            const broken = { ...base } as Record<string, unknown>;
+            delete broken[k];
+            expect(isEncryptedBackup(broken)).toBe(false);
+        }
+    });
+
+    it('AC-8: isEncryptedBackup returns false when encrypted=false (legacy plaintext shape)', () => {
+        expect(isEncryptedBackup({ encrypted: false } as Record<string, unknown>)).toBe(false);
+        expect(isEncryptedBackup({} as Record<string, unknown>)).toBe(false);
+    });
+
+    it('AC-8: encrypted envelope round-trips through parseAnyBackup', async () => {
+        const env = await encryptBackup(buildSampleBackup(), VALID_PASSPHRASE, '1.0.0');
+        const raw = JSON.stringify(env);
+        const result = parseAnyBackup(raw);
+        expect((result as { encrypted?: boolean }).encrypted).toBe(true);
+    });
+});
+
+describe('parseEncryptedEnvelope parse-time guards (AC-4)', () => {
+    const baseEnv = (): Record<string, unknown> => ({
+        envelopeVersion: 1,
+        encrypted: true,
+        algorithm: 'AES-GCM-256',
+        kdf: 'PBKDF2-SHA256',
+        kdfParams: { salt: toBase64(randomBytes(SALT_BYTES)), iterations: PBKDF2_ITERATIONS },
+        iv: toBase64(randomBytes(IV_BYTES)),
+        ciphertext: toBase64(new Uint8Array(64)),
+        appVersion: '1.0.0',
+        encryptedAt: '2026-04-29T00:00:00.000Z',
+    });
+
+    it('AC-4: rejects unknown algorithm literal', () => {
+        const env = { ...baseEnv(), algorithm: 'AES-GCM-256-FUTURE' };
+        expect(() => parseEncryptedEnvelope(env)).toThrow(/アルゴリズム/);
+    });
+
+    it('AC-4: rejects unknown kdf literal', () => {
+        const env = { ...baseEnv(), kdf: 'Argon2id' };
+        expect(() => parseEncryptedEnvelope(env)).toThrow(/鍵派生関数/);
+    });
+
+    it('AC-4: rejects iterations below MIN_ACCEPTED_ITERATIONS', () => {
+        const env = baseEnv();
+        (env.kdfParams as { iterations: number }).iterations = 50_000;
+        expect(() => parseEncryptedEnvelope(env)).toThrow(/iterations/);
+    });
+
+    it('AC-4: rejects iterations above MAX_ACCEPTED_ITERATIONS', () => {
+        const env = baseEnv();
+        (env.kdfParams as { iterations: number }).iterations = 20_000_000;
+        expect(() => parseEncryptedEnvelope(env)).toThrow(/iterations/);
+    });
+
+    it('AC-4: rejects salt with wrong byte length', () => {
+        const env = baseEnv();
+        (env.kdfParams as { salt: string }).salt = toBase64(new Uint8Array(8)); // 8 bytes != 16
+        expect(() => parseEncryptedEnvelope(env)).toThrow(/salt/);
+    });
+
+    it('AC-4: rejects iv with wrong byte length', () => {
+        const env = baseEnv();
+        env.iv = toBase64(new Uint8Array(16)); // 16 bytes != 12
+        expect(() => parseEncryptedEnvelope(env)).toThrow(/iv/);
+    });
+
+    it('AC-4: rejects empty ciphertext', () => {
+        const env = baseEnv();
+        env.ciphertext = '';
+        expect(() => parseEncryptedEnvelope(env)).toThrow(/ciphertext/);
+    });
+
+    it('AC-4: boundary iterations MIN_ACCEPTED_ITERATIONS accepted', () => {
+        const env = baseEnv();
+        (env.kdfParams as { iterations: number }).iterations = 100_000;
+        expect(() => parseEncryptedEnvelope(env)).not.toThrow();
+    });
+
+    it('AC-4: boundary iterations MAX_ACCEPTED_ITERATIONS accepted', () => {
+        const env = baseEnv();
+        (env.kdfParams as { iterations: number }).iterations = 10_000_000;
+        expect(() => parseEncryptedEnvelope(env)).not.toThrow();
+    });
+});

--- a/utils/backupSchema.ts
+++ b/utils/backupSchema.ts
@@ -210,12 +210,15 @@ export const isEncryptedBackup = (
     && json.kdfParams !== null
     && typeof (json.kdfParams as Record<string, unknown>).salt === 'string';
 
+// Strict base64 byte-length check that mirrors atob's accept set.
+// Length must be a multiple of 4 and `=` may only appear as 0/1/2 trailing
+// padding. Avoids materializing huge buffers just for size validation, and
+// keeps decryptBackup from receiving "passes parser, fails atob" inputs.
 const decodedByteLength = (b64: string): number => {
-    // Approximate decoded byte length without allocating: 3 bytes per 4 chars,
-    // minus padding. Avoids materializing huge buffers just for size checks.
-    if (!/^[A-Za-z0-9+/=]+$/.test(b64)) return -1;
+    if (b64.length === 0 || b64.length % 4 !== 0) return -1;
+    if (!/^[A-Za-z0-9+/]+={0,2}$/.test(b64)) return -1;
     const padding = b64.endsWith('==') ? 2 : b64.endsWith('=') ? 1 : 0;
-    return Math.floor((b64.length / 4) * 3) - padding;
+    return (b64.length / 4) * 3 - padding;
 };
 
 export const parseEncryptedEnvelope = (
@@ -275,10 +278,15 @@ export const parseEncryptedEnvelope = (
             `ciphertext の長さが不正です（最大 ${MAX_CIPHERTEXT_BYTES} bytes）。`,
         );
     }
-    const appVersion = typeof json.appVersion === 'string' ? json.appVersion : 'unknown';
-    const encryptedAt = typeof json.encryptedAt === 'string'
-        ? json.encryptedAt
-        : new Date().toISOString();
+    // appVersion / encryptedAt are AAD-bound (see buildAad) so silently
+    // defaulting them would let parser-synthesized values reach the decrypt
+    // step. Reject at parse time instead.
+    if (typeof json.appVersion !== 'string') {
+        throw new BackupValidationError('appVersion が文字列ではありません。');
+    }
+    if (typeof json.encryptedAt !== 'string') {
+        throw new BackupValidationError('encryptedAt が文字列ではありません。');
+    }
 
     return {
         envelopeVersion: 1,
@@ -288,8 +296,8 @@ export const parseEncryptedEnvelope = (
         kdfParams: { salt: kdfParams.salt, iterations: kdfParams.iterations },
         iv: json.iv,
         ciphertext: json.ciphertext,
-        appVersion,
-        encryptedAt,
+        appVersion: json.appVersion,
+        encryptedAt: json.encryptedAt,
     };
 };
 

--- a/utils/backupSchema.ts
+++ b/utils/backupSchema.ts
@@ -3,30 +3,25 @@ import {
     AnalysisResult,
     BACKUP_SCHEMA_VERSION,
     BackupV1,
+    EncryptedBackupV1,
     Project,
 } from '../types';
 import { ProjectValidationError, validateAndSanitizeProjectData } from '../utils';
+import { BackupPreflightError, BackupValidationError } from './backupErrors';
+// Single source of truth: backupCrypto exports the canonical encrypted-envelope
+// constants. Importing here avoids drift if OWASP recommendations change.
+// (No circular: backupCrypto imports BackupValidationError from backupErrors,
+// not from this file.)
+import {
+    IV_BYTES,
+    MAX_ACCEPTED_ITERATIONS,
+    MAX_CIPHERTEXT_BYTES,
+    MIN_ACCEPTED_ITERATIONS,
+    SALT_BYTES,
+} from './backupCrypto';
 
-export class BackupValidationError extends Error {
-    constructor(message: string) {
-        super(message);
-        this.name = 'BackupValidationError';
-    }
-}
-
-/**
- * Thrown by prepareImport when the *preflight* (flushSave-blocking)
- * step fails — i.e. before any backup parsing happens. Distinct from
- * BackupValidationError which is reserved for malformed backup files.
- * Aborting at this layer prevents the silent edit-loss path where a
- * stale on-disk snapshot would be used for conflict detection.
- */
-export class BackupPreflightError extends Error {
-    constructor(message: string) {
-        super(message);
-        this.name = 'BackupPreflightError';
-    }
-}
+// Re-export for callers who import the error types from backupSchema (back-compat).
+export { BackupPreflightError, BackupValidationError };
 
 const isObject = (v: unknown): v is Record<string, unknown> =>
     !!v && typeof v === 'object' && !Array.isArray(v);
@@ -194,6 +189,133 @@ export const parseBackup = (raw: string, opts: ParseOptions = { rawSize: raw.len
         tutorialState,
         analysisHistory,
     };
+};
+
+// --- Encrypted envelope (M6) ---
+//
+// AC-8: discriminate encrypted envelopes from plaintext BackupV1 with an AND
+// of all required fields. Half-broken envelopes (encrypted:true but missing
+// other fields) are rejected explicitly by parseEncryptedEnvelope rather than
+// silently falling through to the plaintext path.
+
+export const isEncryptedBackup = (
+    json: Record<string, unknown>,
+): json is EncryptedBackupV1 & Record<string, unknown> =>
+    json.encrypted === true
+    && typeof json.algorithm === 'string'
+    && typeof json.kdf === 'string'
+    && typeof json.iv === 'string'
+    && typeof json.ciphertext === 'string'
+    && typeof json.kdfParams === 'object'
+    && json.kdfParams !== null
+    && typeof (json.kdfParams as Record<string, unknown>).salt === 'string';
+
+const decodedByteLength = (b64: string): number => {
+    // Approximate decoded byte length without allocating: 3 bytes per 4 chars,
+    // minus padding. Avoids materializing huge buffers just for size checks.
+    if (!/^[A-Za-z0-9+/=]+$/.test(b64)) return -1;
+    const padding = b64.endsWith('==') ? 2 : b64.endsWith('=') ? 1 : 0;
+    return Math.floor((b64.length / 4) * 3) - padding;
+};
+
+export const parseEncryptedEnvelope = (
+    json: Record<string, unknown>,
+): EncryptedBackupV1 => {
+    if (!isEncryptedBackup(json)) {
+        throw new BackupValidationError(
+            '暗号化バックアップの形式が壊れています（必須フィールドが不足しています）。',
+            { cause: { kind: 'envelope-incomplete' } },
+        );
+    }
+    if (json.envelopeVersion !== 1) {
+        throw new BackupValidationError(
+            `対応していない暗号化バックアップ形式です（envelopeVersion=${String(json.envelopeVersion)}）。`,
+        );
+    }
+    if (json.algorithm !== 'AES-GCM-256') {
+        throw new BackupValidationError(
+            `対応していない暗号化アルゴリズムです: ${String(json.algorithm)}`,
+        );
+    }
+    if (json.kdf !== 'PBKDF2-SHA256') {
+        throw new BackupValidationError(
+            `対応していない鍵派生関数です: ${String(json.kdf)}`,
+        );
+    }
+    const kdfParams = json.kdfParams as { salt: string; iterations: unknown };
+    if (
+        typeof kdfParams.iterations !== 'number'
+        || !Number.isFinite(kdfParams.iterations)
+    ) {
+        throw new BackupValidationError('iterations が数値ではありません。');
+    }
+    if (
+        kdfParams.iterations < MIN_ACCEPTED_ITERATIONS
+        || kdfParams.iterations > MAX_ACCEPTED_ITERATIONS
+    ) {
+        throw new BackupValidationError(
+            `iterations が許容範囲外です（${MIN_ACCEPTED_ITERATIONS}〜${MAX_ACCEPTED_ITERATIONS}）。`,
+        );
+    }
+    const saltLen = decodedByteLength(kdfParams.salt);
+    if (saltLen !== SALT_BYTES) {
+        throw new BackupValidationError(
+            `salt の長さが不正です（${SALT_BYTES} bytes 期待）。`,
+        );
+    }
+    const ivLen = decodedByteLength(json.iv);
+    if (ivLen !== IV_BYTES) {
+        throw new BackupValidationError(
+            `iv の長さが不正です（${IV_BYTES} bytes 期待）。`,
+        );
+    }
+    const ciphertextLen = decodedByteLength(json.ciphertext);
+    if (ciphertextLen <= 0 || ciphertextLen > MAX_CIPHERTEXT_BYTES) {
+        throw new BackupValidationError(
+            `ciphertext の長さが不正です（最大 ${MAX_CIPHERTEXT_BYTES} bytes）。`,
+        );
+    }
+    const appVersion = typeof json.appVersion === 'string' ? json.appVersion : 'unknown';
+    const encryptedAt = typeof json.encryptedAt === 'string'
+        ? json.encryptedAt
+        : new Date().toISOString();
+
+    return {
+        envelopeVersion: 1,
+        encrypted: true,
+        algorithm: 'AES-GCM-256',
+        kdf: 'PBKDF2-SHA256',
+        kdfParams: { salt: kdfParams.salt, iterations: kdfParams.iterations },
+        iv: json.iv,
+        ciphertext: json.ciphertext,
+        appVersion,
+        encryptedAt,
+    };
+};
+
+// AC-8: parseAnyBackup is the new top-level entrypoint for encrypted-aware
+// callers. parseBackup keeps its narrow BackupV1 return type unchanged so
+// existing callers don't need union narrowing they don't care about.
+export const parseAnyBackup = (raw: string): BackupV1 | EncryptedBackupV1 => {
+    if (raw.length === 0 || raw.trim() === '') {
+        throw new BackupValidationError('ファイルが空です。');
+    }
+    let json: unknown;
+    try {
+        json = JSON.parse(raw);
+    } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        throw new BackupValidationError(`バックアップファイルが壊れています: ${msg}`);
+    }
+    if (!isObject(json)) {
+        throw new BackupValidationError('バックアップファイルが有効なオブジェクトではありません。');
+    }
+    if (json.encrypted === true) {
+        // Half-broken envelopes (e.g., {encrypted:true} only) are rejected
+        // explicitly here — we never silently fall through to plaintext path.
+        return parseEncryptedEnvelope(json);
+    }
+    return parseBackup(raw);
 };
 
 export interface ResolvedImportProjects {


### PR DESCRIPTION
## Summary

M6 PR-B として E2EE 暗号化バックアップの crypto core 層を実装。AC-1〜4, 7, 8, 10〜14 を達成（AC-5/6/9 の slice/UI 部分は PR-C/D）。

## 変更ファイル

| File | Change |
|---|---|
| `utils/backupErrors.ts` | 新規 — `BackupValidationError` + `BackupErrorCauseKind` 共有（循環 import 解消） |
| `utils/backupCrypto.ts` | 新規 — crypto core (encrypt/decrypt/deriveKey/AAD/randomBytes/base64) |
| `utils/backupCrypto.test.ts` | 新規 — 33 ケース vitest |
| `utils/backupSchema.ts` | 拡張 — isEncryptedBackup / parseEncryptedEnvelope / parseAnyBackup |
| `utils/backupSchema.test.ts` | 拡張 — AC-8 regression + parse-time 境界値 |
| `tests/fixtures/backup.ts` | 新規 — buildSampleProject / buildSampleBackup / buildLargeBackup / tamperLastByte |
| `tests/static/no-export-key.test.ts` | 新規 — AC-14 静的検査 |
| `tests/static/no-error-cause-in-components.test.ts` | 新規 — AC-9 静的検査 |
| `types.ts` | EncryptedBackupV1 interface 追加 |
| `docs/spec/m6/acceptance-criteria.md` | logger.warn → console.warn (FE 慣習に整合、AC-2/9 文言調整) |

## AC 達成状況 (Evaluator APPROVE 済)

| AC | 判定 | 検証方法 |
|---|---|---|
| AC-1 round-trip + KDF determinism | PASS | vitest (deep-equal + getRandomValues spy で salt/iv pin) |
| AC-2 wrong passphrase | PASS | console.warn event id + safe metadata 負 assert |
| AC-3 IV/salt uniqueness | PASS | randomBytes 100 回 + 統合 3 回 |
| AC-4 envelope schema | PASS | parse-time floor/ceiling/byte-length guard 9 ケース |
| AC-7 4 cause kinds | PASS | auth-tag-mismatch / kdf-import-failed / plaintext-corrupted / schema-invalid 全実装 |
| AC-8 後方互換 | PASS | parseBackup 戻り値型不変 + isEncryptedBackup AND 結合 + 半壊 envelope reject |
| AC-10 大容量性能 | PASS | 10MB encrypt+decrypt < 10s (ローカル) / < 15s (CI) |
| AC-11 AbortSignal | PASS | pre-aborted signal で AbortError reject |
| AC-12 NFC normalization | PASS | NFC/NFD interop + grapheme count + 境界 11/12/13 |
| AC-13 AAD metadata | PASS | iv/iterations/appVersion/encryptedAt 改竄全て auth-tag-mismatch |
| AC-14 extractable=false | PASS | deriveKey spy で `extractable === false` + CryptoKey.extractable 直接観察 + exportKey grep |

AC-5/6/9 の slice/UI 部分は PR-C/D で実装。

## Quality Gate

### Evaluator 分離 (rules/quality-gate.md, 新規機能のため発動)
- 1 周目: REQUEST_CHANGES (FAIL 4 件: AC-1 KDF determinism / AC-2 event id assert / AC-7 4 cause / AC-14 extractable spy)
- 2 周目: REQUEST_CHANGES (HIGH 1: 循環 import) → backupErrors.ts に切り出し
- 3 周目: **APPROVE**

### /simplify 3 並列 (reuse / quality / efficiency)
- C1 (rating 7): AC-7 plaintext-corrupted/schema-invalid テストを `buildEnvelopeWithRawPayload` helper に集約 (~50 行純減)
- C2 (rating 7): `BackupValidationError` constructor を `(message, options?)` に拡張、stringly-typed `(err as Error).cause = ...` 直書きを排除
- I1/I3: dead code (`MAX_ENVELOPE_FILE_BYTES` / `'no-pending-decryption'`) 削除 (PR-C/D で再追加)
- I-1 (efficiency): `toBase64` 32KB chunked spread → AC-10 perf **545ms → 356ms** (~35% 短縮)
- §2 (reuse): `buildSampleBackup` を `buildBackupV1` 経由化 (`BACKUP_SCHEMA_VERSION` 単一参照)

先送り (別 PR):
- §1 fixture 3 重複 (`buildSampleProject` / `makeProject` × 2) 統合
- I2/I4-I8 polish

## Test plan

- [x] `npm run lint` 0 errors (tsc --noEmit)
- [x] `npm test` 407 / 407 PASS (前 339 → +68)
- [x] `npm run build` PASS
- [x] AC-10 perf < 10s (ローカル ~360ms)
- [x] grep でロガー sensitive field 不在確認
- [ ] (本 PR merge 後) PR-C 着手時に state-diagram.md 作成 (CLAUDE.md MUST)

## CLAUDE.md MUST 準拠
- 境界値テスト: passphrase 0/11/12/13/1000 grapheme + iterations MIN-1/MIN/MAX/MAX+1 + salt/iv byte 長
- 状態遷移図: M6 PR-B では state field 管理なし (PR-C で対応)
- main 直 push なし、feature ブランチ + PR 経由
- 5 ファイル+ + 新規機能 → Evaluator 分離 + /simplify 3 並列

🤖 Generated with [Claude Code](https://claude.com/claude-code)