### PR TITLE
fix(csp): allow apis.google.com in scriptSrc (Firebase Auth popup ログイン不可の解消)

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -46,6 +46,11 @@ async function startServer() {
                         // 読み込むため。本番アプリ本体 (FE bundle) は jsdelivr を使わないので
                         // 影響なし。/dev/ ページは認証ゲートなしの公開ドキュメント (M7-α 完了時点)。
                         'https://cdn.jsdelivr.net',
+                        // apis.google.com: Firebase Auth signInWithPopup が gapi iframe loader
+                        // (`/js/api.js`) を親ページの script として読み込むため必要。frameSrc の
+                        // accounts.google.com / *.firebaseapp.com とセットで初めて popup フローが
+                        // 完成する (auth/internal-error 回避)。
+                        'https://apis.google.com',
                     ],
                     // fonts.googleapis.com: webfont stylesheets referenced in index.html.
                     styleSrc: [


### PR DESCRIPTION
## Summary
- 本番 (`/`) で Google サインインボタンを押すと `auth/internal-error` で失敗する。原因は CSP の `script-src` directive に `https://apis.google.com` が無く、Firebase Auth の `signInWithPopup` が gapi iframe loader (`apis.google.com/js/api.js`) を読み込めないため。
- `server/index.ts` の helmet `contentSecurityPolicy.scriptSrc` に `https://apis.google.com` を 1 行追加して popup フローを成立させる。frameSrc 側 (`accounts.google.com` / `*.firebaseapp.com`) は既に許可済み。

## Reproduce
```
ブラウザ (DevTools 開いた状態) → 本番 / → 「Googleでログイン」
=> 失敗
=> Console:
   Loading the script 'https://apis.google.com/js/api.js?onload=__iframefcb...' violates the
   following Content Security Policy directive: "script-src 'self' 'unsafe-inline'
   https://aistudiocdn.com https://cdn.jsdelivr.net".
   signInWithGoogle failed: FirebaseError: Firebase: Error (auth/internal-error).
```

## Root cause
- `server/index.ts` の `scriptSrc` は `'self' 'unsafe-inline' https://aistudiocdn.com https://cdn.jsdelivr.net` のみ。
- Firebase Auth は popup フローで gapi の `iframes` API を使うために `https://apis.google.com/js/api.js` を script として親ページに注入する。`script-src-elem` 未指定なので `script-src` がフォールバックとして適用 → ブロック → popup と親の通信が確立せず `auth/internal-error`。

## Fix
`server/index.ts` の helmet CSP scriptSrc に `'https://apis.google.com'` を 1 行追加 (既存の同 directive にコメント付きで配置)。frameSrc / connectSrc 等は既に Google Auth 用設定済みのため変更なし。

## Test plan
- [x] `npm run lint` (tsc --noEmit) → 0 エラー
- [x] `npm run test` (vitest run) → **435 / 435 PASS** (既存の admin SDK / backup crypto / users route 等すべて green)
- [ ] **マージ後 (Cloud Run デプロイ反映後) に本番 `/` でログインを実機検証** — `signInWithPopup` 成功 → ヘッダにユーザー名表示 → ログアウト動作確認
  - Test plan のうち実機ログイン検証はマージ後に AI からの能動依頼ではなくユーザー側で実施する想定（番号単位の実行依頼を受けてから着手）

## Notes
- CSP テストは未整備 (server に CSP 単体テストなし)。今回はピンポイントな directive 追加なので新規テスト追加は見送り、既存全テストを green 維持で確認。CSP 自動検証は M7-α 以降の課題。
- /dev/ 開発者ポータル (PR #84) の Mermaid CDN 許可とは別経路 (本件は本体アプリ FE が読み込む gapi)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)