### PR TITLE
feat(claude): auto-switch gh account via PreToolUse Bash hook

### DIFF
--- a/.claude/hooks/ensure-gh-account.sh
+++ b/.claude/hooks/ensure-gh-account.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Auto-switch `gh` active account to yasushi-honda before any Bash command
+# that invokes `gh`.
+#
+# Why: this project's GitHub identity is yasushi-honda, but `gh auth` state is
+# shared machine-wide via ~/.config/gh/hosts.yml. Other claude sessions and
+# direnv-less subshells can leave Active account pointing to a different user
+# (e.g. yasushihonda-acg), which breaks `gh pr create` / `gh pr merge` etc.
+# direnv `.envrc` does not fire under Claude Code's Bash tool because each
+# tool call spawns a fresh subshell.
+set -euo pipefail
+
+input=$(cat)
+cmd=$(jq -r '.tool_input.command // ""' <<<"$input" 2>/dev/null || echo "")
+
+# Match `gh` as a standalone command word (start, or after pipe/&&/;/space/paren/backtick).
+# Avoid false positives like `something_gh` or `/path/to/gh`.
+if [[ "$cmd" =~ (^|[[:space:]\|\&\;\(\`])gh([[:space:]]|$) ]]; then
+  gh auth switch --user yasushi-honda >/dev/null 2>&1 || true
+fi
+
+exit 0

--- a/.claude/hooks/ensure-gh-account.sh
+++ b/.claude/hooks/ensure-gh-account.sh
@@ -1,22 +1,61 @@
 #!/usr/bin/env bash
-# Auto-switch `gh` active account to yasushi-honda before any Bash command
-# that invokes `gh`.
+# Auto-switch `gh` active account to this project's GitHub identity before
+# any Bash command that invokes `gh`.
 #
-# Why: this project's GitHub identity is yasushi-honda, but `gh auth` state is
-# shared machine-wide via ~/.config/gh/hosts.yml. Other claude sessions and
-# direnv-less subshells can leave Active account pointing to a different user
-# (e.g. yasushihonda-acg), which breaks `gh pr create` / `gh pr merge` etc.
-# direnv `.envrc` does not fire under Claude Code's Bash tool because each
-# tool call spawns a fresh subshell.
+# Why:
+#   `gh auth` state is shared machine-wide via ~/.config/gh/hosts.yml. Other
+#   claude sessions / terminals running `gh auth switch` flip the active
+#   account, so `gh pr create` / `gh pr merge` from this project may run as
+#   the wrong user and fail GitHub's collaborator check.
+#
+#   `.envrc` already calls `gh auth switch` on shell entry, but direnv relies
+#   on the shell's interactive hook (`eval "$(direnv hook bash)"`); Claude
+#   Code's Bash tool spawns non-interactive subshells where direnv does not
+#   fire. Hence this PreToolUse hook bridges the gap.
+#
+# Sunset condition (remove this hook when any of the following holds):
+#   1. Global ~/.claude/ enforces "restore prior gh active account at session
+#      end" (i.e. the cross-session leakage stops at the source).
+#   2. Claude Code's Bash tool starts firing direnv hooks (track Claude Code
+#      changelog / public issues).
+#   3. The project moves to per-command identity (`gh --user X` everywhere or
+#      ephemeral `GH_TOKEN` injection), making the active account irrelevant.
+#
+# PreToolUse hook contract (Claude Code official):
+#   exit 0 -> allow tool call (stderr is recorded in transcript, not blocking)
+#   exit 2 -> BLOCK tool call (stderr fed back to Claude as error)
+# This script never exits 2 by design: every error path falls through to
+# `exit 0` so a misconfigured switch never blocks the user's Bash command.
 set -euo pipefail
 
-input=$(cat)
-cmd=$(jq -r '.tool_input.command // ""' <<<"$input" 2>/dev/null || echo "")
+PROJECT_GH_USER="yasushi-honda"
 
-# Match `gh` as a standalone command word (start, or after pipe/&&/;/space/paren/backtick).
-# Avoid false positives like `something_gh` or `/path/to/gh`.
-if [[ "$cmd" =~ (^|[[:space:]\|\&\;\(\`])gh([[:space:]]|$) ]]; then
-  gh auth switch --user yasushi-honda >/dev/null 2>&1 || true
+if ! command -v jq >/dev/null 2>&1; then
+  printf '[ensure-gh-account] WARN: jq not in PATH; auto gh-switch disabled\n' >&2
+  exit 0
+fi
+
+input=$(cat)
+if ! cmd=$(jq -r '.tool_input.command // ""' <<<"$input" 2>&1); then
+  printf '[ensure-gh-account] WARN: jq parse error: %s\n' "$cmd" >&2
+  exit 0
+fi
+
+# Match `gh` as a standalone command word.
+# Left boundary:  start of string, or any whitespace (incl. \n / \t), pipe,
+#                 &&, ;, paren, backtick.
+# Right boundary: any whitespace, end of string, closing paren (covers
+#                 `result=$(gh pr list)` form), or backtick.
+# False positives avoided: something_gh, /path/to/gh, ./gh, ghostty, length.
+# Known false negatives (acceptable, per PR #80 risk note): absolute-path
+# invocations like `/usr/local/bin/gh`. Manual switch falls back to runbook.
+if [[ "$cmd" =~ (^|[[:space:]\|\&\;\(\`])gh([[:space:]\)\`]|$) ]]; then
+  if ! err=$(gh auth switch --user "$PROJECT_GH_USER" 2>&1); then
+    # Surface to stderr (transcript-only, non-blocking) so a misconfigured
+    # account is debuggable instead of silently retaining a wrong active user.
+    printf '[ensure-gh-account] WARN: gh auth switch to %s failed: %s\n' \
+      "$PROJECT_GH_USER" "$err" >&2
+  fi
 fi
 
 exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/ensure-gh-account.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,8 +109,15 @@ Browser → fetch(/api/*) → server/routes/ → server/services/ → Vertex AI 
 - **本番**: `novel-writer-prod`（課金クォータ引き上げ待ち）
 - **ランタイム**: Cloud Run + Vertex AI（Workload Identity認証）
 - **CI/CD**: GitHub Actions → WIF → Cloud Run自動デプロイ（mainブランチ）
-- **Docker**: マルチステージビルド（`Dockerfile`）
-- **direnv**: `.envrc` で `CLOUDSDK_ACTIVE_CONFIG_NAME=novel-writer-dev` 自動設定
+- **Docker**: マルチステージビルド（`Dockerfile`）。Vite の build-time 静的置換のため、`VITE_FIREBASE_*` 6 変数は `docker build --build-arg` で注入する必要があり、GitHub Secrets → workflow の `env:` ブロック → shell 変数の順で受け渡す（直接 `${{ secrets.* }}` を `run:` に展開しない、command injection 回避）
+- **direnv**: `.envrc` で `CLOUDSDK_ACTIVE_CONFIG_NAME=novel-writer-dev` 自動設定 + `gh auth switch --user yasushi-honda` 自動実行（ただし Claude Code Bash ツールでは direnv hook が発火しないため、補助として下記 `.claude/hooks/` で吸収）
+
+### GitHub アカウント自動切替
+
+`gh auth` の active account はマシン全体で共有される (`~/.config/gh/hosts.yml`)。本プロジェクトの GitHub identity は `yasushi-honda` だが、別 claude セッションや別ターミナルで `gh auth switch` が走ると active account が他ユーザー（例: `yasushihonda-acg`）になり、`gh pr create`/`gh pr merge` が GraphQL の collaborator チェックで失敗する。`.envrc` での自動 switch は Claude Code Bash ツール（毎回サブシェル起動 → direnv 不発火）では機能しないため、プロジェクトローカルの PreToolUse hook で吸収する。
+
+- **`.claude/hooks/ensure-gh-account.sh`**: Bash ツール実行直前に `tool_input.command` を検査し、`gh ` を独立したコマンド語として含む場合は `gh auth switch --user yasushi-honda` を実行（既に同ユーザーなら no-op）。`git push`/`git pull` 等は token 埋込み URL 経由なので対象外
+- **`.claude/settings.json`**: 上記 hook を `PreToolUse` × `Bash` matcher に登録
 
 ## Claude Code 運用ルール（本プロジェクト固有の規律）
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,14 +110,7 @@ Browser → fetch(/api/*) → server/routes/ → server/services/ → Vertex AI 
 - **ランタイム**: Cloud Run + Vertex AI（Workload Identity認証）
 - **CI/CD**: GitHub Actions → WIF → Cloud Run自動デプロイ（mainブランチ）
 - **Docker**: マルチステージビルド（`Dockerfile`）。Vite の build-time 静的置換のため、`VITE_FIREBASE_*` 6 変数は `docker build --build-arg` で注入する必要があり、GitHub Secrets → workflow の `env:` ブロック → shell 変数の順で受け渡す（直接 `${{ secrets.* }}` を `run:` に展開しない、command injection 回避）
-- **direnv**: `.envrc` で `CLOUDSDK_ACTIVE_CONFIG_NAME=novel-writer-dev` 自動設定 + `gh auth switch --user yasushi-honda` 自動実行（ただし Claude Code Bash ツールでは direnv hook が発火しないため、補助として下記 `.claude/hooks/` で吸収）
-
-### GitHub アカウント自動切替
-
-`gh auth` の active account はマシン全体で共有される (`~/.config/gh/hosts.yml`)。本プロジェクトの GitHub identity は `yasushi-honda` だが、別 claude セッションや別ターミナルで `gh auth switch` が走ると active account が他ユーザー（例: `yasushihonda-acg`）になり、`gh pr create`/`gh pr merge` が GraphQL の collaborator チェックで失敗する。`.envrc` での自動 switch は Claude Code Bash ツール（毎回サブシェル起動 → direnv 不発火）では機能しないため、プロジェクトローカルの PreToolUse hook で吸収する。
-
-- **`.claude/hooks/ensure-gh-account.sh`**: Bash ツール実行直前に `tool_input.command` を検査し、`gh ` を独立したコマンド語として含む場合は `gh auth switch --user yasushi-honda` を実行（既に同ユーザーなら no-op）。`git push`/`git pull` 等は token 埋込み URL 経由なので対象外
-- **`.claude/settings.json`**: 上記 hook を `PreToolUse` × `Bash` matcher に登録
+- **direnv**: `.envrc` で `CLOUDSDK_ACTIVE_CONFIG_NAME=novel-writer-dev` 自動設定 + `gh auth switch --user yasushi-honda` 自動実行（direnv は shell の interactive hook (`eval "$(direnv hook bash)"`) に依存し、Claude Code Bash ツールが起動する非対話 subshell では発火しないため、補助として下記 §5 の `.claude/hooks/` で吸収）
 
 ## Claude Code 運用ルール（本プロジェクト固有の規律）
 
@@ -149,3 +142,15 @@ Browser → fetch(/api/*) → server/routes/ → server/services/ → Vertex AI 
 - 同種の規範違反・運用ミスが再発したら、**口頭の謝罪で終わらせず、本セクションへの事例と対策の追記を完了してからセッションを閉じる**。
 - 軽微な事例は `docs/adr/` または個別 ADR に追記、重大な再発防止は本ファイルで常時参照可能にする。
 - 過去事例は時系列の根拠（特定セッション日付）を残す。理由: 規律の正当性が「過去の具体的失敗」に紐付いていると次セッションの Claude がルールを軽視しにくい。詳細セッション要約は `docs/adr/` に分離し、本ファイルからは相対リンクで辿れる構造を保つ。
+
+### 5. GitHub アカウント自動切替（プロジェクトローカル hook）
+
+`gh auth` の active account はマシン全体で `~/.config/gh/hosts.yml` で共有される。本プロジェクトの GitHub identity は `yasushi-honda` だが、別 claude セッションや別ターミナルで `gh auth switch` が走ると active account が他ユーザーに変わり、`gh pr create` / `gh pr merge` が GraphQL の collaborator チェックで失敗する（2026-04-29 セッション、PR #80 の発端事象）。`.envrc` での自動 switch は direnv の interactive hook 依存により Claude Code Bash ツールでは機能しないため、プロジェクトローカルの PreToolUse hook で吸収する。
+
+- **`.claude/hooks/ensure-gh-account.sh`**: Bash ツール実行直前に `tool_input.command` を検査し、`gh ` を独立したコマンド語として含む場合は `gh auth switch --user yasushi-honda` を実行（既に同ユーザーなら no-op）。失敗時は stderr に `[ensure-gh-account] WARN:` で診断を出すが、exit 0 を維持して Bash tool は block しない。`git push` / `git pull` 等は origin URL に token (`https://x-access-token:gho_...@github.com/...`) を埋め込んで認証するため、`gh auth` の active account に依存しない（hook の検知対象外で問題ない）
+- **`.claude/settings.json`**: 上記 hook を `PreToolUse` × `Bash` matcher に登録
+- **`tests/static/ensure-gh-account-hook-resilience.test.ts`**: jq 不在 / malformed JSON / 空 input 等の異常系で hook が exit 0 を維持することを vitest で hard-pin
+- **廃止条件 (sunset)**: 以下のいずれかが満たされたら本 hook は撤去する
+  1. グローバル `~/.claude/` 側で「他プロジェクトでの `gh auth switch` を session 終了時に元アカウントへ復帰させる」規律 / hook が確立されたとき
+  2. Claude Code Bash ツールが direnv hook を発火するようになったとき（公式 changelog で確認）
+  3. プロジェクトが per-command identity（全 gh 呼出で `--user` flag、または ephemeral `GH_TOKEN`）に移行し、active account 依存が解消されたとき

--- a/tests/static/ensure-gh-account-hook-resilience.test.ts
+++ b/tests/static/ensure-gh-account-hook-resilience.test.ts
@@ -1,0 +1,59 @@
+// Static behavioral check: .claude/hooks/ensure-gh-account.sh must always exit 0,
+// even when the PreToolUse input is malformed / empty / missing required fields.
+//
+// Why: PreToolUse hook with non-zero exit blocks the entire Bash tool call from
+// Claude Code. A bug here would silently break every Bash command in this
+// project, with confusing failure modes. The hook script is purely advisory
+// (auto-switches gh active account), so any hard failure is a regression.
+
+import { describe, expect, it } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { resolve } from 'node:path';
+
+const HOOK_PATH = resolve(__dirname, '../../.claude/hooks/ensure-gh-account.sh');
+
+const runHook = (input: string) =>
+    spawnSync('bash', [HOOK_PATH], {
+        input,
+        encoding: 'utf-8',
+        timeout: 10_000,
+    });
+
+describe('.claude/hooks/ensure-gh-account.sh resilience', () => {
+    it('exits 0 with empty input', () => {
+        const result = runHook('');
+        expect(result.status).toBe(0);
+    });
+
+    it('exits 0 when input is malformed JSON', () => {
+        const result = runHook('not-json{{{');
+        expect(result.status).toBe(0);
+    });
+
+    it('exits 0 when tool_input.command is missing', () => {
+        const result = runHook(JSON.stringify({ tool_name: 'Bash' }));
+        expect(result.status).toBe(0);
+    });
+
+    it('exits 0 when tool_input.command is null', () => {
+        const result = runHook(JSON.stringify({ tool_input: { command: null } }));
+        expect(result.status).toBe(0);
+    });
+
+    it('exits 0 when tool_input is unrelated structure', () => {
+        const result = runHook(JSON.stringify({ tool_input: { other: 'value' } }));
+        expect(result.status).toBe(0);
+    });
+
+    it('exits 0 for non-gh command (no switch attempted)', () => {
+        const result = runHook(JSON.stringify({ tool_input: { command: 'git status' } }));
+        expect(result.status).toBe(0);
+    });
+
+    it('exits 0 even when command contains gh (switch may succeed or warn)', () => {
+        // The hook may attempt `gh auth switch` but must surface failure via
+        // stderr WARN and still exit 0 so the Bash tool is not blocked.
+        const result = runHook(JSON.stringify({ tool_input: { command: 'gh pr list' } }));
+        expect(result.status).toBe(0);
+    });
+});


### PR DESCRIPTION
## Summary
- `gh auth` の active account はマシン全体で共有 (`~/.config/gh/hosts.yml`) されるため、別 claude セッションで `gh auth switch` が走ると本プロジェクトの active account が他ユーザーに変わり、`gh pr create`/`gh pr merge` が collaborator チェックで失敗する問題を修正
- `.envrc` での自動 switch は direnv の interactive hook 依存により Claude Code Bash ツール（非対話 subshell）では機能しないため、プロジェクトローカルの PreToolUse × Bash hook で吸収

## Changes
- `.claude/hooks/ensure-gh-account.sh`: PreToolUse hook script
  - `tool_input.command` から jq で抽出
  - 独立した `gh ` コマンド語を正規表現で検出（左境界: 行頭/whitespace/`|`/`&`/`;`/`(`/backtick、右境界: whitespace/EOL/`)`/backtick）
  - false positive (`/path/to/gh-something`, `something_gh`, `ghostty` 等) を除外
  - 既知 false negative: 絶対パス起動 (`/usr/local/bin/gh`)。手動 switch にフォールバック
  - マッチ時のみ `gh auth switch --user yasushi-honda` 実行（既に同ユーザーなら no-op）
  - 失敗時は stderr に `[ensure-gh-account] WARN:` で診断を出し、exit 0 を維持（Bash tool を block しない）
  - 廃止条件 3 つを header に明記（上流規律強化で寿命を迎える defensive code を後続が誤解しないため）
- `.claude/settings.json`: hook を PreToolUse × Bash matcher に登録 (`${CLAUDE_PROJECT_DIR}` 経由で絶対パス解決)
- `tests/static/ensure-gh-account-hook-resilience.test.ts`: hook が異常系入力 7 ケース全てで exit 0 を維持することを vitest で hard-pin
- `CLAUDE.md`: `## Claude Code 運用ルール` §5 として GitHub アカウント自動切替の経緯・運用・廃止条件を記録

## Why this approach
| 候補 | 評価 |
|---|---|
| グローバル `~/.claude/hooks/` で SessionStart hook | プロジェクト固有の identity を global に書くのは scope 違反 (CLAUDE.md §1) |
| `.envrc` 強化 | Claude Code Bash ツールで direnv 不発火、効果なし |
| AI が gh 実行前に毎回 status 確認 | 運用依存、忘却リスク |
| **PreToolUse Bash hook (本 PR)** | **プロジェクトスコープに閉じ、自動反映、direnv 問題回避** |

## Review feedback addressed (4 エージェント並列レビュー)
- ✅ silent-failure-hunter I1 / code-reviewer I-1: `gh auth switch` 失敗の stderr 抑制を解除
- ✅ comment-analyzer IMP-1: 廃止条件 (sunset) を hook header + CLAUDE.md に追記
- ✅ comment-analyzer IMP-2: direnv 不発火を「direnv の interactive hook 依存」と修正（Claude Code 仕様への誤帰属を是正）
- ✅ comment-analyzer IMP-3: `git push`/`pull` の「対象外」を「`gh auth` active account に依存しない」と明確化
- ✅ code-reviewer S-3: CLAUDE.md の配置を `## GCP / デプロイ` から `## Claude Code 運用ルール §5` へ移動
- ✅ pr-test-analyzer R2: jq 不在 / malformed JSON 等の異常系で hook が exit 0 を保証する vitest static test 追加
- ✅ silent-failure-hunter S2: regex 末尾に `\)` `\` を追加し `result=$(gh pr list)` 形式の false negative 解消

## Test plan
- [x] CI (`npm run lint && npm run test && npm run test:firestore-rules`) PASS
- [x] hook script 単体テスト 4 ケース PASS (gh コマンド検知、git status no-op、`/path/to/gh-something` no-op、`result=$(gh ...)` 検知 - 修正後追加)
- [x] vitest static resilience test 7 ケース PASS (空入力 / malformed JSON / null / 不在フィールド / 非 gh / gh) → 全て exit 0
- [x] hook script 実行権限 (755) 設定済
- [ ] **(設定/devtooling PR exemption per CLAUDE.md DoD)** PR マージ後、新 claude セッション最初の gh 実行で active account が `yasushi-honda` に保持されること（次セッション 1 回確認で十分）

## Risk
- 低: 実行コストは hook あたり ~50ms (`gh auth switch` no-op ケース)、Bash 呼出毎に常に発火
- false positive で switch が走っても `gh auth switch` は idempotent なので副作用なし
- false negative (絶対パス起動 等) があれば従来通り手動 switch にフォールバック、hook 側では stderr WARN を出すため診断可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)