### PR TITLE
feat(m6): PR-C slice integration (encrypted export/import + state machine)

### DIFF
--- a/docs/spec/m6/acceptance-criteria.md
+++ b/docs/spec/m6/acceptance-criteria.md
@@ -344,10 +344,14 @@ expect(elapsed).toBeLessThan(limit);
 ### AC-11: AbortSignal 対応 + UI timeout
 
 **Given**: `encryptBackup` / `decryptBackup` の long-running 操作（PBKDF2 + AES-GCM）
-**When**: `AbortSignal` を option として渡し、KDF 中に `controller.abort()` を呼ぶ
+**When**: `AbortSignal` を option として渡し、abort タイミングは以下のチェックポイントで検知される (Web Crypto API は `crypto.subtle.deriveKey` / `decrypt` の **mid-execution 中断をサポートしない**ため、KDF 自体の早期終了は不可能)
+- `encryptBackup` / `decryptBackup` 開始直後
+- KDF (PBKDF2 600k iter.) 完了直後
+- AES-GCM `encrypt` / `decrypt` 完了直後
 **Then**:
 - `encryptBackup({ signal })` / `decryptBackup({ signal })` が `'AbortError'` DOMException で reject
 - abort 時に Blob 未生成 (export) / pendingDecryption state 未更新 (import) の invariant 維持
+- KDF 進行中に `controller.abort()` を呼んだ場合、KDF 完了 (~70ms 〜数百 ms) まで待機後に直近の `checkAborted` で abort が発火する (実装の限界)
 - UI 層は **30 秒経過時に強制 abort** + トースト「暗号化に時間がかかっています。デバイス性能を確認するか、データ量を減らしてください」+ cancel ボタン
 - mobile Safari の background throttle (15 秒以上) に対しては、abort 後の再試行を許可（state を「再試行可能」に戻す）
 

--- a/docs/spec/m6/state-diagram.md
+++ b/docs/spec/m6/state-diagram.md
@@ -1,0 +1,106 @@
+# M6 PR-C `pendingDecryption` State Machine
+
+CLAUDE.md MUST「statusフィールドで処理状態を管理する設計 → 状態遷移図を先に作成」に従い、`pendingDecryption` の状態遷移を実装前に確定する。
+
+実装タスク: `store/backupSlice.ts` への encrypt/decrypt 経路統合 (M6 PR-C)。
+
+## 状態定義
+
+```
+pendingDecryption: null
+  | { rawEnvelope: EncryptedBackupV1; retryCount: number; abortController: AbortController; isDecrypting: boolean }
+```
+
+| state | 意味 | UI 反映 |
+|---|---|---|
+| `null` (= idle) | encrypted import 待機なし | ImportPassphraseModal は mount しない |
+| `{ ..., isDecrypting: false }` (= awaiting passphrase) | encrypted envelope 検出済、ユーザーのパスフレーズ入力待ち | ImportPassphraseModal mount、入力可能 |
+| `{ ..., isDecrypting: true }` (= decrypting) | パスフレーズ受領、KDF/AES-GCM 実行中 | ImportPassphraseModal mount、入力 disabled、cancel ボタン enable |
+| (`importPlan` set へ移行) | 復号成功 → conflict 検出フロー | ImportConflictModal mount |
+
+## 遷移図 (Mermaid)
+
+```mermaid
+stateDiagram-v2
+    [*] --> Idle : initial
+
+    Idle --> AwaitingPassphrase : prepareImport(encrypted envelope)
+    Idle --> ImportPlan : prepareImport(plaintext BackupV1) — 既存フロー
+
+    AwaitingPassphrase --> Decrypting : decryptAndPrepareImport(passphrase)
+    AwaitingPassphrase --> Idle : cancelPendingDecryption()
+    AwaitingPassphrase --> AwaitingPassphrase : prepareImport(2nd encrypted)\n— 内部で先に cancel→set
+    AwaitingPassphrase --> ImportPlan : prepareImport(2nd plaintext)\n— 内部で先に cancel→set
+
+    Decrypting --> ImportPlan : decrypt OK\n→ existing conflict flow
+    Decrypting --> AwaitingPassphrase : decrypt FAIL (retry < 5)\n→ retryCount++
+    Decrypting --> Idle : decrypt FAIL (retry == 5)\n→ force close + toast
+    Decrypting --> Idle : cancelPendingDecryption()\n→ AbortController.abort()
+
+    ImportPlan --> [*] : executeImport / cancelImport
+```
+
+## 遷移ルールと禁則
+
+### 許可される遷移
+- `Idle → AwaitingPassphrase`: `prepareImport` で `EncryptedBackupV1` を検出
+- `Idle → ImportPlan`: `prepareImport` で 平文 `BackupV1` を検出 (既存挙動)
+- `AwaitingPassphrase → Decrypting`: ユーザーがパスフレーズを送信
+- `AwaitingPassphrase → Idle`: `cancelPendingDecryption()` 呼び出し
+- `Decrypting → ImportPlan`: 復号成功 → 既存 conflict 検出フローへ合流
+- `Decrypting → AwaitingPassphrase`: 復号失敗 (retryCount < 5)、retryCount を increment
+- `Decrypting → Idle`: 復号失敗 (retryCount == 5、上限到達) または cancelPendingDecryption
+
+### 禁則 (illegal transitions)
+- **`Idle → Decrypting` 直接遷移禁止**: `decryptAndPrepareImport` を `pendingDecryption === null` で呼ぶと `BackupValidationError({ cause: { kind: 'no-pending-decryption' } })` throw、state 不変
+- **`AwaitingPassphrase` への暗黙上書き禁止**: 既存 `pendingDecryption` がある時に `prepareImport(2nd)` が呼ばれた場合、必ず `cancelPendingDecryption()` を**同期的に先**に呼んでから new state を set する (race-free)
+- **`Decrypting` 中の二重 `decryptAndPrepareImport` 禁止**: 既存 `isDecrypting === true` 時の追加呼び出しは throw (`{ cause: { kind: 'concurrent-decrypt' } }`)
+
+### 不変条件 (invariants)
+1. `pendingDecryption !== null` の間は `importPlan === null` (相互排他)
+2. `Decrypting → ImportPlan` 遷移時、`pendingDecryption` を `null` にしてから `importPlan` を set する (中間状態で両方 set にならない)
+3. AbortController abort 後の KDF/decrypt 完了 handler は `signal.aborted` を check してから state 更新を skip (race-free closure)
+4. `retryCount` は 0..5 範囲の整数。5 到達時は強制 close + トースト表示
+
+## ModalManager 統合
+
+| 状況 | 表示するモーダル |
+|---|---|
+| `pendingDecryption !== null` | `ImportPassphraseModal` (PR-D で実装) |
+| `pendingDecryption === null && importPlan !== null` | 既存 `ImportConflictModal` |
+| 両方 null | モーダルなし |
+
+`pendingDecryption` が **`importPlan` より優先表示**される。M7-α `TermsConsentModal` の先頭分岐パターンと整合 (`needsTermsAccept && !isTermsDevBypass()`)。
+
+## エラー文言 (AC-6)
+
+| 状況 | UI 文言 |
+|---|---|
+| 復号失敗 (retry 1〜4) | `DECRYPT_FAILURE_MESSAGE` (定数、AC-2 と同一) + 「(あと N 回まで再試行できます)」 (※ 残回数の suffix は **UI 側** で `pendingDecryption.retryCount` から `MAX_DECRYPT_RETRIES - retryCount` として導出する。slice は文言生成しない) |
+| 復号失敗 (retry 5、強制 close) | トースト「再試行回数の上限に達しました。ファイルとパスフレーズを確認してください。」 |
+| `cancelPendingDecryption()` | トースト無し (ユーザー意図のキャンセル) |
+| `prepareImport(2nd)` で上書き発生 | トースト「進行中の復号処理を中断しました」 |
+
+## 実装注意点
+
+1. **AbortController は state 内に保持**: 各 `decryptAndPrepareImport` 呼び出しで新規 controller を生成。`cancelPendingDecryption` は `controller.abort()` を呼んだ上で state を init
+2. **race-free 上書き**: `prepareImport` 冒頭で既存 `pendingDecryption` があれば `cancelPendingDecryption()` を**同期実行**してから new state set
+3. **decrypt 完了 handler の guard**: `await decryptBackup(...)` 後に `signal.aborted` を check し、true なら state 更新せずに return (古い session の resolve が新 session を上書きする race を防止)
+4. **retry counter のリセット**: cancel / 新規 prepareImport 時に必ず 0 にリセット (5 回上限の意図は「同一 envelope 内」)
+
+## テスト要件 (PR-C vitest)
+
+state machine 遷移テストとして以下を網羅:
+
+- T1: Idle → AwaitingPassphrase (encrypted envelope detection)
+- T2: Idle → ImportPlan (plaintext BackupV1 既存挙動 regression)
+- T3: AwaitingPassphrase → Decrypting → ImportPlan (happy path)
+- T4: AwaitingPassphrase → Decrypting → AwaitingPassphrase (retry 1〜4)
+- T5: AwaitingPassphrase → Decrypting → Idle (retry == 5、強制 close)
+- T6: AwaitingPassphrase → Idle (cancel)
+- T7: Decrypting → Idle (cancel during KDF、AbortController.abort 連動)
+- T8: Idle → Decrypting 直接呼び出しが throw (`no-pending-decryption`)
+- T9: AwaitingPassphrase → AwaitingPassphrase (2nd prepareImport 上書き、cancel→set 順序保証)
+- T10: AwaitingPassphrase → ImportPlan (2nd prepareImport が plaintext)
+- T11: Decrypting 中の 2nd `decryptAndPrepareImport` が throw (`concurrent-decrypt`)
+- T12: Race - decrypt 完了が cancel 後に来た場合 state 更新 skip

--- a/store/backupSlice.test.ts
+++ b/store/backupSlice.test.ts
@@ -852,13 +852,29 @@ describe('M6 PR-C state machine (pendingDecryption)', () => {
         expect(fake.state.pendingDecryption).toBeNull();
     });
 
-    it('T7: cancel during KDF triggers AbortController', async () => {
+    it('T7-pre: cancel from AwaitingPassphrase fires abort()', async () => {
         const fake = createFakeStore();
         const raw = await buildEncryptedRaw();
         await fake.state.prepareImport(raw);
         const controller = fake.state.pendingDecryption!.abortController;
         const abortSpy = vi.spyOn(controller, 'abort');
         fake.state.cancelPendingDecryption();
+        expect(abortSpy).toHaveBeenCalled();
+        expect(fake.state.pendingDecryption).toBeNull();
+    });
+
+    it('T7-real: Decrypting → Idle (cancel mid-decrypt) abort fires AND retryCount stays 0', async () => {
+        const fake = createFakeStore();
+        const raw = await buildEncryptedRaw();
+        await fake.state.prepareImport(raw);
+        const controller = fake.state.pendingDecryption!.abortController;
+        const abortSpy = vi.spyOn(controller, 'abort');
+        // Kick off a real decrypt with WRONG passphrase so a successful retry
+        // increment would otherwise be observable. Cancel synchronously so
+        // the catch arm hits isStaleDecryptSession instead.
+        const decryptPromise = fake.state.decryptAndPrepareImport('wrong-passphrase-12c');
+        fake.state.cancelPendingDecryption();
+        await expect(decryptPromise).rejects.toThrow();
         expect(abortSpy).toHaveBeenCalled();
         expect(fake.state.pendingDecryption).toBeNull();
     });
@@ -985,5 +1001,59 @@ describe('M6 PR-C encrypted exportAllData', () => {
         await fake.state.exportAllData();
         expect(capturedFilename).toMatch(/^novel-writer-backup_.*\.json$/);
         expect(capturedFilename).not.toMatch(/\.enc\.json$/);
+    });
+});
+
+// =============================================================================
+// M6 PR-C review-pr 反映: race-during-decrypt + saveLastExportedAt 失敗 toast
+// =============================================================================
+describe('M6 PR-C race during decrypt + export error branches', () => {
+    beforeEach(() => {
+        readSnapshot.mockResolvedValue({
+            projects: [makeProject({ id: 'p-1' })],
+            tutorialState: {},
+            analysisHistory: [],
+        });
+    });
+
+    it('T9b: Decrypting × prepareImport(2nd) — stale decrypt resolution does NOT clobber new session', async () => {
+        const fake = createFakeStore();
+        const raw1 = await buildEncryptedRaw();
+        const raw2 = await buildEncryptedRaw();
+        await fake.state.prepareImport(raw1);
+        const decryptPromise = fake.state.decryptAndPrepareImport(VALID_PASSPHRASE);
+        // While KDF is running, second prepareImport arrives.
+        await fake.state.prepareImport(raw2);
+        // Session 1's promise must reject (race guard fires) and importPlan
+        // must NOT be set from session 1's plaintext.
+        await expect(decryptPromise).rejects.toThrow();
+        expect(fake.state.importPlan).toBeNull();
+        expect(fake.state.pendingDecryption).not.toBeNull();
+        expect(fake.state.pendingDecryption!.retryCount).toBe(0);
+    });
+
+    it('G1 (encrypted): saveLastExportedAt failure surfaces "saved file but timestamp lost" toast, not generic export failure', async () => {
+        saveLastExportedAt.mockRejectedValue(new Error('IDB write failed'));
+        const fake = createFakeStore();
+        await fake.state.exportAllData({ encrypt: { passphrase: VALID_PASSPHRASE } });
+        const calls = (fake.state.showToast as any).mock.calls;
+        // Last toast should be the timestamp-failure variant (download succeeded).
+        const lastCall = calls[calls.length - 1];
+        expect(lastCall[0]).toMatch(/最終バックアップ日時の記録に失敗/);
+        // Critical negative assertion: NEVER claim the export itself failed.
+        expect(lastCall[0]).not.toMatch(/^エクスポートに失敗/);
+        expect(lastCall[1]).toBe('error');
+        expect(fake.state.backupMetaStatus).toBe('unknown'); // wasn't promoted to loaded
+    });
+
+    it('G1 (plaintext): saveLastExportedAt failure surfaces same contract', async () => {
+        saveLastExportedAt.mockRejectedValue(new Error('IDB write failed'));
+        const fake = createFakeStore();
+        await fake.state.exportAllData();
+        const calls = (fake.state.showToast as any).mock.calls;
+        const lastCall = calls[calls.length - 1];
+        expect(lastCall[0]).toMatch(/最終バックアップ日時の記録に失敗/);
+        expect(lastCall[0]).not.toMatch(/^エクスポートに失敗/);
+        expect(lastCall[1]).toBe('error');
     });
 });

--- a/store/backupSlice.test.ts
+++ b/store/backupSlice.test.ts
@@ -156,7 +156,7 @@ describe('prepareImport / executeImport (AC-3, AC-5)', () => {
             tutorialState: {},
             analysisHistory: [],
         });
-        const plan = await fake.state.prepareImport(raw);
+        const result = await fake.state.prepareImport(raw); if (result.kind !== "plaintext") throw new Error("expected plaintext"); const plan = result.plan;
         expect(plan.conflicts).toHaveLength(1);
         expect(plan.conflicts[0].incomingId).toBe('p-existing');
         expect(plan.conflicts[0].existingName).toBe('既存');
@@ -241,7 +241,7 @@ describe('prepareImport / executeImport (AC-3, AC-5)', () => {
             const fake = createFakeStore();
             fake.set({ flushSaveBlocking });
 
-            const plan = await fake.state.prepareImport(minimalRaw);
+            const result = await fake.state.prepareImport(minimalRaw); if (result.kind !== "plaintext") throw new Error("expected plaintext"); const plan = result.plan;
 
             // Common case: no retry needed, no nag toast.
             expect(flushSaveBlocking).toHaveBeenCalledOnce();
@@ -258,7 +258,7 @@ describe('prepareImport / executeImport (AC-3, AC-5)', () => {
             const fake = createFakeStore();
             fake.set({ flushSaveBlocking });
 
-            const plan = await fake.state.prepareImport(minimalRaw);
+            const result = await fake.state.prepareImport(minimalRaw); if (result.kind !== "plaintext") throw new Error("expected plaintext"); const plan = result.plan;
 
             // Retry actually happened (2 attempts), the import proceeded
             // (plan is seeded), and we did NOT toast — a transient blip
@@ -317,7 +317,7 @@ describe('prepareImport / executeImport (AC-3, AC-5)', () => {
             fake.set({ flushSave });
             // No flushSaveBlocking on the fake store.
 
-            const plan = await fake.state.prepareImport(minimalRaw);
+            const result = await fake.state.prepareImport(minimalRaw); if (result.kind !== "plaintext") throw new Error("expected plaintext"); const plan = result.plan;
             expect(flushSave).toHaveBeenCalledOnce();
             expect(plan.backup.projects).toHaveLength(1);
             expect(fake.state.importPlan).not.toBeNull();
@@ -327,7 +327,7 @@ describe('prepareImport / executeImport (AC-3, AC-5)', () => {
             readSnapshot.mockResolvedValue({ projects: [], tutorialState: {}, analysisHistory: [] });
             const fake = createFakeStore();
             // No flush API of any kind.
-            const plan = await fake.state.prepareImport(minimalRaw);
+            const result = await fake.state.prepareImport(minimalRaw); if (result.kind !== "plaintext") throw new Error("expected plaintext"); const plan = result.plan;
             expect(plan.backup.projects).toHaveLength(1);
         });
     });
@@ -755,5 +755,235 @@ describe('isBackupStale (AC-7)', () => {
             setLoaded(fake, isoFromNowMinus((STALE_BACKUP_DAYS + 1) * DAY_MS + 1));
             expect(fake.state.isBackupStale()).toBe(true);
         });
+    });
+});
+
+// =============================================================================
+// M6 PR-C: state machine tests for pendingDecryption
+// =============================================================================
+import { encryptBackup } from '../utils/backupCrypto';
+import { buildSampleBackup } from '../tests/fixtures/backup';
+import {
+    DECRYPT_OVERWRITE_TOAST,
+    DECRYPT_RETRY_EXCEEDED_TOAST,
+    MAX_DECRYPT_RETRIES,
+} from './backupSlice';
+
+const VALID_PASSPHRASE = 'pr-c-passphrase-test';
+
+const buildEncryptedRaw = async (): Promise<string> => {
+    const backup = buildSampleBackup();
+    const env = await encryptBackup(backup, VALID_PASSPHRASE, '1.0.0');
+    return JSON.stringify(env);
+};
+
+describe('M6 PR-C state machine (pendingDecryption)', () => {
+    beforeEach(() => {
+        readSnapshot.mockResolvedValue({
+            projects: [],
+            tutorialState: {},
+            analysisHistory: [],
+        });
+    });
+
+    it('T1: Idle → AwaitingPassphrase (encrypted envelope detection)', async () => {
+        const fake = createFakeStore();
+        const raw = await buildEncryptedRaw();
+        const result = await fake.state.prepareImport(raw);
+        expect(result.kind).toBe('encrypted');
+        expect(fake.state.pendingDecryption).not.toBeNull();
+        expect(fake.state.pendingDecryption!.retryCount).toBe(0);
+        expect(fake.state.pendingDecryption!.isDecrypting).toBe(false);
+        expect(fake.state.importPlan).toBeNull();
+    });
+
+    it('T2: Idle → ImportPlan (plaintext BackupV1, regression of legacy path)', async () => {
+        const fake = createFakeStore();
+        const raw = JSON.stringify(buildSampleBackup());
+        const result = await fake.state.prepareImport(raw);
+        expect(result.kind).toBe('plaintext');
+        expect(fake.state.importPlan).not.toBeNull();
+        expect(fake.state.pendingDecryption).toBeNull();
+    });
+
+    it('T3: AwaitingPassphrase → Decrypting → ImportPlan (happy path)', async () => {
+        const fake = createFakeStore();
+        const raw = await buildEncryptedRaw();
+        await fake.state.prepareImport(raw);
+        const result = await fake.state.decryptAndPrepareImport(VALID_PASSPHRASE);
+        expect(result.kind).toBe('plaintext');
+        expect(fake.state.pendingDecryption).toBeNull();
+        expect(fake.state.importPlan).not.toBeNull();
+    });
+
+    it('T4: AwaitingPassphrase → Decrypting → AwaitingPassphrase (retry < 5)', async () => {
+        const fake = createFakeStore();
+        const raw = await buildEncryptedRaw();
+        await fake.state.prepareImport(raw);
+        await expect(
+            fake.state.decryptAndPrepareImport('wrong-passphrase-12c'),
+        ).rejects.toThrow(/パスフレーズ/);
+        expect(fake.state.pendingDecryption).not.toBeNull();
+        expect(fake.state.pendingDecryption!.retryCount).toBe(1);
+        expect(fake.state.pendingDecryption!.isDecrypting).toBe(false);
+    });
+
+    it('T5: AwaitingPassphrase → Decrypting → Idle (retry == MAX, force close + toast)', async () => {
+        const fake = createFakeStore();
+        const raw = await buildEncryptedRaw();
+        await fake.state.prepareImport(raw);
+        for (let i = 0; i < MAX_DECRYPT_RETRIES; i++) {
+            await expect(
+                fake.state.decryptAndPrepareImport('wrong-passphrase-12c'),
+            ).rejects.toThrow();
+        }
+        expect(fake.state.pendingDecryption).toBeNull();
+        expect(fake.state.showToast).toHaveBeenCalledWith(
+            DECRYPT_RETRY_EXCEEDED_TOAST,
+            'error',
+        );
+    });
+
+    it('T6: AwaitingPassphrase → Idle (cancel)', async () => {
+        const fake = createFakeStore();
+        const raw = await buildEncryptedRaw();
+        await fake.state.prepareImport(raw);
+        fake.state.cancelPendingDecryption();
+        expect(fake.state.pendingDecryption).toBeNull();
+    });
+
+    it('T7: cancel during KDF triggers AbortController', async () => {
+        const fake = createFakeStore();
+        const raw = await buildEncryptedRaw();
+        await fake.state.prepareImport(raw);
+        const controller = fake.state.pendingDecryption!.abortController;
+        const abortSpy = vi.spyOn(controller, 'abort');
+        fake.state.cancelPendingDecryption();
+        expect(abortSpy).toHaveBeenCalled();
+        expect(fake.state.pendingDecryption).toBeNull();
+    });
+
+    it('T8: Idle → Decrypting direct call throws no-pending-decryption', async () => {
+        const fake = createFakeStore();
+        await expect(
+            fake.state.decryptAndPrepareImport('any-pass-12-chars-ok'),
+        ).rejects.toMatchObject({
+            cause: { kind: 'no-pending-decryption' },
+        });
+    });
+
+    it('T9: AwaitingPassphrase → AwaitingPassphrase (2nd encrypted prepareImport, race-free overwrite)', async () => {
+        const fake = createFakeStore();
+        const raw1 = await buildEncryptedRaw();
+        const raw2 = await buildEncryptedRaw();
+        await fake.state.prepareImport(raw1);
+        const ctrl1 = fake.state.pendingDecryption!.abortController;
+        const abortSpy = vi.spyOn(ctrl1, 'abort');
+        const result = await fake.state.prepareImport(raw2);
+        expect(result.kind).toBe('encrypted');
+        expect(abortSpy).toHaveBeenCalled();
+        // new pending replaced cleanly
+        expect(fake.state.pendingDecryption).not.toBeNull();
+        expect(fake.state.pendingDecryption!.abortController).not.toBe(ctrl1);
+        expect(fake.state.pendingDecryption!.retryCount).toBe(0);
+        expect(fake.state.showToast).toHaveBeenCalledWith(DECRYPT_OVERWRITE_TOAST, 'info');
+    });
+
+    it('T10: AwaitingPassphrase → ImportPlan (2nd prepareImport is plaintext)', async () => {
+        const fake = createFakeStore();
+        const rawEnc = await buildEncryptedRaw();
+        const rawPlain = JSON.stringify(buildSampleBackup());
+        await fake.state.prepareImport(rawEnc);
+        const ctrl = fake.state.pendingDecryption!.abortController;
+        const abortSpy = vi.spyOn(ctrl, 'abort');
+        const result = await fake.state.prepareImport(rawPlain);
+        expect(result.kind).toBe('plaintext');
+        expect(abortSpy).toHaveBeenCalled();
+        expect(fake.state.pendingDecryption).toBeNull();
+        expect(fake.state.importPlan).not.toBeNull();
+    });
+
+    it('T11: concurrent decryptAndPrepareImport during decrypt throws concurrent-decrypt', async () => {
+        const fake = createFakeStore();
+        const raw = await buildEncryptedRaw();
+        await fake.state.prepareImport(raw);
+        // Manually flip isDecrypting to simulate in-flight decrypt
+        const pending = fake.state.pendingDecryption!;
+        fake.set({
+            pendingDecryption: { ...pending, isDecrypting: true },
+        });
+        await expect(
+            fake.state.decryptAndPrepareImport(VALID_PASSPHRASE),
+        ).rejects.toMatchObject({
+            cause: { kind: 'concurrent-decrypt' },
+        });
+    });
+
+    it('T12: race - decrypt completion after cancel does not overwrite state', async () => {
+        const fake = createFakeStore();
+        const raw = await buildEncryptedRaw();
+        await fake.state.prepareImport(raw);
+        // Start decrypt, but cancel before await completes.
+        const pending = fake.state.pendingDecryption!;
+        const decryptPromise = fake.state.decryptAndPrepareImport(VALID_PASSPHRASE);
+        // Synchronously cancel — this aborts the controller mid-KDF.
+        pending.abortController.abort();
+        fake.set({ pendingDecryption: null });
+        await expect(decryptPromise).rejects.toThrow();
+        expect(fake.state.pendingDecryption).toBeNull();
+        expect(fake.state.importPlan).toBeNull();
+    });
+});
+
+// =============================================================================
+// M6 PR-C: encrypted exportAllData
+// =============================================================================
+describe('M6 PR-C encrypted exportAllData', () => {
+    beforeEach(() => {
+        readSnapshot.mockResolvedValue({
+            projects: [makeProject({ id: 'p-1' })],
+            tutorialState: {},
+            analysisHistory: [],
+        });
+        saveLastExportedAt.mockResolvedValue(undefined);
+    });
+
+    it('encrypted: filename ends with .enc.json and content is an envelope, not plaintext', async () => {
+        const fake = createFakeStore();
+        let captured: { filename?: string; content?: string } = {};
+        (globalThis as any).document.createElement = vi.fn(() => ({
+            click: vi.fn(),
+            remove: vi.fn(),
+            set href(_v: string) {},
+            set download(v: string) { captured.filename = v; },
+        }));
+        // Capture Blob content
+        (globalThis as any).Blob = class {
+            constructor(public parts: any, public opts: any) {
+                captured.content = parts.join('');
+            }
+        } as any;
+        await fake.state.exportAllData({ encrypt: { passphrase: VALID_PASSPHRASE } });
+        expect(captured.filename).toMatch(/\.enc\.json$/);
+        const json = JSON.parse(captured.content!);
+        expect(json.encrypted).toBe(true);
+        expect(json.algorithm).toBe('AES-GCM-256');
+        expect(json.envelopeVersion).toBe(1);
+        // ciphertext is opaque — must not contain the project name in plaintext
+        expect(captured.content).not.toContain('"name":"P"');
+    });
+
+    it('plaintext: filename uses .json (no .enc) and content is a plain BackupV1', async () => {
+        const fake = createFakeStore();
+        let capturedFilename = '';
+        (globalThis as any).document.createElement = vi.fn(() => ({
+            click: vi.fn(),
+            remove: vi.fn(),
+            set href(_v: string) {},
+            set download(v: string) { capturedFilename = v; },
+        }));
+        await fake.state.exportAllData();
+        expect(capturedFilename).toMatch(/^novel-writer-backup_.*\.json$/);
+        expect(capturedFilename).not.toMatch(/\.enc\.json$/);
     });
 });

--- a/store/backupSlice.ts
+++ b/store/backupSlice.ts
@@ -84,7 +84,11 @@ export interface BackupSlice {
     setImportResolution: (incomingId: string, resolution: ImportConflictResolution) => void;
     cancelImport: () => void;
     executeImport: () => Promise<{ upserted: number; created: number; skipped: number }>;
-    decryptAndPrepareImport: (passphrase: string) => Promise<PrepareImportResult>;
+    // decryptAndPrepareImport always resolves with the plaintext arm — the
+    // 'encrypted' arm is only produced by prepareImport when an envelope is
+    // first detected. Narrowing here removes a dead branch in PR-D's modal.
+    decryptAndPrepareImport: (passphrase: string)
+        => Promise<Extract<PrepareImportResult, { kind: 'plaintext' }>>;
     cancelPendingDecryption: () => void;
     isBackupStale: () => boolean;
 }
@@ -177,10 +181,16 @@ export const createBackupSlice = (set, get): BackupSlice => ({
                       await encryptBackup(backup, encryptOpt.passphrase, APP_VERSION, {
                           signal: opts?.signal,
                       }),
-                      null,
-                      2,
                   )
                 : serializeBackup(backup);
+            // Post-encrypt abort: encryptBackup may resolve before the abort
+            // event reaches the WebCrypto handler (KDF cannot be interrupted
+            // mid-execution). Re-check signal here so a cancel that landed
+            // during the await does NOT trigger the file download or update
+            // lastExportedAt — the user explicitly asked to stop.
+            if (opts?.signal?.aborted) {
+                return;
+            }
             const filename = encryptOpt
                 ? buildEncryptedBackupFilename()
                 : buildBackupFilename();
@@ -208,6 +218,12 @@ export const createBackupSlice = (set, get): BackupSlice => ({
                 );
             }
         } catch (e: unknown) {
+            // AbortError from encryptBackup is a deliberate cancel, not a
+            // failure — suppress the failure toast (the user knows they
+            // pressed cancel; surfacing "export failed" would be misleading).
+            if (e instanceof Error && e.name === 'AbortError') {
+                return;
+            }
             console.error('exportAllData failed:', e);
             (get() as WithToast).showToast?.(`エクスポートに失敗しました: ${errorMessage(e)}`, 'error');
         } finally {
@@ -405,9 +421,14 @@ export const createBackupSlice = (set, get): BackupSlice => ({
                 signal: sessionController.signal,
             });
         } catch (e) {
-            // Race guard: if a cancel/overwrite happened mid-decrypt, drop the
-            // result — the new session (or null) already owns the state slot.
+            // Race guard: if a cancel/overwrite happened mid-decrypt, drop
+            // the result — the new session (or null) already owns the state
+            // slot. We log the swallowed error so a real crypto failure that
+            // happens during an overwrite race remains visible to Sentry /
+            // devtools (the UI deliberately shows nothing here because a new
+            // session has already taken the modal).
             if (isStaleDecryptSession(sessionController, get().pendingDecryption)) {
+                console.warn('decryptBackup error on stale session (ignored):', e);
                 throw e;
             }
             const next = get().pendingDecryption!;
@@ -429,13 +450,21 @@ export const createBackupSlice = (set, get): BackupSlice => ({
             throw e;
         }
 
-        // Race guard on success path too: drop the result rather than silently
+        // Race guard on success path: drop the result rather than silently
         // replacing the new session's state with stale plaintext.
         if (isStaleDecryptSession(sessionController, get().pendingDecryption)) {
+            console.warn('decryptBackup success on stale session (dropped)');
             throw new BackupValidationError('復号処理がキャンセルされました。');
         }
 
         const snapshot = await readSnapshot();
+        // Re-check after the second await — a cancel / overwrite during
+        // readSnapshot() (which may take 10s of ms on cold IDB) would
+        // otherwise let stale plaintext clobber the newer session's state.
+        if (isStaleDecryptSession(sessionController, get().pendingDecryption)) {
+            console.warn('decryptBackup success on stale session (dropped)');
+            throw new BackupValidationError('復号処理がキャンセルされました。');
+        }
         const conflicts = detectConflicts(backup.projects, snapshot.projects);
         const plan: ImportPlan = { backup, conflicts };
         // Atomic transition: clear pendingDecryption and set importPlan in

--- a/store/backupSlice.ts
+++ b/store/backupSlice.ts
@@ -1,5 +1,6 @@
 import {
     BackupV1,
+    EncryptedBackupV1,
     ImportConflict,
     ImportConflictResolution,
     ImportPlan,
@@ -10,10 +11,13 @@ import {
     BackupValidationError,
     buildBackupFilename,
     buildBackupV1,
+    buildEncryptedBackupFilename,
+    parseAnyBackup,
     parseBackup,
     resolveImportProjects,
     serializeBackup,
 } from '../utils/backupSchema';
+import { decryptBackup, encryptBackup } from '../utils/backupCrypto';
 import {
     loadLastExportedAt,
     readSnapshot,
@@ -42,19 +46,46 @@ const errorMessage = (e: unknown): string =>
 
 export type BackupMetaStatus = 'unknown' | 'loaded';
 
+// M6 PR-C: pendingDecryption represents the in-flight encrypted import flow.
+// Spec: docs/spec/m6/state-diagram.md
+export interface PendingDecryption {
+    rawEnvelope: EncryptedBackupV1;
+    retryCount: number;          // 0..MAX_DECRYPT_RETRIES
+    abortController: AbortController;
+    isDecrypting: boolean;       // true while KDF/AES-GCM in flight
+}
+
+export const MAX_DECRYPT_RETRIES = 5;
+
+// User-facing toast contracts pinned by docs/spec/m6/state-diagram.md §エラー文言.
+// Mirrors the DECRYPT_FAILURE_MESSAGE constant pattern (utils/backupCrypto.ts):
+// the constant is the contract, tests assert exact equality so silent text
+// drift between spec / slice / UI fails CI rather than the user.
+export const DECRYPT_OVERWRITE_TOAST = '進行中の復号処理を中断しました。';
+export const DECRYPT_RETRY_EXCEEDED_TOAST =
+    '再試行回数の上限に達しました。ファイルとパスフレーズを確認してください。';
+
+// Discriminated result of prepareImport so callers (UI) know which modal to mount.
+export type PrepareImportResult =
+    | { kind: 'plaintext'; plan: ImportPlan }
+    | { kind: 'encrypted' };  // pendingDecryption is set; UI mounts ImportPassphraseModal
+
 export interface BackupSlice {
     lastExportedAt: string | null;
     backupMetaStatus: BackupMetaStatus;
     importPlan: ImportPlan | null;
+    pendingDecryption: PendingDecryption | null;
     isExporting: boolean;
     isImporting: boolean;
 
     initBackupState: () => Promise<void>;
-    exportAllData: () => Promise<void>;
-    prepareImport: (raw: string) => Promise<ImportPlan>;
+    exportAllData: (opts?: { encrypt?: { passphrase: string }; signal?: AbortSignal }) => Promise<void>;
+    prepareImport: (raw: string) => Promise<PrepareImportResult>;
     setImportResolution: (incomingId: string, resolution: ImportConflictResolution) => void;
     cancelImport: () => void;
     executeImport: () => Promise<{ upserted: number; created: number; skipped: number }>;
+    decryptAndPrepareImport: (passphrase: string) => Promise<PrepareImportResult>;
+    cancelPendingDecryption: () => void;
     isBackupStale: () => boolean;
 }
 
@@ -72,6 +103,19 @@ const triggerDownload = (filename: string, content: string) => {
     // pipeline and produces empty files in those engines.
     setTimeout(() => URL.revokeObjectURL(url), 0);
 };
+
+// Returns true when this decrypt session no longer owns pendingDecryption —
+// either the abort signal fired, or a later prepareImport / cancel installed a
+// different (or null) state. Centralizing both checks ensures the failure
+// path and success path race guards stay in lockstep when the predicate
+// evolves (e.g. adding a generation counter in M6.5 cloud storage).
+const isStaleDecryptSession = (
+    sessionController: AbortController,
+    current: PendingDecryption | null,
+): boolean =>
+    sessionController.signal.aborted
+    || !current
+    || current.abortController !== sessionController;
 
 const detectConflicts = (incoming: Project[], existing: Project[]): ImportConflict[] => {
     const existingMap = new Map(existing.map(p => [p.id, p]));
@@ -94,6 +138,7 @@ export const createBackupSlice = (set, get): BackupSlice => ({
     lastExportedAt: null,
     backupMetaStatus: 'unknown',
     importPlan: null,
+    pendingDecryption: null,
     isExporting: false,
     isImporting: false,
 
@@ -114,7 +159,7 @@ export const createBackupSlice = (set, get): BackupSlice => ({
         }
     },
 
-    exportAllData: async () => {
+    exportAllData: async (opts) => {
         if (get().isExporting) return;
         set({ isExporting: true });
         try {
@@ -125,8 +170,20 @@ export const createBackupSlice = (set, get): BackupSlice => ({
                 analysisHistory: snapshot.analysisHistory,
                 appVersion: APP_VERSION,
             });
-            const json = serializeBackup(backup);
-            const filename = buildBackupFilename();
+
+            const encryptOpt = opts?.encrypt;
+            const json = encryptOpt
+                ? JSON.stringify(
+                      await encryptBackup(backup, encryptOpt.passphrase, APP_VERSION, {
+                          signal: opts?.signal,
+                      }),
+                      null,
+                      2,
+                  )
+                : serializeBackup(backup);
+            const filename = encryptOpt
+                ? buildEncryptedBackupFilename()
+                : buildBackupFilename();
 
             // 1. Trigger the download. If this fails (e.g. blob/anchor APIs
             //    unavailable), nothing has been saved yet — propagate as a
@@ -211,12 +268,35 @@ export const createBackupSlice = (set, get): BackupSlice => ({
                 console.error('flushSave before prepareImport failed (legacy path):', e);
             }
         }
-        const backup = parseBackup(raw);
+        // Race-free overwrite: if a previous encrypted import is still in
+        // flight, abort it deterministically before installing new state so
+        // the old session's resolve handler (post-KDF) is gated by aborted.
+        // Also surface a toast so the user isn't surprised by the discard.
+        const prior = get().pendingDecryption;
+        if (prior) {
+            prior.abortController.abort();
+            set({ pendingDecryption: null });
+            (get() as WithToast).showToast?.(DECRYPT_OVERWRITE_TOAST, 'info');
+        }
+
+        const parsed = parseAnyBackup(raw);
+        // 'encrypted' is absent on BackupV1 — `in` triggers TS narrowing
+        // without needing the runtime === true check.
+        if ('encrypted' in parsed) {
+            const pending: PendingDecryption = {
+                rawEnvelope: parsed,
+                retryCount: 0,
+                abortController: new AbortController(),
+                isDecrypting: false,
+            };
+            set({ pendingDecryption: pending, importPlan: null });
+            return { kind: 'encrypted' };
+        }
         const snapshot = await readSnapshot();
-        const conflicts = detectConflicts(backup.projects, snapshot.projects);
-        const plan: ImportPlan = { backup, conflicts };
+        const conflicts = detectConflicts(parsed.projects, snapshot.projects);
+        const plan: ImportPlan = { backup: parsed, conflicts };
         set({ importPlan: plan });
-        return plan;
+        return { kind: 'plaintext', plan };
     },
 
     setImportResolution: (incomingId, resolution) => {
@@ -296,6 +376,81 @@ export const createBackupSlice = (set, get): BackupSlice => ({
         } finally {
             set({ isImporting: false });
         }
+    },
+
+    decryptAndPrepareImport: async (passphrase: string) => {
+        const pending = get().pendingDecryption;
+        if (!pending) {
+            throw new BackupValidationError(
+                '復号対象のバックアップがありません。',
+                { cause: { kind: 'no-pending-decryption' } },
+            );
+        }
+        if (pending.isDecrypting) {
+            throw new BackupValidationError(
+                '既に復号処理中です。',
+                { cause: { kind: 'concurrent-decrypt' } },
+            );
+        }
+        // Snapshot the controller before transitioning so the post-await
+        // closure tests against THIS session's abort signal — a later
+        // cancelPendingDecryption / prepareImport(2nd) installs a new
+        // controller and we must not mistake that for "this session ok".
+        const sessionController = pending.abortController;
+        set({ pendingDecryption: { ...pending, isDecrypting: true } });
+
+        let backup: BackupV1;
+        try {
+            backup = await decryptBackup(pending.rawEnvelope, passphrase, {
+                signal: sessionController.signal,
+            });
+        } catch (e) {
+            // Race guard: if a cancel/overwrite happened mid-decrypt, drop the
+            // result — the new session (or null) already owns the state slot.
+            if (isStaleDecryptSession(sessionController, get().pendingDecryption)) {
+                throw e;
+            }
+            const next = get().pendingDecryption!;
+            const newRetry = next.retryCount + 1;
+            if (newRetry >= MAX_DECRYPT_RETRIES) {
+                set({ pendingDecryption: null });
+                (get() as WithCloseModal).closeModal?.();
+                (get() as WithToast).showToast?.(DECRYPT_RETRY_EXCEEDED_TOAST, 'error');
+            } else {
+                // Slice owns retryCount; UI (PR-D) reads pendingDecryption.retryCount
+                // and renders the "(あと N 回まで再試行できます)" suffix from
+                // MAX_DECRYPT_RETRIES - retryCount. The composed string stays out
+                // of state so the modal re-renders reactively without slice churn,
+                // matching docs/spec/m6/state-diagram.md §エラー文言.
+                set({
+                    pendingDecryption: { ...next, retryCount: newRetry, isDecrypting: false },
+                });
+            }
+            throw e;
+        }
+
+        // Race guard on success path too: drop the result rather than silently
+        // replacing the new session's state with stale plaintext.
+        if (isStaleDecryptSession(sessionController, get().pendingDecryption)) {
+            throw new BackupValidationError('復号処理がキャンセルされました。');
+        }
+
+        const snapshot = await readSnapshot();
+        const conflicts = detectConflicts(backup.projects, snapshot.projects);
+        const plan: ImportPlan = { backup, conflicts };
+        // Atomic transition: clear pendingDecryption and set importPlan in
+        // one set() so the invariant `pendingDecryption !== null ⇒ importPlan === null`
+        // is never observably violated.
+        set({ pendingDecryption: null, importPlan: plan });
+        return { kind: 'plaintext', plan };
+    },
+
+    cancelPendingDecryption: () => {
+        const pending = get().pendingDecryption;
+        if (!pending) return;
+        pending.abortController.abort();
+        set({ pendingDecryption: null });
+        (get() as WithCloseModal).closeModal?.();
     },
 
     isBackupStale: () => {

--- a/utils/backupErrors.ts
+++ b/utils/backupErrors.ts
@@ -6,12 +6,25 @@
 // Discriminated union of internal failure causes carried via Error.cause.
 // UI must NOT branch on this — it exists for log triage / debug only.
 // See AC-2/AC-7/AC-9 (fingerprinting prevention vs developer debuggability).
+//
+// Categories:
+//   crypto / parse — produced inside utils/backupCrypto.ts and
+//     utils/backupSchema.ts when an envelope or its payload is malformed.
+//   flow guard (M6 PR-C) — produced by store/backupSlice.ts state machine
+//     guards. These never bubble up to the UI as user-visible messages
+//     (the slice transitions back to a recoverable state and lets the UI
+//     re-prompt) but remain on the typed cause chain so tests and Sentry
+//     breadcrumbs can discriminate them from real crypto failures.
 export type BackupErrorCauseKind =
+    // crypto / parse
     | 'auth-tag-mismatch'
     | 'plaintext-corrupted'
     | 'schema-invalid'
     | 'kdf-import-failed'
-    | 'envelope-incomplete';
+    | 'envelope-incomplete'
+    // flow guard
+    | 'no-pending-decryption'
+    | 'concurrent-decrypt';
 
 export interface BackupErrorCause {
     kind: BackupErrorCauseKind;

--- a/utils/backupSchema.ts
+++ b/utils/backupSchema.ts
@@ -94,6 +94,15 @@ export const buildBackupFilename = (now: Date = new Date()): string => {
     return `novel-writer-backup_${iso}.json`;
 };
 
+// Encrypted variant — same timestamp policy as buildBackupFilename, just a
+// different suffix so users can tell at a glance which file requires a
+// passphrase to import. Co-located so a future timestamp-format change
+// (e.g. shortening, switching to local time) updates both consistently.
+export const buildEncryptedBackupFilename = (now: Date = new Date()): string => {
+    const iso = now.toISOString().replace(/[:.]/g, '-');
+    return `novel-writer-backup_${iso}.enc.json`;
+};
+
 interface ParseOptions {
     rawSize: number;
 }


### PR DESCRIPTION
## Summary

M6 PR-C として `store/backupSlice.ts` に encrypted Export/Import 経路を統合。AC-5 (slice 層) / AC-6 (state machine) / AC-11 (AbortSignal) を達成。UI 部分は PR-D で実装。

## 変更ファイル

| File | Change |
|---|---|
| `store/backupSlice.ts` | exportAllData encrypt option / PendingDecryption / decryptAndPrepareImport / cancelPendingDecryption + race guard helper |
| `store/backupSlice.test.ts` | T1〜T12 state machine 12 件 + encrypted export 2 件 |
| `utils/backupSchema.ts` | buildEncryptedBackupFilename を export 追加 (重複解消) |
| `utils/backupErrors.ts` | BackupErrorCauseKind に 'no-pending-decryption' / 'concurrent-decrypt' 追加 |
| `docs/spec/m6/state-diagram.md` | 新規 — T1〜T12 遷移 / 禁則 / 不変条件 / エラー文言契約 |
| `docs/spec/m6/acceptance-criteria.md` | AC-11 を実装限界 (Web Crypto API mid-execution 中断不可) に合わせ修正 |

## State Machine (state-diagram.md)

```
Idle → AwaitingPassphrase → Decrypting → ImportPlan (happy)
                              ↓ (retry < 5)
                          AwaitingPassphrase
                              ↓ (retry == 5)
                              Idle (force close + toast)
```

不変条件: `pendingDecryption !== null ⇒ importPlan === null` を atomic set で保持。Race guard は `isStaleDecryptSession(controller, current)` helper で 2 callsite に統一。

## Quality Gate

### Evaluator 分離プロトコル (新規機能発動)
- 1 周目: REQUEST_CHANGES — MEDIUM 2 (retry 残回数の責務 / AC-11 KDF mid-execution 不可)
- 反映後: APPROVE 想定

### /simplify 3 並列 (reuse / quality / efficiency)
- **C1 rating 8**: `BackupErrorCauseKind` 拡張 → `as never` キャスト 2 箇所削除
- **I1 rating 7**: toast 文字列を `DECRYPT_OVERWRITE_TOAST` / `DECRYPT_RETRY_EXCEEDED_TOAST` 定数化、test を equality match に変更
- **I2/M1 rating 7**: retry 残回数 「(あと N 回)」の責務を slice (state) と UI (文言) で分離する旨を comment + spec 1 行追記
- **R1 Important**: `buildEncryptedBackupFilename` を `utils/backupSchema.ts` へ移動 (`buildBackupFilename` の隣)
- **R2 Important**: `isStaleDecryptSession` helper 抽出 (race-guard 述語の重複解消)
- **M2 MEDIUM**: AC-11 spec を Web Crypto API の制約 (KDF mid-execution 中断不可) に整合
- efficiency: JSON.stringify indent オーバーヘッドは 52 byte 固定 (0.0004%) と実測判明 → 改修不要

## State Machine テスト (T1〜T12)

| ID | 遷移 |
|---|---|
| T1 | Idle → AwaitingPassphrase (encrypted detection) |
| T2 | Idle → ImportPlan (plaintext regression) |
| T3 | AwaitingPassphrase → Decrypting → ImportPlan (happy) |
| T4 | Decrypting → AwaitingPassphrase (retry < 5) |
| T5 | Decrypting → Idle (retry == 5、強制 close + toast) |
| T6 | AwaitingPassphrase → Idle (cancel) |
| T7 | cancel during KDF が AbortController.abort() 連動 |
| T8 | Idle → Decrypting 直接呼び出しが no-pending-decryption throw |
| T9 | 2nd encrypted prepareImport (race-free overwrite + DECRYPT_OVERWRITE_TOAST) |
| T10 | AwaitingPassphrase → ImportPlan (2nd plaintext) |
| T11 | concurrent decryptAndPrepareImport (concurrent-decrypt throw) |
| T12 | race - decrypt 完了が cancel 後の場合 state 更新 skip |

## Test plan

- [x] `npm run lint` 0 errors
- [x] `npm test` 421 / 421 PASS (前 407 → +14)
- [x] `npm run build` PASS
- [x] state-diagram.md と AC-6 transition table が一致 (T1〜T12)
- [ ] (本 PR merge 後) PR-D 着手時に UI が `pendingDecryption.retryCount` から「あと N 回」を導出する規約に従っているか確認

## CLAUDE.md MUST 準拠

- statusフィールド管理 → 状態遷移図先行作成 (state-diagram.md)
- 境界値: retry 0 / 4 (まだ可) / 5 (上限到達) を T4/T5 で網羅
- main 直 push なし、feature ブランチ + PR 経由
- 5 ファイル+ + 新規機能 → Evaluator 分離 + /simplify 3 並列 + /review-pr 6 並列 (本 PR review コメントで実施予定)

🤖 Generated with [Claude Code](https://claude.com/claude-code)