### PR TITLE
fix(editor): applyMarkdown placeholder/race fix (closes #102)

### DIFF
--- a/components/EditableParagraph.tsx
+++ b/components/EditableParagraph.tsx
@@ -7,6 +7,7 @@ import { renderMarkdown } from '../utils/sanitizeHtml';
 import * as Icons from '../icons';
 import { useStore } from '../store/index';
 import { Tooltip } from './Tooltip';
+import { applyMarkdown as applyMarkdownPure } from './applyMarkdown';
 
 // 執筆の世界観に合うプリセットカラー
 const PRESET_COLORS = [
@@ -176,42 +177,46 @@ export const EditableParagraph: React.FC<EditableParagraphProps> = React.memo(({
                 case 'u': e.preventDefault(); applyMarkdown('__'); break;
                 case 'h': e.preventDefault(); applyMarkdown('# ', ''); break;
                 case 'r': e.preventDefault(); applyMarkdown('{', '|ふりがな}'); break;
-                case 'c': if(e.shiftKey) { e.preventDefault(); applyMarkdown(`<c:${brushColor}>`, '</c>', 'テキスト', true); } break;
+                case 'c': if(e.shiftKey) { e.preventDefault(); applyMarkdown(`<c:${brushColor}>`, '</c>', { placeholder: 'テキスト', shouldClearSelection: true }); } break;
                 default: break;
             }
         }
     };
     
-    const applyMarkdown = (prefix: string, suffix: string = prefix, placeholder: string = 'テキスト', shouldClearSelection: boolean = false) => {
+    const applyMarkdown = (
+        prefix: string,
+        suffix: string = prefix,
+        options: { placeholder?: string; shouldClearSelection?: boolean } = {}
+    ) => {
         if (!textareaRef.current) return;
-        
-        // Refから保存済みの選択範囲を取得
-        const { start, end } = selectionRef.current;
-        
+
+        // Read selection directly from the textarea to avoid stale `selectionRef`
+        // when keyboard shortcuts fire before `onSelect` has propagated (issue #102).
+        const selectionStart = textareaRef.current.selectionStart;
+        const selectionEnd = textareaRef.current.selectionEnd;
+
         setEditText(prev => {
-            const selectedText = prev.substring(start, end);
-            const newText = selectedText || placeholder;
-            const replacement = `${prefix}${newText}${suffix}`;
-            const newEditText = prev.substring(0, start) + replacement + prev.substring(end);
-            
-            // ステート反映後のカーソル制御
+            const result = applyMarkdownPure({
+                text: prev,
+                selectionStart,
+                selectionEnd,
+                prefix,
+                suffix,
+                placeholder: options.placeholder,
+                shouldClearSelection: options.shouldClearSelection,
+            });
+
             setTimeout(() => {
                 if (!textareaRef.current) return;
                 textareaRef.current.focus({ preventScroll: true });
-                
-                if (shouldClearSelection) {
-                    const newPos = start + replacement.length;
-                    textareaRef.current.setSelectionRange(newPos, newPos);
+                textareaRef.current.setSelectionRange(result.newSelectionStart, result.newSelectionEnd);
+                if (options.shouldClearSelection) {
                     window.getSelection()?.removeAllRanges();
-                } else if (selectedText) {
-                    textareaRef.current.setSelectionRange(start + prefix.length, end + prefix.length);
-                } else {
-                    textareaRef.current.setSelectionRange(start + prefix.length, start + prefix.length + placeholder.length);
                 }
                 syncSelection();
             }, 0);
 
-            return newEditText;
+            return result.newText;
         });
     };
 
@@ -249,9 +254,9 @@ export const EditableParagraph: React.FC<EditableParagraphProps> = React.memo(({
                                         <button 
                                             onMouseDown={preventFocusLoss}
                                             onClick={() => {
-                                                applyMarkdown(`<c:${brushColor}>`, '</c>', 'テキスト', true);
+                                                applyMarkdown(`<c:${brushColor}>`, '</c>', { placeholder: 'テキスト', shouldClearSelection: true });
                                                 setIsApplyPulseActive(false);
-                                            }} 
+                                            }}
                                             className={`p-1.5 rounded hover:bg-gray-600 transition-all duration-300 flex items-center justify-center ${isApplyPulseActive ? 'animate-pulse-prompt' : ''}`}
                                             style={{ color: brushColor }}
                                         >
@@ -294,7 +299,7 @@ export const EditableParagraph: React.FC<EditableParagraphProps> = React.memo(({
                                                     onMouseDown={preventFocusLoss}
                                                     onClick={() => {
                                                         setBrushColor(color);
-                                                        applyMarkdown(`<c:${color}>`, '</c>', 'テキスト', true);
+                                                        applyMarkdown(`<c:${color}>`, '</c>', { placeholder: 'テキスト', shouldClearSelection: true });
                                                         setIsColorPaletteOpen(false);
                                                         setIsApplyPulseActive(false);
                                                     }}
@@ -315,7 +320,7 @@ export const EditableParagraph: React.FC<EditableParagraphProps> = React.memo(({
                                                         onMouseDown={preventFocusLoss}
                                                         onClick={() => {
                                                             setBrushColor(char.themeColor!);
-                                                            applyMarkdown(`<c:${char.themeColor}>`, '</c>', 'テキスト', true);
+                                                            applyMarkdown(`<c:${char.themeColor}>`, '</c>', { placeholder: 'テキスト', shouldClearSelection: true });
                                                             setIsColorPaletteOpen(false);
                                                             setIsApplyPulseActive(false);
                                                         }}

--- a/components/EditableParagraph.tsx
+++ b/components/EditableParagraph.tsx
@@ -43,7 +43,9 @@ export const EditableParagraph: React.FC<EditableParagraphProps> = React.memo(({
     const textareaRef = useRef<HTMLTextAreaElement>(null);
     const wrapperRef = useRef<HTMLDivElement>(null);
 
-    // 選択範囲を保持するためのRef
+    // Cached textarea selection updated by `syncSelection` on focus/select/keyup/mouseup/change.
+    // `applyMarkdown` reads selection directly from `textareaRef` (race fix, PR #108) and does
+    // not depend on this ref; kept here so future imperative reads have a single accessor.
     const selectionRef = useRef({ start: 0, end: 0 });
 
     const aiSettings = useStore(state => state.allProjectsData[state.activeProjectId]?.aiSettings);
@@ -209,10 +211,14 @@ export const EditableParagraph: React.FC<EditableParagraphProps> = React.memo(({
             setTimeout(() => {
                 if (!textareaRef.current) return;
                 textareaRef.current.focus({ preventScroll: true });
-                textareaRef.current.setSelectionRange(result.newSelectionStart, result.newSelectionEnd);
+                // Clear the document selection BEFORE applying the textarea selection.
+                // Some browsers tie textarea selection to window.getSelection(); calling
+                // removeAllRanges() after setSelectionRange() resets the cursor to [0, 0]
+                // (Codex review on PR #108).
                 if (options.shouldClearSelection) {
                     window.getSelection()?.removeAllRanges();
                 }
+                textareaRef.current.setSelectionRange(result.newSelectionStart, result.newSelectionEnd);
                 syncSelection();
             }, 0);
 

--- a/components/applyMarkdown.test.ts
+++ b/components/applyMarkdown.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest';
+import { applyMarkdown } from './applyMarkdown';
+
+describe('applyMarkdown — no selection (collapsed cursor)', () => {
+  it('B with no selection inserts **** and places cursor between markers', () => {
+    const r = applyMarkdown({ text: 'hello', selectionStart: 5, selectionEnd: 5, prefix: '**' });
+    expect(r.newText).toBe('hello****');
+    expect(r.newSelectionStart).toBe(7);
+    expect(r.newSelectionEnd).toBe(7);
+  });
+
+  it('U with no selection inserts ____ and places cursor between markers', () => {
+    const r = applyMarkdown({ text: '', selectionStart: 0, selectionEnd: 0, prefix: '__' });
+    expect(r.newText).toBe('____');
+    expect(r.newSelectionStart).toBe(2);
+    expect(r.newSelectionEnd).toBe(2);
+  });
+
+  it('H with no selection inserts "# " and places cursor after the marker', () => {
+    const r = applyMarkdown({ text: 'foo', selectionStart: 0, selectionEnd: 0, prefix: '# ', suffix: '' });
+    expect(r.newText).toBe('# foo');
+    expect(r.newSelectionStart).toBe(2);
+    expect(r.newSelectionEnd).toBe(2);
+  });
+
+  it('R (ruby) with no selection inserts {|ふりがな} and places cursor after {', () => {
+    const r = applyMarkdown({ text: '', selectionStart: 0, selectionEnd: 0, prefix: '{', suffix: '|ふりがな}' });
+    expect(r.newText).toBe('{|ふりがな}');
+    expect(r.newSelectionStart).toBe(1);
+    expect(r.newSelectionEnd).toBe(1);
+  });
+});
+
+describe('applyMarkdown — with selection (wrap, preserve inner)', () => {
+  it('B with a range selection wraps and keeps the inner text selected', () => {
+    const r = applyMarkdown({ text: 'hello world', selectionStart: 6, selectionEnd: 11, prefix: '**' });
+    expect(r.newText).toBe('hello **world**');
+    expect(r.newSelectionStart).toBe(8);
+    expect(r.newSelectionEnd).toBe(13);
+  });
+
+  it('B with full-text selection does not inject placeholder (regression for issue #102)', () => {
+    const r = applyMarkdown({ text: 'あいうえお', selectionStart: 0, selectionEnd: 5, prefix: '**' });
+    expect(r.newText).toBe('**あいうえお**');
+    expect(r.newSelectionStart).toBe(2);
+    expect(r.newSelectionEnd).toBe(7);
+  });
+
+  it('H with a selection prepends "# " and keeps the inner selection', () => {
+    const r = applyMarkdown({ text: 'foo', selectionStart: 0, selectionEnd: 3, prefix: '# ', suffix: '' });
+    expect(r.newText).toBe('# foo');
+    expect(r.newSelectionStart).toBe(2);
+    expect(r.newSelectionEnd).toBe(5);
+  });
+
+  it('R with a selection wraps the kanji with ruby brackets', () => {
+    const r = applyMarkdown({ text: '漢字テスト', selectionStart: 0, selectionEnd: 2, prefix: '{', suffix: '|ふりがな}' });
+    expect(r.newText).toBe('{漢字|ふりがな}テスト');
+    expect(r.newSelectionStart).toBe(1);
+    expect(r.newSelectionEnd).toBe(3);
+  });
+
+  it('normalizes reversed selectionStart > selectionEnd inputs', () => {
+    const r = applyMarkdown({ text: 'abc', selectionStart: 3, selectionEnd: 0, prefix: '**' });
+    expect(r.newText).toBe('**abc**');
+    expect(r.newSelectionStart).toBe(2);
+    expect(r.newSelectionEnd).toBe(5);
+  });
+});
+
+describe('applyMarkdown — color tag (opt-in placeholder)', () => {
+  const COLOR_PREFIX = '<c:#ef4444>';
+  const COLOR_SUFFIX = '</c>';
+
+  it('color with no selection inserts placeholder and collapses cursor to the end', () => {
+    const r = applyMarkdown({
+      text: '',
+      selectionStart: 0,
+      selectionEnd: 0,
+      prefix: COLOR_PREFIX,
+      suffix: COLOR_SUFFIX,
+      placeholder: 'テキスト',
+      shouldClearSelection: true,
+    });
+    expect(r.newText).toBe('<c:#ef4444>テキスト</c>');
+    expect(r.newSelectionStart).toBe(r.newText.length);
+    expect(r.newSelectionEnd).toBe(r.newText.length);
+  });
+
+  it('color with selection wraps and collapses cursor to the end', () => {
+    const r = applyMarkdown({
+      text: 'hello',
+      selectionStart: 0,
+      selectionEnd: 5,
+      prefix: COLOR_PREFIX,
+      suffix: COLOR_SUFFIX,
+      placeholder: 'テキスト',
+      shouldClearSelection: true,
+    });
+    expect(r.newText).toBe('<c:#ef4444>hello</c>');
+    expect(r.newSelectionStart).toBe(r.newText.length);
+    expect(r.newSelectionEnd).toBe(r.newText.length);
+  });
+
+  it('placeholder without shouldClearSelection pre-selects the placeholder for overwrite', () => {
+    const r = applyMarkdown({
+      text: 'a',
+      selectionStart: 1,
+      selectionEnd: 1,
+      prefix: '[',
+      suffix: ']',
+      placeholder: 'X',
+    });
+    expect(r.newText).toBe('a[X]');
+    expect(r.newSelectionStart).toBe(2);
+    expect(r.newSelectionEnd).toBe(3);
+  });
+});
+
+describe('applyMarkdown — boundary conditions', () => {
+  it('empty text + collapsed selection at 0 inserts at the start', () => {
+    const r = applyMarkdown({ text: '', selectionStart: 0, selectionEnd: 0, prefix: '**' });
+    expect(r.newText).toBe('****');
+    expect(r.newSelectionStart).toBe(2);
+    expect(r.newSelectionEnd).toBe(2);
+  });
+
+  it('selection at the very end of text inserts at the tail', () => {
+    const r = applyMarkdown({ text: 'abc', selectionStart: 3, selectionEnd: 3, prefix: '**' });
+    expect(r.newText).toBe('abc****');
+    expect(r.newSelectionStart).toBe(5);
+    expect(r.newSelectionEnd).toBe(5);
+  });
+
+  it('multi-byte (Japanese) selection wraps correctly', () => {
+    const r = applyMarkdown({ text: '日本語テスト', selectionStart: 0, selectionEnd: 3, prefix: '__' });
+    expect(r.newText).toBe('__日本語__テスト');
+    expect(r.newSelectionStart).toBe(2);
+    expect(r.newSelectionEnd).toBe(5);
+  });
+});

--- a/components/applyMarkdown.ts
+++ b/components/applyMarkdown.ts
@@ -1,0 +1,69 @@
+// Pure markdown-application helper extracted from EditableParagraph.
+//
+// Default behaviour (no `placeholder`): when there is no selection, insert just
+// `${prefix}${suffix}` and place a collapsed cursor between them. When there is
+// a selection, wrap it (`${prefix}${selected}${suffix}`) and keep the inner
+// text selected for further typing.
+//
+// `placeholder` is opt-in (color tag legacy): when supplied AND there is no
+// selection, the placeholder text is inserted between prefix/suffix and either
+// pre-selected for overwrite (default) or replaced by a collapsed cursor at the
+// end of the replacement (when `shouldClearSelection` is true).
+
+export interface ApplyMarkdownInput {
+  text: string;
+  selectionStart: number;
+  selectionEnd: number;
+  prefix: string;
+  suffix?: string;
+  placeholder?: string;
+  shouldClearSelection?: boolean;
+}
+
+export interface ApplyMarkdownResult {
+  newText: string;
+  newSelectionStart: number;
+  newSelectionEnd: number;
+}
+
+export function applyMarkdown(input: ApplyMarkdownInput): ApplyMarkdownResult {
+  const {
+    text,
+    selectionStart,
+    selectionEnd,
+    prefix,
+    suffix = prefix,
+    placeholder,
+    shouldClearSelection = false,
+  } = input;
+
+  const start = Math.min(selectionStart, selectionEnd);
+  const end = Math.max(selectionStart, selectionEnd);
+  const hasSelection = end > start;
+  const selectedText = text.substring(start, end);
+
+  const inner = hasSelection ? selectedText : (placeholder ?? '');
+  const replacement = `${prefix}${inner}${suffix}`;
+  const newText = text.substring(0, start) + replacement + text.substring(end);
+
+  let newSelectionStart: number;
+  let newSelectionEnd: number;
+
+  if (shouldClearSelection) {
+    const cursor = start + replacement.length;
+    newSelectionStart = cursor;
+    newSelectionEnd = cursor;
+  } else if (hasSelection) {
+    newSelectionStart = start + prefix.length;
+    newSelectionEnd = newSelectionStart + selectedText.length;
+  } else if (placeholder) {
+    newSelectionStart = start + prefix.length;
+    newSelectionEnd = newSelectionStart + placeholder.length;
+  } else {
+    const cursor = start + prefix.length;
+    newSelectionStart = cursor;
+    newSelectionEnd = cursor;
+  }
+
+  return { newText, newSelectionStart, newSelectionEnd };
+}


### PR DESCRIPTION
## Summary

- 選択なし時の \`テキスト\` placeholder 注入を撤去し、B/U/H/R では prefix と suffix の間に collapsed cursor を置くデフォルト挙動に変更
- Color tag (Ctrl+Shift+C) のみ opt-in で placeholder + shouldClearSelection を継続 (#101 と整合)
- selectionRef stale read race を解消 (textarea から selectionStart/End を直読み)

Closes #102

## 変更内容

| ファイル | 変更 |
|---------|------|
| \`components/applyMarkdown.ts\` (新規) | Pure helper — 副作用なしの replacement / selection 計算ロジックを分離 |
| \`components/applyMarkdown.test.ts\` (新規) | 15 unit tests (no-selection / wrap / color opt-in / boundary / multi-byte) |
| \`components/EditableParagraph.tsx\` | applyMarkdown を pure helper 呼び出しにリファクタ、signature を options object 化、textarea 直読みで race fix |

### 新 signature

\`\`\`ts
applyMarkdown(
  prefix: string,
  suffix: string = prefix,
  options: { placeholder?: string; shouldClearSelection?: boolean } = {}
)
\`\`\`

- B/U/H/R: \`applyMarkdown('**')\` / \`applyMarkdown('# ', '')\` / \`applyMarkdown('{', '|ふりがな}')\` — 第三引数なし、placeholder 不要
- Color: \`applyMarkdown(\`<c:\${brushColor}>\`, '</c>', { placeholder: 'テキスト', shouldClearSelection: true })\` — 4 箇所更新済 (keydown + 3 palette button)

### Race fix

旧実装は \`selectionRef.current\` を読んでいたが、\`onSelect\` / \`syncSelection\` の伝播タイミングによって stale な値が残るケースがあった (#102 仮説 c)。新実装は \`textareaRef.current.selectionStart/End\` を直読みすることで最新の selection state を保証する。

## Test plan

- [x] 単体 test 15 ケース PASS (\`npm run test components/applyMarkdown.test.ts\` → 15/15 PASS)
- [x] \`npm run lint\` PASS (tsc 0 errors)
- [x] \`npm run test\` 全 460/460 PASS (445 baseline + 15 new)
- [x] Playwright 動作確認 (dev server localhost:3100):
  - [x] Scenario 1: \`適当にテキスト\` cursor=末尾 + Ctrl+B → \`適当にテキスト****\`, cursor=[9,9] ✓
  - [x] Scenario 2: \`あいうえお\` 全選択 + Ctrl+B → \`**あいうえお**\`, sel=[2,7] (placeholder 混入なし、issue #102 の regression test) ✓
  - [x] Scenario 3: 空 textarea + Ctrl+Shift+C → \`<c:#ef4444>テキスト</c>\` (color 経路の placeholder 維持) ✓
  - [x] Scenario 4: \`foo\` cursor=0 + Ctrl+H → \`# foo\`, cursor=[2,2] (suffix='' special case) ✓
- [x] color path Tooltip placeholder 維持 (Issue #101 で別判断)

## 関連 Issue

- Closes #102
- 関連: Issue #101 (Ctrl+Shift+C 重複) — 本 PR では color path を維持し、後続 PR で撤去判断

🤖 Generated with [Claude Code](https://claude.com/claude-code)