### PR TITLE
fix(ui): resolve AuthButton overlap with BackupWarningBanner

### DIFF
--- a/components/ProjectSelectionScreen.tsx
+++ b/components/ProjectSelectionScreen.tsx
@@ -18,11 +18,11 @@ export function ProjectSelectionScreen({ projects, onCreateProject, onDeleteProj
     const importInputRef = useRef(null);
     const handleCreate = (e) => { e.preventDefault(); if (!newProjectName.trim()) return; onCreateProject(newProjectName, newProjectMode); setNewProjectName(''); };
     return (
-        <div className="min-h-screen bg-gray-900 text-gray-200 flex flex-col items-center justify-start p-4 sm:p-8 pt-16 sm:pt-24">
-            <div className="absolute top-4 right-4 sm:top-6 sm:right-6">
-                <AuthButton />
-            </div>
+        <div className="min-h-screen bg-gray-900 text-gray-200 flex flex-col items-center justify-start p-4 sm:p-8">
             <div className="w-full max-w-3xl">
+                <div className="flex items-center justify-end mb-4">
+                    <AuthButton />
+                </div>
                 <h1 className="text-4xl font-bold text-center text-indigo-400 mb-4">小説らいたー</h1>
                 
                 {showWarning && (


### PR DESCRIPTION
## Summary
ProjectSelectionScreen で AuthButton を `absolute top-4 right-4` で画面右上に絶対配置していたため、画面トップの `BackupWarningBanner` 右端の「今すぐエクスポート」ボタンと **狭い画面で衝突**していた問題を修正。

## Root cause
- `BackupWarningBanner`: 画面横幅一杯の通常 flow バナー。右端に「今すぐエクスポート」ボタン
- `AuthButton`: ProjectSelectionScreen 内で `position: absolute` により画面右上 (top-4, right-4) に配置
- 両者の z-index が同等で右上座標域が重なるため、狭い画面で重畳表示される

## Fix
AuthButton を absolute から normal flow に移し、メインコンテンツコンテナ (`max-w-3xl`) 内の上部に `flex justify-end` で右寄せ配置。Banner と AuthButton が別行に分離するため衝突しない。

```
BEFORE:                          AFTER:
[Banner ......... [Export]]      [Banner ......... [Export]]
[                  [Login]] ←重なり
                                                    [Login] ←右寄せ
[小説らいたー]                   [小説らいたー]
```

## Test plan
- [x] `npm run lint` PASS (0 errors)
- [x] `npm run test` PASS (435/435)
- [x] `npm run dev` HTTP 200 確認、コードレベルで `absolute top-4 right-4` 削除確認
- [ ] **(マージ後)** Cloud Run dev でブラウザ確認、狭い画面 (DevTools 200-400px) でログインボタンと「今すぐエクスポート」が重ならないこと
- [ ] **(マージ後)** 広い画面 (1920px) で AuthButton が右上に正しく表示されること

## Risk
- 低: 1 ファイル / +4 -4 行、normal flow への配置変更のみ。Auth/Backup ロジック変更なし
- AuthButton は ProjectSelectionScreen 専用配置の変更、Editor 画面 (Header.tsx 経由) には影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)