### PR TITLE
fix(dev-portal): /dev/ Mermaid 図の Syntax error 表示を修正（描画タイミング問題）

### DIFF
--- a/public/dev/index.html
+++ b/public/dev/index.html
@@ -1281,7 +1281,7 @@ flowchart LR
 <script type="module">
   import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';
   mermaid.initialize({
-    startOnLoad: true,
+    startOnLoad: false,
     theme: 'base',
     fontFamily: '"EB Garamond", "Hiragino Mincho ProN", serif',
     themeVariables: {
@@ -1313,6 +1313,30 @@ flowchart LR
     sequence: { actorMargin: 60, messageMargin: 38, mirrorActors: false },
     gantt: { fontSize: 13, sectionFontSize: 13 }
   });
+
+  // パネルが display:none の状態で mermaid.run() するとレイアウト測定が NaN になり
+  // 「Syntax error in text」フォールバックが描画される。アクティブなパネル内の
+  // 未処理ノードだけを順次レンダリングする。
+  window.__renderMermaidIn = async function(panel){
+    if (!panel) return;
+    var nodes = panel.querySelectorAll('.mermaid:not([data-processed="true"])');
+    if (!nodes.length) return;
+    try {
+      await mermaid.run({ nodes: Array.prototype.slice.call(nodes) });
+    } catch (e) {
+      console.error('mermaid.run failed', e);
+    }
+  };
+  // 初期アクティブパネルを最初に描画
+  document.addEventListener('DOMContentLoaded', function(){
+    var active = document.querySelector('section.panel.is-active');
+    if (active) window.__renderMermaidIn(active);
+  });
+  // DOMContentLoaded が既に発火済みのケース（module scriptは defer 相当）
+  if (document.readyState !== 'loading'){
+    var active0 = document.querySelector('section.panel.is-active');
+    if (active0) window.__renderMermaidIn(active0);
+  }
 </script>
 
 <script>
@@ -1329,6 +1353,11 @@ flowchart LR
     });
     if (push && history && history.replaceState){
       history.replaceState(null, '', '#' + id);
+    }
+    // 切替先パネルの未描画 mermaid を遅延レンダリング（display:block 反映後）
+    var target = document.getElementById(id);
+    if (target && typeof window.__renderMermaidIn === 'function'){
+      requestAnimationFrame(function(){ window.__renderMermaidIn(target); });
     }
     window.scrollTo({ top: 0, behavior: 'smooth' });
   }
@@ -1586,7 +1615,11 @@ flowchart LR
   document.getElementById('cl-print').addEventListener('click', function(){
     document.querySelectorAll('.cl-cat-body').forEach(function(b){ b.style.display = ''; });
     panels.forEach(function(p){ p.classList.add('is-active'); });
-    setTimeout(function(){ window.print(); }, 200);
+    // 全パネル可視化後に未描画 mermaid をまとめて描画してから印刷
+    var renderAll = typeof window.__renderMermaidIn === 'function'
+      ? Promise.all(Array.prototype.map.call(panels, window.__renderMermaidIn))
+      : Promise.resolve();
+    renderAll.then(function(){ setTimeout(function(){ window.print(); }, 200); });
   });
 
   render();


### PR DESCRIPTION
## Summary

- `/dev/` 開発者ポータルの 9 つの Mermaid 図のうち **Fig. II-1 / II-3 / III-3** が「Syntax error in text」と表示されていた問題を修正
- **真因は Mermaid 構文エラーではなく、描画タイミング**。`section.panel { display: none }` の状態で `mermaid.run()` が走ると DOM 寸法測定が NaN/負値となり、mermaid 10.9.5 がフォールバック SVG（"Syntax error in text"）を描画していた
- 初期アクティブパネルおよびタブ切替時（`display:block` 反映後）に対象パネル内の未処理ノードだけを `mermaid.run({ nodes })` で描画するよう変更

## 調査メモ

| 検証 | 結果 |
|---|---|
| 9 図の Mermaid 構文を mermaid@10 で `parse` / `render` 単体実行 | 全 PASS |
| 実ページを Puppeteer で開く（修正前） | Fig. II-1 / II-3 / III-3 のみ `Syntax error in text` |
| 全 panel に `display: block !important` を注入して再現 | 全 9 図エラー消失（仮説確認） |
| 修正後の全タブ巡回 | 全 9 図 `aria-roledescription` 取得、エラー文言なし |

失敗していた 3 図（flowchart 大型・classDiagram・stateDiagram-v2）は DOM 測定要件が厳しく、他の 6 図（小型 flowchart・sequenceDiagram・gantt）は偶然成立していた。

## Changes

- `public/dev/index.html` (+35 / -2)
  - `mermaid.initialize({ startOnLoad: true })` → `false`
  - `window.__renderMermaidIn(panel)`: `data-processed` を持たない `.mermaid` ノードを `mermaid.run({ nodes })` で順次描画
  - 初期アクティブパネル → DOMContentLoaded で描画
  - タブ切替（`activate` 関数内） → `requestAnimationFrame` で `display:block` 反映後に対象パネルを描画
  - 印刷ボタン → 全パネルを `Promise.all` で描画完了させてから `window.print()`

## Test plan

- [x] `npm run lint` PASS
- [x] `npm run test` 435/435 PASS（既存テストへの影響なし）
- [x] Puppeteer + mermaid@10 で 9 図すべて正常 `aria-roledescription` を持ち、`Syntax error in text` を含まないこと
- [ ] マージ後 Cloud Run デプロイ完了後、本番 `/dev/` で各タブ（アーキテクチャ / フロー図 / マイルストーン / 開発者情報）を開いて 9 図がすべて正常描画されることを目視確認
- [ ] 印刷プレビュー（チェックリストの「印刷用に展開」ボタン）でも全図が描画されることを確認

## 影響範囲

- `/dev/` ポータルのみ。本体 SPA / API / 認証フロー・バックアップ機構等の機能には一切影響なし
- `npm run build` 出力（`dist/dev/index.html`）に上記修正がそのまま反映される（Vite publicDir 経由）

🤖 Generated with [Claude Code](https://claude.com/claude-code)