### PR TITLE
fix(mobile): ボタンの縦書き化を防ぐ (whitespace-nowrap + flex-shrink-0)

### DIFF
--- a/components/BackupWarningBanner.tsx
+++ b/components/BackupWarningBanner.tsx
@@ -27,7 +27,7 @@ export const BackupWarningBanner: React.FC = () => {
                 type="button"
                 onClick={() => openModal('exportEncrypt')}
                 disabled={isExporting}
-                className="flex items-center gap-1 rounded bg-yellow-600 px-3 py-1 text-xs font-semibold text-white transition hover:bg-yellow-500 disabled:opacity-50 btn-pressable"
+                className="flex flex-shrink-0 items-center gap-1 whitespace-nowrap rounded bg-yellow-600 px-3 py-1 text-xs font-semibold text-white transition hover:bg-yellow-500 disabled:opacity-50 btn-pressable"
             >
                 <Icons.DownloadIcon className="h-3 w-3" />
                 {isExporting ? 'エクスポート中…' : '今すぐエクスポート'}

--- a/components/ProjectSelectionScreen.tsx
+++ b/components/ProjectSelectionScreen.tsx
@@ -46,7 +46,7 @@ export function ProjectSelectionScreen({ projects, onCreateProject, onDeleteProj
                 <div className="bg-gray-800/50 p-6 rounded-lg shadow-lg mb-8">
                     <div className="flex justify-between items-center mb-4">
                         <h2 className="text-xl font-semibold">新しい物語を始める</h2>
-                        <button onClick={() => importInputRef.current.click()} className="flex items-center px-4 py-2 text-sm rounded-md btn-pressable btn-invert-green"><Icons.DownloadIcon />プロジェクトをインポート</button>
+                        <button onClick={() => importInputRef.current.click()} className="flex flex-shrink-0 items-center whitespace-nowrap px-4 py-2 text-sm rounded-md btn-pressable btn-invert-green"><Icons.DownloadIcon />プロジェクトをインポート</button>
                         <input type="file" ref={importInputRef} onChange={onImportProject} accept=".json" className="hidden"/>
                     </div>
                     <form onSubmit={handleCreate}>
@@ -70,7 +70,7 @@ export function ProjectSelectionScreen({ projects, onCreateProject, onDeleteProj
                                 </label>
                                 <input id="new-project-name" type="text" value={newProjectName} onChange={(e) => setNewProjectName(e.target.value)} placeholder="タイトル..." className="w-full bg-gray-900 border border-gray-600 rounded-md px-4 py-2 text-sm"/>
                             </div>
-                            <button type="submit" className="px-6 py-2 h-[42px] rounded-md font-semibold disabled:bg-gray-500 btn-pressable btn-invert-indigo" disabled={!newProjectName.trim()}>作成</button>
+                            <button type="submit" className="flex-shrink-0 whitespace-nowrap px-6 py-2 h-[42px] rounded-md font-semibold disabled:bg-gray-500 btn-pressable btn-invert-indigo" disabled={!newProjectName.trim()}>作成</button>
                         </div>
                     </form>
                 </div>


### PR DESCRIPTION
## Summary
- 375px 幅で ProjectSelectionScreen の「作成」「プロジェクトをインポート」、BackupWarningBanner の「今すぐエクスポート」ボタンが flex-shrink され、文字が縦書き化 (例: 「作」「成」が縦並び) する問題を修正。
- 3 ボタンに `whitespace-nowrap flex-shrink-0` を追加。

## Visual evidence (修正前 — 375px)

mobile-375-home.png スクショ:
- 警告バナー右端「今すぐエクスポート」: 「今」「す」「ぐ」「エ」… が縦並び
- 「プロジェクトをインポート」: 折り返し
- 「作成」: 「作」「成」が縦並び

(Playwright で再撮影してマージ後の本番で確認予定)

## 修正対象ファイル
- `components/BackupWarningBanner.tsx` (1 行)
- `components/ProjectSelectionScreen.tsx` (2 行)

## Test plan
- [x] `npm run lint` → 0 エラー
- [x] `npm run test` → 434 / 434 PASS
- [ ] マージ後デプロイ反映 → Playwright で 375 / 768 / 1440px の 3 サイズで再撮影してボタンが横書きになっていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)