### PR TITLE
feat(diag): auth-flow 診断ログ収集 (login 障害切り分け用)

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -9,6 +9,7 @@ import { mountAiRoutes } from './aiRoutes';
 import { logger, serializeError } from './utils/logger';
 
 import usersRoutes from './routes/users';
+import diagRoutes from './routes/diag';
 
 const isDev = process.env.NODE_ENV !== 'production';
 
@@ -119,6 +120,9 @@ async function startServer() {
     mountAiRoutes(app, { rateLimit: aiLimiter });
 
     app.use('/api/users', usersRoutes);
+
+    // 認証フロー診断ログ (no-auth, rate-limited, 1KB cap)。詳細: server/routes/diag.ts
+    app.use('/api/diag', diagRoutes);
 
     // Any unmatched /api/* path must 404 instead of falling through to the
     // SPA fallback (dev: Vite middleware / prod: index.html static). Without

--- a/server/routes/diag.ts
+++ b/server/routes/diag.ts
@@ -1,0 +1,108 @@
+// 認証フローの診断ログ収集エンドポイント (M7-α 後 / login 障害切り分け用)。
+//
+// 目的: signInWithPopup → users/init の各段階で FE からタイムスタンプ + 状態を
+// fire-and-forget で送り、Cloud Logging に集約することで AI / 運用者が一次情報を
+// 直接読めるようにする。FE 側のブラウザ console / network ペーストを介さない。
+//
+// 規律 (本 endpoint が常時 production にある間の安全性担保):
+// - **認証なし**: pre-sign-in 段階のイベントも拾うため Bearer 必須にしない。
+// - **rate limit**: 120 req/min/IP。spam による Cloud Logging 課金爆発を抑止。
+// - **body サイズ**: 1KB cap。Express json parser を local 適用 (10MB の global parser を上書き)。
+// - **event allowlist**: 既知 event 名のみ `eventKnown=true` でタグ。未知名も logging するが
+//   `eventKnown=false` で grep フィルタを容易にする。
+// - **PII 規律**: FE 呼出側で uid のみ送る (email / displayName / token は送らない)。
+//   サーバ側でも detail を素通しにせず allowlist key だけ抽出する。
+// - **撤去条件**: 障害切り分け完了後に PR で削除する (本ファイル + index.ts mount + FE 呼出)。
+//   エンドポイントが常駐しても 1KB cap + rate limit + uid only なので即時の害はない。
+
+import express, { Router } from 'express';
+import rateLimit from 'express-rate-limit';
+import { logger } from '../utils/logger';
+
+const router = Router();
+
+const diagLimiter = rateLimit({
+    windowMs: 60 * 1000,
+    max: 120,
+    standardHeaders: true,
+    legacyHeaders: false,
+    message: { error: 'Too many diagnostic logs.' },
+});
+
+// 1KB cap の専用 json parser。global の 10MB parser より先にここで limit する。
+const diagJsonParser = express.json({ limit: '1kb' });
+
+const KNOWN_EVENTS = new Set([
+    'signin:start',
+    'signin:popup-resolve',
+    'signin:popup-reject',
+    'signin:users-init-start',
+    'signin:users-init-success',
+    'signin:users-init-error',
+    'auth:state-changed',
+    'auth:state-error',
+]);
+
+// detail から拾う key の allowlist。FE が誤って token / email を送っても
+// ここで filtering される (defense in depth)。
+const DETAIL_KEY_ALLOWLIST = new Set([
+    'uid',
+    'code',
+    'message',
+    'status',
+    'hasUser',
+    'hasCurrentTermsVersion',
+    'providerId',
+    'durationMs',
+]);
+
+function pickAllowlistedDetail(input: unknown): Record<string, unknown> | null {
+    if (typeof input !== 'object' || input === null) return null;
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(input as Record<string, unknown>)) {
+        if (!DETAIL_KEY_ALLOWLIST.has(k)) continue;
+        // primitive のみ通す。object / array は素通しさせない (誤って大きな payload が
+        // 入ったときに log ノイズ + Cloud Logging 課金になる)。
+        if (v === null || typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean') {
+            out[k] = v;
+        }
+    }
+    return Object.keys(out).length > 0 ? out : null;
+}
+
+interface DiagBody {
+    event?: unknown;
+    ts?: unknown;
+    sessionId?: unknown;
+    detail?: unknown;
+}
+
+router.post('/auth-flow', diagLimiter, diagJsonParser, (req, res) => {
+    const body = (req.body ?? {}) as DiagBody;
+    const event = typeof body.event === 'string' ? body.event : null;
+    const clientTs = typeof body.ts === 'number' && Number.isFinite(body.ts) ? body.ts : null;
+    const sessionId = typeof body.sessionId === 'string' && body.sessionId.length <= 64
+        ? body.sessionId
+        : null;
+    if (!event || !clientTs) {
+        return res.status(400).json({ error: 'invalid body' });
+    }
+    if (event.length > 64) {
+        return res.status(400).json({ error: 'event name too long' });
+    }
+    const detail = pickAllowlistedDetail(body.detail);
+    logger.info({
+        message: 'auth-flow diag event',
+        component: 'diagAuth',
+        event,
+        eventKnown: KNOWN_EVENTS.has(event),
+        sessionId,
+        clientTs,
+        detail,
+        userAgent: req.headers['user-agent'] ?? null,
+        ip: req.ip,
+    });
+    return res.status(204).send();
+});
+
+export default router;

--- a/store/authSlice.ts
+++ b/store/authSlice.ts
@@ -11,6 +11,7 @@ import {
     isKnownAcceptTerms409Code,
     type KnownAcceptTerms409Code,
 } from '../shared/termsCodes';
+import { postAuthDiag } from '../utils/authDiag';
 
 export type AuthStatus = 'initializing' | 'unauthenticated' | 'authenticated';
 
@@ -339,6 +340,10 @@ export const createAuthSlice = (set, get): AuthSlice => ({
         const unsubscribe = onAuthStateChanged(
             auth,
             (user) => {
+                postAuthDiag('auth:state-changed', {
+                    hasUser: !!user,
+                    uid: user?.uid,
+                });
                 set({
                     currentUser: toCurrentUser(user),
                     authStatus: user ? 'authenticated' : 'unauthenticated',
@@ -368,6 +373,9 @@ export const createAuthSlice = (set, get): AuthSlice => ({
                 })();
             },
             (error) => {
+                const code = (error as { code?: string }).code;
+                const errMsg = error instanceof Error ? error.message : String(error);
+                postAuthDiag('auth:state-error', { code, message: errMsg });
                 console.error('onAuthStateChanged error:', error);
                 const message = reportAuthError(get, '認証状態の取得に失敗しました', error);
                 set({ currentUser: null, authStatus: 'unauthenticated', authError: message });
@@ -377,23 +385,42 @@ export const createAuthSlice = (set, get): AuthSlice => ({
     },
 
     signInWithGoogle: async () => {
+        const startTs = Date.now();
+        postAuthDiag('signin:start');
         try {
             set({ authError: null });
             const provider = new GoogleAuthProvider();
             const result = await signInWithPopup(auth, provider);
+            postAuthDiag('signin:popup-resolve', {
+                uid: result.user.uid,
+                providerId: result.providerId ?? undefined,
+                durationMs: Date.now() - startTs,
+            });
             // currentUser update flows through onAuthStateChanged listener.
 
             // Server-side transaction creates/refreshes users/{uid} metadata
             // and preserves createdAt across re-logins. transient (503) は
             // needsUserInit=true で残し、AI 呼出時に retry させる。permanent
             // (4xx) はトーストのみで残す（再 init しても直らないため）。
+            postAuthDiag('signin:users-init-start', { uid: result.user.uid });
             try {
                 const termsState = await callUsersInit(result.user);
+                postAuthDiag('signin:users-init-success', {
+                    uid: result.user.uid,
+                    hasCurrentTermsVersion: !!termsState?.currentTermsVersion,
+                });
                 set({ needsUserInit: false });
                 if (termsState) {
                     applyTermsState(set, termsState);
                 }
             } catch (initError: unknown) {
+                const status = isUserInitError(initError) ? initError.status : undefined;
+                const errMsg = initError instanceof Error ? initError.message : String(initError);
+                postAuthDiag('signin:users-init-error', {
+                    uid: result.user.uid,
+                    status,
+                    message: errMsg,
+                });
                 console.error('users/init failed:', initError);
                 reportAuthError(get, 'ユーザー初期化に失敗しました', initError);
                 // type guard 経由で UserInitError の status を読む。foreign error
@@ -404,10 +431,16 @@ export const createAuthSlice = (set, get): AuthSlice => ({
                 }
             }
         } catch (error: unknown) {
+            const code = (error as { code?: string }).code;
+            const errMsg = error instanceof Error ? error.message : String(error);
+            postAuthDiag('signin:popup-reject', {
+                code,
+                message: errMsg,
+                durationMs: Date.now() - startTs,
+            });
             // User-intent cancels (closed popup, double-clicked sign-in) are
             // not errors — silence them so the toast stays for actual problems
             // (network failure, popup blocker, provider config).
-            const code = (error as { code?: string }).code;
             if (code === 'auth/popup-closed-by-user' || code === 'auth/cancelled-popup-request') {
                 return;
             }

--- a/utils/authDiag.ts
+++ b/utils/authDiag.ts
@@ -1,0 +1,69 @@
+// FE 側の認証フロー診断ログ helper (M7-α 後 / login 障害切り分け用)。
+//
+// signInWithPopup → users/init → onAuthStateChanged の各段階で fire-and-forget
+// で BE の /api/diag/auth-flow に POST する。BE 側で構造化ログとして Cloud Logging
+// に集約され、AI / 運用者がブラウザ console を介さず直接読める。
+//
+// 規律:
+// - **fire-and-forget**: 失敗を sign-in フローの邪魔にしない (catch で握りつぶす)。
+// - **PII 規律**: detail に email / displayName / token を入れない。uid のみ可。
+// - **同期 send (sendBeacon 不使用)**: sendBeacon は即時送信されるが先頭で失敗を
+//   検知できないため、本診断目的では fetch + keepalive を採用。
+// - **撤去条件**: 障害切り分け完了後にこのファイル + 呼出箇所を削除する PR。
+
+const DIAG_ENDPOINT = '/api/diag/auth-flow';
+
+// ブラウザタブ単位の ephemeral session id。複数イベントを横断 grep で
+// 1 ログイン試行に correlate するための識別子。値は uid と無関係 (PII でない)。
+const sessionId: string = (() => {
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+        return crypto.randomUUID();
+    }
+    return `s-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+})();
+
+// detail に許可する key (BE 側 allowlist と揃える)。誤って token / email を渡すのを
+// 型レベルで弾く。
+export interface AuthDiagDetail {
+    uid?: string;
+    code?: string;
+    message?: string;
+    status?: number;
+    hasUser?: boolean;
+    hasCurrentTermsVersion?: boolean;
+    providerId?: string;
+    durationMs?: number;
+}
+
+export type AuthDiagEvent =
+    | 'signin:start'
+    | 'signin:popup-resolve'
+    | 'signin:popup-reject'
+    | 'signin:users-init-start'
+    | 'signin:users-init-success'
+    | 'signin:users-init-error'
+    | 'auth:state-changed'
+    | 'auth:state-error';
+
+export function postAuthDiag(event: AuthDiagEvent, detail?: AuthDiagDetail): void {
+    const body = JSON.stringify({
+        event,
+        ts: Date.now(),
+        sessionId,
+        detail: detail ?? null,
+    });
+    try {
+        // keepalive: ページ遷移 / popup close 直後でも送信を完走させる。
+        // 失敗 (rate limit 429 / network) は握りつぶして sign-in 本体を妨害しない。
+        void fetch(DIAG_ENDPOINT, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body,
+            keepalive: true,
+        }).catch(() => {
+            // intentionally swallow
+        });
+    } catch {
+        // intentionally swallow (keepalive 非対応 / fetch 未定義環境等)
+    }
+}


### PR DESCRIPTION
## Summary
- 本番ログイン障害 (signInWithPopup popup 完了後 UI 不変) の切り分けが、ブラウザ console / network ペースト依存で時間がかかる。
- BE 側に `POST /api/diag/auth-flow` (no-auth, rate-limited, 1KB cap, allowlist filtering) を追加し、FE 側で signInWithGoogle / onAuthStateChanged の各段階から fire-and-forget で送信させる。
- これにより AI / 運用者が Cloud Logging で `jsonPayload.component="diagAuth"` を grep するだけで各段階のタイムスタンプ + uid + status + error code が読める状態にする。

## 規律
- **PII**: email / displayName / token は記録しない (FE 型レベル + BE allowlist の二重防衛)
- **DoS 抑止**: 120 req/min/IP rate limit + 1KB body cap + 64 char event 名 cap
- **撤去条件**: 障害切り分け完了後に削除 PR を出す (本 PR の逆向け)

## 追加 / 変更ファイル
- `server/routes/diag.ts` (新規, 108 lines)
- `server/index.ts` (+4 lines: import + mount)
- `utils/authDiag.ts` (新規, 69 lines)
- `store/authSlice.ts` (+34 lines: 各段階で postAuthDiag 呼出)

## Test plan
- [x] `npm run lint` (tsc --noEmit) → 0 エラー
- [x] `npm run test` (vitest run) → 435 / 435 PASS
- [ ] マージ後 Cloud Run デプロイ反映 → ユーザー再ログイン
- [ ] Cloud Logging で `jsonPayload.component="diagAuth"` を grep して各イベントのタイムスタンプ + 中継状態を AI が直接読み取り、停留段階を特定
- [ ] 切り分け完了次第、削除 PR を提出

🤖 Generated with [Claude Code](https://claude.com/claude-code)