### PR TITLE
fix(editor): H ボタンが選択末尾にも "# " を挿入する不具合を修正 (#98)

### DIFF
--- a/components/EditableParagraph.tsx
+++ b/components/EditableParagraph.tsx
@@ -174,7 +174,7 @@ export const EditableParagraph: React.FC<EditableParagraphProps> = React.memo(({
             switch (e.key) {
                 case 'b': e.preventDefault(); applyMarkdown('**'); break;
                 case 'u': e.preventDefault(); applyMarkdown('__'); break;
-                case 'h': e.preventDefault(); applyMarkdown('# '); break;
+                case 'h': e.preventDefault(); applyMarkdown('# ', ''); break;
                 case 'r': e.preventDefault(); applyMarkdown('{', '|ふりがな}'); break;
                 case 'c': if(e.shiftKey) { e.preventDefault(); applyMarkdown(`<c:${brushColor}>`, '</c>', 'テキスト', true); } break;
                 default: break;
@@ -234,7 +234,7 @@ export const EditableParagraph: React.FC<EditableParagraphProps> = React.memo(({
                                 <button onMouseDown={preventFocusLoss} onClick={() => applyMarkdown('__')} className="p-1.5 text-gray-300 hover:text-white hover:bg-gray-600 rounded transition-colors"><Icons.UnderlineIcon className="h-4 w-4" /></button>
                             </Tooltip>
                             <Tooltip helpId="heading">
-                                <button onMouseDown={preventFocusLoss} onClick={() => applyMarkdown('# ')} className="p-1.5 text-gray-300 hover:text-white hover:bg-gray-600 rounded transition-colors"><Icons.TypeIcon className="h-4 w-4" /></button>
+                                <button onMouseDown={preventFocusLoss} onClick={() => applyMarkdown('# ', '')} className="p-1.5 text-gray-300 hover:text-white hover:bg-gray-600 rounded transition-colors"><Icons.TypeIcon className="h-4 w-4" /></button>
                             </Tooltip>
                             <Tooltip helpId="ruby">
                                 <button onMouseDown={preventFocusLoss} onClick={() => applyMarkdown('{', '|ふりがな}')} className="p-1.5 text-gray-300 hover:text-white hover:bg-gray-600 rounded font-bold text-xs px-2">ルビ</button>


### PR DESCRIPTION
## Summary

- エディタのツールバー「H」ボタンと `Ctrl/⌘ + H` ショートカットが、選択範囲の両端に `# ` を挿入していた不具合を修正
- `applyMarkdown('# ', '')` で suffix を明示的に空にし、Markdown 見出しの行頭プレフィクス仕様に揃えた
- Closes #98

## 原因

`components/EditableParagraph.tsx:185`
```ts
const applyMarkdown = (prefix: string, suffix: string = prefix, ...)
```

`suffix` のデフォルトが `prefix` と同一。これは `**bold**` / `__underline__` / `{ruby|ふりがな}` のような両端挟み型には正しいが、見出し記号 `#` は行頭プレフィクスのため不適。結果として `# {選択}# ` が挿入され、レンダリング後に右端 `#` が残っていた（出力例: 「適当にテキスト#」）。

## 変更内容

- `components/EditableParagraph.tsx:177` (Ctrl/⌘ + H): `applyMarkdown('# ')` → `applyMarkdown('# ', '')`
- `components/EditableParagraph.tsx:237` (ツールバー H ボタン): `applyMarkdown('# ')` → `applyMarkdown('# ', '')`

## Test plan

- [x] `npm run lint` (tsc --noEmit) PASS
- [x] `npm run test` 434/434 PASS（既存テスト全て regression なし）
- [x] Playwright 実機検証: 全選択 + `Ctrl+H` → textarea 内が `# 適当にテキスト` になり、右端 `# ` なし
- [x] Playwright 実機検証: 選択なし + ツールバー H ボタン → `<text># テキスト` (placeholder 挿入、右端 `# ` なし)
- [x] B / U / ルビ / カラー ボタンの挙動に影響なし（既存テスト + ロジック不変）
- [ ] マージ後、Cloud Run 本番で再確認（既知の dev portal チェックリスト経路）

## 関連

- Issue: #98
- 規模: 2 行修正、影響範囲: `components/EditableParagraph.tsx` のみ

🤖 Generated with [Claude Code](https://claude.com/claude-code)