### PR TITLE
fix(header): hide-on-small breakpoint を 1200 → 1400 に引き上げ

### DIFF
--- a/index.css
+++ b/index.css
@@ -457,7 +457,12 @@ kbd {
 .btn-invert-orange { background-color: #ea580c; color: white; }
 .btn-invert-orange:hover { background-color: white; color: #ea580c; }
 
-@media (max-width: 1200px) {
+/* Header の検索/表示/モード toggle のテキストラベルを viewport 幅で抑制する。
+   3 panel layout (ActivityBar 56 + LeftPanel 280 + Main + RightPanel 400 ≈ 1280) で
+   Main column 内 Header の右側群 (検索/表示/モード/AuthButton/RightSidebar toggle) が
+   AuthButton (アバター + email 最大 218px) を含むと、1280-1400 viewport で overflow し
+   AuthButton が見切れるため。1400+ では label 表示でも余裕がある。 */
+@media (max-width: 1400px) {
   .hide-on-small {
     display: none;
   }


### PR DESCRIPTION
## Summary
- ログイン状態の workspace を 1280 viewport で確認したところ、Header に AuthButton (アバター + email 最大 218px) が追加され、検索/表示/モード button の label と合わせて overflow → AuthButton が見切れる問題を確認。
- `index.css` の `.hide-on-small` の breakpoint を `max-width: 1200px` → `max-width: 1400px` に引き上げ、1280-1400 viewport では label を非表示にして AuthButton 表示の space を確保。

## Visual evidence (Playwright + ユーザー実機ログイン)

- 1440 viewport: 検索/表示/シンプルモードへ + アバター + email すべて表示 ✅
- 1280 viewport: 検索/表示/シンプルモード**へ** で右端切れ、AuthButton (アバター + email) **不可視** ❌

## Fix
`index.css` の `.hide-on-small` を `max-width: 1400px` に変更 (1 ファイル / +6/-1)。

## 影響範囲
| Viewport | Before | After |
|---|---|---|
| ≤1200 | label hidden, icon のみ | 変化なし |
| 1201-1400 | label 表示 (overflow リスク) | label hidden, icon のみ |
| ≥1401 | label 表示 | 変化なし |

icon のみでもクリック動作・Tooltip 表示は維持されるため UX 劣化は最小。

## Test plan
- [x] `npm run lint` → 0 エラー
- [x] `npm run test` → 434 / 434 PASS
- [ ] マージ後デプロイ反映 → Playwright で 1280 ログイン状態で AuthButton (アバター + email) が可視であること確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)