### PR TITLE
fix(shortcuts): resolve key collisions + add static conflict pin (closes #101)

### DIFF
--- a/components/EditableParagraph.tsx
+++ b/components/EditableParagraph.tsx
@@ -175,11 +175,13 @@ export const EditableParagraph: React.FC<EditableParagraphProps> = React.memo(({
         if (e.key === 'Escape') { e.preventDefault(); handleCancel(); }
         if ((e.ctrlKey || e.metaKey)) {
             switch (e.key) {
+                // Editor shortcut keys must NOT collide with global keybindings (hooks/useKeybindings.ts)
+                // or browser-reserved keys. See issue #101 for the audit.
+                // - Ctrl+R (ruby) was dropped: collided with browser Reload. Use the toolbar ルビ button.
+                // - Ctrl+Shift+C (color) was dropped: collided with global Ctrl+Shift+C (相関図). Use the palette button.
                 case 'b': e.preventDefault(); applyMarkdown('**'); break;
                 case 'u': e.preventDefault(); applyMarkdown('__'); break;
                 case 'h': e.preventDefault(); applyMarkdown('# ', ''); break;
-                case 'r': e.preventDefault(); applyMarkdown('{', '|ふりがな}'); break;
-                case 'c': if(e.shiftKey) { e.preventDefault(); applyMarkdown(`<c:${brushColor}>`, '</c>', { placeholder: 'テキスト', shouldClearSelection: true }); } break;
                 default: break;
             }
         }

--- a/helpTexts.ts
+++ b/helpTexts.ts
@@ -39,13 +39,13 @@ export const helpTexts: Record<string, Record<UserMode, HelpContent>> = {
     },
     ruby: {
         simple: { title: 'ふりがな', desc: '漢字の上に読みがなをつけます。' },
-        standard: { title: 'ルビを振る', desc: '選択範囲にふりがなを設定。', shortcut: 'R' },
-        pro: { title: 'ルビ構文の挿入', desc: '{漢字|よみ} 形式を挿入。', shortcut: 'R', tech: 'ruby要素として描画' }
+        standard: { title: 'ルビを振る', desc: '選択範囲にふりがなを設定。' },
+        pro: { title: 'ルビ構文の挿入', desc: '{漢字|よみ} 形式を挿入。', tech: 'ruby要素として描画' }
     },
     palette: {
         simple: { title: '色をぬる', desc: '文字に色をつけます。' },
-        standard: { title: '文字色を適用', desc: '選んでいるブラシの色で塗ります。', shortcut: 'Shift+C' },
-        pro: { title: 'カラータグの挿入', desc: '独自拡張タグ (<c:#hex>) を挿入。', shortcut: 'Shift+C', tech: 'Inline Style Injection' }
+        standard: { title: '文字色を適用', desc: '選んでいるブラシの色で塗ります。' },
+        pro: { title: 'カラータグの挿入', desc: '独自拡張タグ (<c:#hex>) を挿入。', tech: 'Inline Style Injection' }
     },
     palette_select: {
         simple: { title: '色をえらぶ', desc: 'ぬる色を変えます。' },
@@ -199,8 +199,8 @@ export const helpTexts: Record<string, Record<UserMode, HelpContent>> = {
     },
     plot_plus: {
         simple: { title: 'プロット追加', desc: '話を足します。' },
-        standard: { title: '新規カード作成', desc: 'プロットを追加。', shortcut: 'Shift+P' },
-        pro: { title: 'New Plot Card', desc: 'Ctrl+Shift+P', shortcut: 'Shift+P' }
+        standard: { title: '新規カード作成', desc: 'プロットを追加。', shortcut: 'Shift+L' },
+        pro: { title: 'New Plot Card', desc: 'Ctrl+Shift+L (storyLine)', shortcut: 'Shift+L' }
     },
     plotBoard: {
         simple: { title: 'プロットボードの使い方', desc: '物語の構成をカードで整理する方法です。' },

--- a/hooks/useKeybindings.ts
+++ b/hooks/useKeybindings.ts
@@ -106,7 +106,9 @@ export const useKeybindings = ({
                             e.preventDefault();
                             openModal('timeline');
                             break;
-                        case 'p':
+                        case 'l':
+                             // Ctrl+Shift+L (storyLine = plot) — moved off Ctrl+Shift+P
+                             // to avoid colliding with browser Print (issue #101).
                              e.preventDefault();
                              openModal('plot');
                              break;

--- a/tests/static/shortcut-conflicts.test.ts
+++ b/tests/static/shortcut-conflicts.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// Static-grep regression test for Issue #101.
+// Pins the *set* of shortcut keys handled in two independent places:
+//   1. Global keybindings (`hooks/useKeybindings.ts`) — fires when no inline editor
+//      is focused, mounted on `window.keydown`.
+//   2. Inline editor shortcuts (`components/EditableParagraph.tsx`) — fires only
+//      while a paragraph textarea is being edited.
+//
+// Both layers must NOT bind the same physical key combination, since global
+// listeners still receive the event during textarea editing (`isInputFocused`
+// is checked only on a subset of branches). The original collision (Ctrl+Shift+C
+// firing both "文字色" and "相関図") is the motivation.
+
+const ROOT = resolve(__dirname, '..', '..');
+
+const readSrc = (rel: string): string => readFileSync(resolve(ROOT, rel), 'utf-8');
+
+// --- Global keybindings (Ctrl/Cmd + ...) ---
+// Each entry is "modifier-keychord -> meaning".
+interface KeyBinding {
+    chord: string;
+    source: 'global' | 'editor';
+    purpose: string;
+}
+
+const GLOBAL_SHORTCUTS: KeyBinding[] = [
+    // Direct (no shift/alt) — non-shifted alphabetic ctrl/cmd
+    { chord: 'Ctrl+Z', source: 'global', purpose: 'undo' },
+    { chord: 'Ctrl+Shift+Z', source: 'global', purpose: 'redo' },
+    { chord: 'Ctrl+Y', source: 'global', purpose: 'redo' },
+    { chord: 'Ctrl+F', source: 'global', purpose: 'globalSearch' },
+    { chord: 'Ctrl+K', source: 'global', purpose: 'commandPalette' },
+    { chord: 'Ctrl+S', source: 'global', purpose: 'modalSave' },
+    { chord: 'Ctrl+Alt+S', source: 'global', purpose: 'aiSettings' },
+    { chord: 'Ctrl+Shift+M', source: 'global', purpose: 'toggleGenerationMode' },
+    { chord: 'Ctrl+Shift+C', source: 'global', purpose: 'characterChart' },
+    { chord: 'Ctrl+Shift+T', source: 'global', purpose: 'timeline' },
+    { chord: 'Ctrl+Shift+L', source: 'global', purpose: 'plot' },
+    { chord: 'Ctrl+Shift+G', source: 'global', purpose: 'nameGenerator' },
+    { chord: 'Ctrl+Shift+K', source: 'global', purpose: 'knowledgeBase' },
+    { chord: 'Ctrl+Alt+I', source: 'global', purpose: 'toggleNewChunkInput' },
+    { chord: 'Ctrl+Alt+C', source: 'global', purpose: 'newCharacter' },
+    { chord: 'Ctrl+Alt+W', source: 'global', purpose: 'newWorld' },
+    { chord: 'Ctrl+Alt+K', source: 'global', purpose: 'newKnowledge' },
+    { chord: 'Ctrl+Alt+A', source: 'global', purpose: 'importText' },
+    { chord: 'Ctrl+[', source: 'global', purpose: 'toggleLeftSidebar' },
+    { chord: 'Ctrl+]', source: 'global', purpose: 'toggleRightSidebar' },
+    { chord: 'Ctrl+/', source: 'global', purpose: 'focusAiInput' },
+];
+
+// --- Editor shortcuts (inside `<textarea aria-label="本文段落の編集">`) ---
+const EDITOR_SHORTCUTS: KeyBinding[] = [
+    { chord: 'Ctrl+Enter', source: 'editor', purpose: 'saveEdit' },
+    { chord: 'Ctrl+B', source: 'editor', purpose: 'bold' },
+    { chord: 'Ctrl+U', source: 'editor', purpose: 'underline' },
+    { chord: 'Ctrl+H', source: 'editor', purpose: 'heading' },
+];
+
+describe('shortcut-conflicts — Issue #101 regression', () => {
+    it('no chord is shared between global and editor handlers', () => {
+        const globalChords = new Set(GLOBAL_SHORTCUTS.map(s => s.chord));
+        const collisions = EDITOR_SHORTCUTS.filter(s => globalChords.has(s.chord));
+        expect(collisions).toEqual([]);
+    });
+
+    it('hooks/useKeybindings.ts does not bind Ctrl+Shift+P (browser Print conflict)', () => {
+        const src = readSrc('hooks/useKeybindings.ts');
+        // Search inside the e.shiftKey branch for `case 'p':`. The plot shortcut
+        // was moved to Ctrl+Shift+L.
+        // Allow the literal 'p' to appear elsewhere (e.g. in regex / strings),
+        // but `case 'p':` followed by openModal('plot') would be a regression.
+        const shiftBranchMatch = src.match(/if \(e\.shiftKey\)[\s\S]*?\n {16}\}/);
+        expect(shiftBranchMatch).not.toBeNull();
+        expect(shiftBranchMatch![0]).not.toMatch(/case 'p':[\s\S]*?openModal\('plot'\)/);
+        expect(shiftBranchMatch![0]).toMatch(/case 'l':[\s\S]*?openModal\('plot'\)/);
+    });
+
+    it('components/EditableParagraph.tsx does not bind Ctrl+R (browser Reload conflict)', () => {
+        const src = readSrc('components/EditableParagraph.tsx');
+        // The ruby shortcut was dropped; toolbar button still works.
+        const switchMatch = src.match(/switch \(e\.key\) \{[\s\S]*?\n {12}\}/);
+        expect(switchMatch).not.toBeNull();
+        expect(switchMatch![0]).not.toMatch(/case 'r':/);
+    });
+
+    it('components/EditableParagraph.tsx does not bind Ctrl+Shift+C (global Character chart conflict)', () => {
+        const src = readSrc('components/EditableParagraph.tsx');
+        const switchMatch = src.match(/switch \(e\.key\) \{[\s\S]*?\n {12}\}/);
+        expect(switchMatch).not.toBeNull();
+        expect(switchMatch![0]).not.toMatch(/case 'c':/);
+    });
+});


### PR DESCRIPTION
## Summary

Issue #101 のショートカット重複監査結果に基づき HIGH と MEDIUM を解消し、静的 regression pin を追加。

- **HIGH**: \`Ctrl/⌘+Shift+C\` (文字色 vs 相関図) → EditableParagraph の \`case 'c'\` を撤去。color は palette ボタン経由のみで操作可能 (機能消失なし)
- **MEDIUM**: \`Ctrl/⌘+Shift+P\` (Browser Print 奪う) → \`Ctrl/⌘+Shift+L\` (storyLine) に変更
- **MEDIUM**: \`Ctrl/⌘+R\` (Browser Reload 奪う) → 撤去 (ルビは toolbar ボタンのみ)
- **regression pin**: \`tests/static/shortcut-conflicts.test.ts\` で global / editor の chord 衝突 + 撤去 / 移動済キーバインドを静的 grep で固定

Closes #101

## 変更内容

| ファイル | 変更 |
|---------|------|
| \`components/EditableParagraph.tsx\` | \`case 'c'\` (color) と \`case 'r'\` (ruby) を撤去 + 経緯コメント追加 |
| \`hooks/useKeybindings.ts\` | \`case 'p'\` (plot) → \`case 'l'\` に変更 + 経緯コメント追加 |
| \`helpTexts.ts\` | tooltip の \`shortcut: 'Shift+C'\` (palette) と \`shortcut: 'R'\` (ruby) を撤去、plot_plus を Shift+L に同期 |
| \`tests/static/shortcut-conflicts.test.ts\` (新規) | 4 test cases (global×editor 衝突なし / Ctrl+Shift+P 未バインド / Ctrl+R 未バインド / Ctrl+Shift+C エディタ側未バインド) |

## scope 外 (別 PR / 別 Issue で対応)

- Issue #101 修正案 D: ヘルプモーダル / Tooltip にショートカット一覧表 + Tooltip 文字列の SSOT 化 (\`hooks/useShortcutLabels.ts\` 等で一元化)

## Test plan

- [x] 静的 conflict test 4 ケース PASS
- [x] \`npm run lint\` PASS (tsc 0 errors)
- [x] \`npm run test\` 全 468/468 PASS (464 baseline + 4 new)
- [x] Playwright 動作確認 (dev server localhost:3100):
  - [x] Top page で \`Ctrl+Shift+C\` 押下 → キャラクター相関図 modal が開く ✓
  - [x] Top page で \`Ctrl+Shift+L\` 押下 → プロットボード modal が開く ✓
  - [x] エディタ編集中 \`Ctrl+Shift+C\` 押下 → textarea 値不変 (color 挿入なし) + 相関図 modal が開く ✓ (重複完全解消)
  - [x] エディタ編集中 \`Ctrl+B\` 押下 → \`****\` 挿入 cursor 中央 ✓ (regression なし)

## 関連

- Closes #101
- 後続予定: 修正案 D (Tooltip SSOT) を別 Issue 起票候補

🤖 Generated with [Claude Code](https://claude.com/claude-code)