### PR TITLE
fix(coop): allow popups so Firebase Auth signInWithPopup can postMessage back

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -79,6 +79,14 @@ async function startServer() {
                 },
             },
         crossOriginEmbedderPolicy: false,
+        // Firebase Auth signInWithPopup は popup → 親への window.opener 経由で
+        // 認証結果を postMessage する。helmet のデフォルト 'same-origin' は
+        // cross-origin popup から window.opener 参照を遮断するため、popup が
+        // 認証完了しても親が結果を受け取れず Firebase が auth/popup-closed-by-user と
+        // 誤検知する (PR #89 の diag log で 10 秒タイムアウト + reject を観測)。
+        // 'same-origin-allow-popups' は **自分が開いた popup** とのみ通信を許可し、
+        // 自分を開いた他オリジンとは引き続き隔離する (XS-Leaks の主要保護を維持)。
+        crossOriginOpenerPolicy: { policy: 'same-origin-allow-popups' },
     }));
 
     // Same-origin requests (Origin host === request host) are always allowed:


### PR DESCRIPTION
## Summary
- 本番ログインで signInWithPopup が `auth/popup-closed-by-user` で reject 続けていた根本原因が判明。helmet のデフォルト Cross-Origin-Opener-Policy `same-origin` が、popup (firebaseapp.com の auth handler) → 親 window への `window.opener` 参照を遮断 → 認証結果の postMessage を親が受け取れず Firebase が popup の手動 close と誤検知。
- COOP を `same-origin-allow-popups` に変更し、自分が開いた popup との通信のみ許可する (XS-Leaks の主要保護は維持)。

## Evidence (from PR #89 diag log)

```
2026-05-09T13:07:00 signin:start
2026-05-09T13:07:11 signin:popup-reject  code=auth/popup-closed-by-user durationMs=10201
```

10 秒のタイムアウト後に Firebase が popup を closed と判定 → `/api/users/init` へ到達せず → ログイン UI 不変。

## Root cause
- helmet 既定 COOP = `same-origin` は cross-origin popup から `window.opener` を `null` 化する。
- Firebase Auth は popup の `window.opener.postMessage` で認証結果を返すため、`window.opener` が null だと結果を伝えられず popup が空白のまま自動 close される。
- Firebase 側はこの状態を popup-closed-by-user として扱い reject。

## Fix
`server/index.ts` の helmet 設定に `crossOriginOpenerPolicy: { policy: 'same-origin-allow-popups' }` を追加 (1 ファイル / +8 行)。

## Test plan
- [x] `npm run lint` → 0 エラー
- [x] `npm run test` → 435 / 435 PASS
- [ ] マージ後 Cloud Run デプロイ反映 → ユーザー再ログイン
- [ ] diag log で `signin:popup-resolve` → `signin:users-init-success` を観測 (現状: popup-reject 止まり)
- [ ] 切り分け完了後に PR #89 の診断ログを撤去 PR で reverse する

🤖 Generated with [Claude Code](https://claude.com/claude-code)