### PR TITLE
fix(layout): isMobile 閾値を 1280/1340 に引き上げ (PR #94 fixup)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -89,17 +89,21 @@ export default function App() {
     const isSwapped = displaySettings?.swapSidebars ?? false;
 
     // Mobile Detection with Threshold Stability
-    // 1024px 未満は AppMobile レイアウト (1 panel) にフォールバック。3 panel の
-    // ActivityBar + LeftPanel + Main + RightPanel は最小幅 ~1024px ないと Main が
-    // ほぼ zero-width に潰れるため、タブレット (iPad portrait 768 / 古い iPad 1024)
-    // も mobile レイアウトに倒す。1024 ↔ 1100 の 76px ヒステリシスで境界の chatter を防ぐ。
+    // 1280px 未満は AppMobile レイアウト (1 panel) にフォールバック。3 panel
+    // (ActivityBar 56 + LeftPanel ~280 + Main 必要 400+ + RightPanel ~400) の合計が
+    // ~1136px、padding/gap 込みで実用には ~1280px が必要。1024 で試した結果、
+    // Main editor が 150px 程度に潰れて backup banner が縦書き化する致命的な崩れが
+    // 確認できたため (PR #94 で 1024/1100 に上げたが不十分だった)。
+    // タブレット (iPad portrait 810 / iPad Air landscape 1180 / iPad Pro 13-inch portrait 1024)
+    // は全て mobile 倒し、13-inch ノート PC (MacBook Air 1280x800) からデスクトップ。
+    // 1280 ↔ 1340 の 60px ヒステリシスで境界の chatter を防ぐ。
     const [isMobile, setIsMobile] = useState(false);
     useEffect(() => {
         const checkMobile = () => {
             const width = window.innerWidth;
             setIsMobile(prev => {
-                if (prev) return width < 1100; // mobile 維持 (上端): 1100px 未満は mobile
-                return width < 1024; // mobile 切替 (下端): 1024px 未満は mobile
+                if (prev) return width < 1340; // mobile 維持 (上端): 1340px 未満は mobile
+                return width < 1280; // mobile 切替 (下端): 1280px 未満は mobile
             });
         };
         checkMobile();


### PR DESCRIPTION
## Summary
- PR #94 で 768/800 → 1024/1100 に閾値を上げたが、1024px でも 3 panel layout が破綻する (Main editor が ~150px に圧縮、backup banner が縦書き化) ことを Playwright 検証で確認。
- 閾値をさらに 1280/1340 に引き上げ、タブレット〜13-inch ノート PC の境界を mobile レイアウトに倒す。

## Visual evidence (PR #94 マージ後の 1024px)
- ActivityBar (56px) + LeftPanel (~280px) + RightPanel (~400px) で Main editor の取り分が ~150px しかない
- backup banner 「バ/ッ/ク/ア/ッ/プ/未/取/得」が縦並び
- Header 操作 icon が画面外 overflow

## 設計根拠 (実用最小幅)
| 要素 | 幅 |
|---|---|
| ActivityBar | 56 |
| LeftPanel default | ~280 |
| Main editor 必要 | 400+ |
| RightPanel default | ~400 |
| **合計** | **~1136 + padding/gap = ~1280** |

## Fix
`App.tsx` の閾値を 1024/1100 → 1280/1340 に変更 (1 ファイル / +10/-6)。

## 影響範囲
- iPad portrait 810 / iPad Pro 13-inch portrait 1024 / iPad Air landscape 1180 → 全て mobile
- MacBook Air 13-inch (1280x800 デフォルト) → desktop (3 panel) で問題なく表示
- Full HD 1920+ デスクトップ → 影響なし

## Test plan
- [x] `npm run lint` → 0 エラー
- [x] `npm run test` → 434 / 434 PASS
- [ ] マージ後デプロイ反映 → Playwright で 1279 (mobile) / 1280 (desktop) / 1339 (mobile 維持) / 1340 (desktop) の 4 ポイントで切替確認
- [ ] 1280 desktop で 3 panel が破綻なく収まることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)