### PR TITLE
feat(backup): relocate data-management to ProjectSelectionScreen + add subset scope (closes #104)

### DIFF
--- a/components/ProjectSelectionScreen.tsx
+++ b/components/ProjectSelectionScreen.tsx
@@ -2,6 +2,9 @@ import React, { useState, useRef } from 'react';
 import * as Icons from '../icons';
 import { Project } from '../types';
 import { AuthButton } from './AuthButton';
+import { useStore } from '../store/index';
+import { STALE_BACKUP_DAYS, formatLastExportedAt } from '../utils/backupFormat';
+import { readFileAsText } from '../utils/readFileAsText';
 
 interface ProjectSelectionScreenProps {
     projects: Project[];
@@ -17,6 +20,33 @@ export function ProjectSelectionScreen({ projects, onCreateProject, onDeleteProj
     const [deletingProjectId, setDeletingProjectId] = useState<string | null>(null);
     const importInputRef = useRef(null);
     const handleCreate = (e) => { e.preventDefault(); if (!newProjectName.trim()) return; onCreateProject(newProjectName, newProjectMode); setNewProjectName(''); };
+
+    // Issue #104: データ管理セクション (全データバックアップを SettingsPanel から移設)。
+    const openModal = useStore(state => state.openModal);
+    const lastExportedAt = useStore(state => state.lastExportedAt);
+    const isStale = useStore(state => state.isBackupStale());
+    const isExporting = useStore(state => state.isExporting);
+    const prepareImport = useStore(state => state.prepareImport);
+    const showToast = useStore(state => state.showToast);
+    const backupImportInputRef = useRef<HTMLInputElement>(null);
+
+    const handleBackupImportFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
+        const file = e.target.files?.[0];
+        e.target.value = '';
+        if (!file) return;
+        try {
+            const raw = await readFileAsText(file);
+            const result = await prepareImport(raw);
+            // 暗号化 envelope の場合は pendingDecryption が ModalManager 経由で自動 mount。
+            // 平文はここで ImportConflictModal を開く。
+            if (result.kind === 'plaintext') {
+                openModal('importConflict');
+            }
+        } catch (err: unknown) {
+            const msg = err instanceof Error ? err.message : 'インポートの準備に失敗しました';
+            showToast(msg, 'error');
+        }
+    };
     return (
         <div className="min-h-screen bg-gray-900 text-gray-200 flex flex-col items-center justify-start p-4 sm:p-8">
             <div className="w-full max-w-3xl">
@@ -74,6 +104,44 @@ export function ProjectSelectionScreen({ projects, onCreateProject, onDeleteProj
                         </div>
                     </form>
                 </div>
+                <div className="bg-gray-800/50 p-6 rounded-lg shadow-lg mb-8">
+                    <h2 className="text-xl font-semibold mb-2">データ管理</h2>
+                    <p className="text-sm text-gray-400 mb-4">
+                        すべてのプロジェクトを 1 つのファイルにまとめて保存・復元できます。
+                        暗号化エクスポートと復元のどちらもここから操作します。
+                    </p>
+                    <div className={`text-xs mb-3 ${isStale ? 'text-yellow-400' : 'text-gray-400'}`}>
+                        最終バックアップ: {formatLastExportedAt(lastExportedAt)}
+                        {isStale && ` (推奨は ${STALE_BACKUP_DAYS} 日以内)`}
+                    </div>
+                    <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+                        <button
+                            type="button"
+                            onClick={() => openModal('exportEncrypt')}
+                            disabled={isExporting}
+                            className="flex items-center justify-center gap-2 px-4 py-2 text-sm rounded-md btn-pressable bg-emerald-700 text-white hover:bg-emerald-600 disabled:opacity-50"
+                        >
+                            <Icons.DownloadIcon className="h-4 w-4 flex-shrink-0" />
+                            <span>{isExporting ? 'エクスポート中…' : '全データをエクスポート'}</span>
+                        </button>
+                        <button
+                            type="button"
+                            onClick={() => backupImportInputRef.current?.click()}
+                            className="flex items-center justify-center gap-2 px-4 py-2 text-sm rounded-md btn-pressable bg-gray-700 text-gray-200 hover:bg-gray-600"
+                        >
+                            <Icons.UploadIcon className="h-4 w-4 flex-shrink-0" />
+                            <span>バックアップから復元</span>
+                        </button>
+                        <input
+                            type="file"
+                            ref={backupImportInputRef}
+                            onChange={handleBackupImportFile}
+                            accept=".json,application/json"
+                            className="hidden"
+                        />
+                    </div>
+                </div>
+
                 <div className="bg-gray-800/50 p-6 rounded-lg shadow-lg">
                     <h2 className="text-xl font-semibold mb-4">既存の物語</h2>
                     <div className="space-y-3 max-h-60 overflow-y-auto pr-2">

--- a/components/modals/ExportEncryptModal.tsx
+++ b/components/modals/ExportEncryptModal.tsx
@@ -14,11 +14,25 @@ const TIMEOUT_TOAST =
 const isAbortError = (e: unknown): boolean =>
     e instanceof Error && e.name === 'AbortError';
 
+type ExportScope = 'all' | 'active';
+
 export const ExportEncryptModal: React.FC = () => {
     const closeModal = useStore(state => state.closeModal);
     const exportAllData = useStore(state => state.exportAllData);
     const isExporting = useStore(state => state.isExporting);
     const showToast = useStore(state => state.showToast);
+    const activeProjectId = useStore(state => state.activeProjectId);
+    const activeProjectName = useStore(state =>
+        state.activeProjectId
+            ? state.allProjectsData[state.activeProjectId]?.name
+            : undefined,
+    );
+
+    // Issue #104: scope chooser. "active" is only offered when an active
+    // project is loaded — opening from ProjectSelectionScreen pins scope to "all".
+    const canSelectActive = Boolean(activeProjectId);
+    const [scope, setScope] = useState<ExportScope>('all');
+    const effectiveScope: ExportScope = canSelectActive ? scope : 'all';
 
     const [encrypt, setEncrypt] = useState<boolean>(false);
     const [passphrase, setPassphrase] = useState<string>('');
@@ -69,13 +83,17 @@ export const ExportEncryptModal: React.FC = () => {
     const handleSubmit = async (): Promise<void> => {
         if (submitDisabled) return;
 
+        const projectIds = effectiveScope === 'active' && activeProjectId
+            ? [activeProjectId]
+            : undefined;
+
         if (!encrypt) {
             // 平文 export: slice 側で toast + lastExportedAt 更新が走る。throw した場合は
             // slice 側 catch で toast 済 (AbortError は別途 suppress)。modal は throw 有無で
             // 分岐 close する (silent-failure-hunter B3 — closeModal を await 前に呼ぶと
             // unhandled rejection 化するため try/catch で囲む)。
             try {
-                await exportAllData();
+                await exportAllData({ projectIds });
                 closeModal();
             } catch (e) {
                 if (!isAbortError(e)) {
@@ -104,6 +122,7 @@ export const ExportEncryptModal: React.FC = () => {
             await exportAllData({
                 encrypt: { passphrase: usedPassphrase },
                 signal: controller.signal,
+                projectIds,
             });
             // signal.aborted を post-await check (timeout 発火後に slice 内で early return
             // した場合は succeeded=true でも実 download は行われていない)。
@@ -151,14 +170,66 @@ export const ExportEncryptModal: React.FC = () => {
             <div className="w-full max-w-lg rounded-lg bg-gray-800 shadow-xl">
                 <div className="border-b border-gray-700 px-6 py-4">
                     <h2 id="export-encrypt-title" className="text-lg font-semibold text-white">
-                        全データバックアップ
+                        データエクスポート
                     </h2>
                     <p id="export-encrypt-description" className="mt-1 text-sm text-gray-400">
-                        プロジェクト・チュートリアル状態・解析履歴をまとめてエクスポートします。
+                        エクスポート範囲と形式を選んでファイルとして保存します。
                     </p>
                 </div>
 
                 <div className="space-y-4 px-6 py-4">
+                    <fieldset className="space-y-2">
+                        <legend className="text-xs font-semibold uppercase tracking-wide text-gray-400">
+                            エクスポート範囲
+                        </legend>
+                        <label className="flex cursor-pointer items-start gap-3 rounded border border-gray-700 bg-gray-900/40 px-4 py-3 hover:bg-gray-700/30">
+                            <input
+                                type="radio"
+                                name="export-scope"
+                                value="all"
+                                checked={effectiveScope === 'all'}
+                                onChange={() => setScope('all')}
+                                className="mt-0.5"
+                            />
+                            <span className="text-sm">
+                                <span className="block font-semibold text-white">全データ</span>
+                                <span className="block text-xs text-gray-400">
+                                    すべてのプロジェクト + チュートリアル進捗 + 解析履歴。バックアップ用途に推奨。
+                                </span>
+                            </span>
+                        </label>
+                        <label
+                            className={`flex items-start gap-3 rounded border px-4 py-3 ${
+                                canSelectActive
+                                    ? 'cursor-pointer border-gray-700 bg-gray-900/40 hover:bg-gray-700/30'
+                                    : 'cursor-not-allowed border-gray-800 bg-gray-900/20 opacity-50'
+                            }`}
+                        >
+                            <input
+                                type="radio"
+                                name="export-scope"
+                                value="active"
+                                checked={effectiveScope === 'active'}
+                                onChange={() => setScope('active')}
+                                disabled={!canSelectActive}
+                                className="mt-0.5"
+                            />
+                            <span className="text-sm">
+                                <span className="block font-semibold text-white">
+                                    現在のプロジェクトのみ
+                                    {canSelectActive && activeProjectName && (
+                                        <span className="ml-2 text-gray-300">「{activeProjectName}」</span>
+                                    )}
+                                </span>
+                                <span className="block text-xs text-gray-400">
+                                    {canSelectActive
+                                        ? '共有・移行用。チュートリアル進捗と解析履歴は含まれません。'
+                                        : 'プロジェクトを開いてから選択できます。'}
+                                </span>
+                            </span>
+                        </label>
+                    </fieldset>
+
                     <label className="flex cursor-pointer items-start gap-3 rounded border border-gray-700 bg-gray-900/40 px-4 py-3 hover:bg-gray-700/30">
                         <input
                             type="checkbox"

--- a/components/modals/ExportEncryptModal.tsx
+++ b/components/modals/ExportEncryptModal.tsx
@@ -199,6 +199,7 @@ export const ExportEncryptModal: React.FC = () => {
                             </span>
                         </label>
                         <label
+                            aria-disabled={!canSelectActive ? 'true' : undefined}
                             className={`flex items-start gap-3 rounded border px-4 py-3 ${
                                 canSelectActive
                                     ? 'cursor-pointer border-gray-700 bg-gray-900/40 hover:bg-gray-700/30'

--- a/components/panels/SettingsPanel.tsx
+++ b/components/panels/SettingsPanel.tsx
@@ -1,10 +1,8 @@
 
-import React, { useMemo, useRef } from 'react';
+import React, { useMemo } from 'react';
 import * as Icons from '../../icons';
 import { useStore } from '../../store/index';
 import { Tooltip } from '../Tooltip';
-import { STALE_BACKUP_DAYS, formatLastExportedAt } from '../../utils/backupFormat';
-import { readFileAsText } from '../../utils/readFileAsText';
 
 interface SettingsPanelProps {
     onExportProject: () => void;
@@ -14,32 +12,9 @@ interface SettingsPanelProps {
 export const SettingsPanel: React.FC<SettingsPanelProps> = ({ onExportProject, onExportTxt }) => {
     const openModal = useStore(state => state.openModal);
     const userMode = useStore(state => state.userMode);
-    const lastExportedAt = useStore(state => state.lastExportedAt);
-    const isStale = useStore(state => state.isBackupStale());
     const isExporting = useStore(state => state.isExporting);
-    const prepareImport = useStore(state => state.prepareImport);
-    const showToast = useStore(state => state.showToast);
-    const importInputRef = useRef<HTMLInputElement>(null);
 
-    const handleImportFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
-        const file = e.target.files?.[0];
-        e.target.value = '';
-        if (!file) return;
-        try {
-            const raw = await readFileAsText(file);
-            const result = await prepareImport(raw);
-            // 暗号化 envelope の場合は pendingDecryption が set され ImportPassphraseModal が
-            // ModalManager 経由で自動 mount される (state-diagram.md ModalManager 統合節)。
-            // 平文の場合のみ既存の ImportConflictModal を開く。
-            if (result.kind === 'plaintext') {
-                openModal('importConflict');
-            }
-        } catch (err: unknown) {
-            const msg = err instanceof Error ? err.message : 'インポートの準備に失敗しました';
-            showToast(msg, 'error');
-        }
-    };
-    
+
     const tools = useMemo(() => [
         { label: '相関図', icon: <Icons.UserCogIcon />, action: () => openModal('characterChart'), color: 'text-violet-300', helpId: 'chart_open' },
         { label: 'タイムライン', icon: <Icons.ClockIcon />, action: () => openModal('timeline'), color: 'text-orange-300', helpId: 'timeline_open' },
@@ -97,38 +72,22 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({ onExportProject, o
                 </div>
             </div>
 
+            {/* 全データバックアップ section moved to ProjectSelectionScreen "データ管理"
+                (issue #104) — this panel is per-project context, the export is global. */}
             <div>
-                <h3 className="text-sm font-semibold text-gray-400 mb-2">全データバックアップ</h3>
-                <div className={`text-xs mb-2 ${isStale ? 'text-yellow-400' : 'text-gray-400'}`}>
-                    最終バックアップ: {formatLastExportedAt(lastExportedAt)}
-                    {isStale && ` (推奨は${STALE_BACKUP_DAYS}日以内)`}
-                </div>
-                <div className="space-y-2">
-                    <button
-                        type="button"
-                        onClick={() => openModal('exportEncrypt')}
-                        disabled={isExporting}
-                        className="w-full text-sm px-3 py-2 bg-emerald-700 hover:bg-emerald-600 rounded-md transition flex items-center gap-2 btn-pressable text-white disabled:opacity-50"
-                    >
-                        <Icons.DownloadIcon className="h-4 w-4 mr-1 flex-shrink-0" />
-                        <span>{isExporting ? 'エクスポート中…' : '全データをエクスポート'}</span>
-                    </button>
-                    <button
-                        type="button"
-                        onClick={() => importInputRef.current?.click()}
-                        className="w-full text-sm px-3 py-2 bg-gray-700 hover:bg-gray-600 rounded-md transition flex items-center gap-2 btn-pressable text-gray-300"
-                    >
-                        <Icons.UploadIcon className="h-4 w-4 mr-1 flex-shrink-0" />
-                        <span>バックアップから復元</span>
-                    </button>
-                    <input
-                        type="file"
-                        ref={importInputRef}
-                        onChange={handleImportFile}
-                        accept=".json,application/json"
-                        className="hidden"
-                    />
-                </div>
+                <h3 className="text-sm font-semibold text-gray-400 mb-2">バックアップ</h3>
+                <p className="text-xs text-gray-400 mb-2">
+                    現在のプロジェクトまたは全データを暗号化して保存できます。
+                </p>
+                <button
+                    type="button"
+                    onClick={() => openModal('exportEncrypt')}
+                    disabled={isExporting}
+                    className="w-full text-sm px-3 py-2 bg-emerald-700 hover:bg-emerald-600 rounded-md transition flex items-center gap-2 btn-pressable text-white disabled:opacity-50"
+                >
+                    <Icons.DownloadIcon className="h-4 w-4 mr-1 flex-shrink-0" />
+                    <span>{isExporting ? 'エクスポート中…' : 'バックアップを作成'}</span>
+                </button>
             </div>
         </div>
     );

--- a/components/panels/SettingsPanel.tsx
+++ b/components/panels/SettingsPanel.tsx
@@ -1,8 +1,9 @@
 
-import React, { useMemo } from 'react';
+import React, { useMemo, useRef } from 'react';
 import * as Icons from '../../icons';
 import { useStore } from '../../store/index';
 import { Tooltip } from '../Tooltip';
+import { readFileAsText } from '../../utils/readFileAsText';
 
 interface SettingsPanelProps {
     onExportProject: () => void;
@@ -13,6 +14,28 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({ onExportProject, o
     const openModal = useStore(state => state.openModal);
     const userMode = useStore(state => state.userMode);
     const isExporting = useStore(state => state.isExporting);
+    const prepareImport = useStore(state => state.prepareImport);
+    const showToast = useStore(state => state.showToast);
+    const importInputRef = useRef<HTMLInputElement>(null);
+
+    // Issue #104 evaluator MEDIUM: SettingsPanel から「バックアップから復元」が
+    // 消えた regression を解消する。主導線は ProjectSelectionScreen の「データ管理」
+    // に移ったが、編集中にも復元できる安全弁を残す。
+    const handleImportFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
+        const file = e.target.files?.[0];
+        e.target.value = '';
+        if (!file) return;
+        try {
+            const raw = await readFileAsText(file);
+            const result = await prepareImport(raw);
+            if (result.kind === 'plaintext') {
+                openModal('importConflict');
+            }
+        } catch (err: unknown) {
+            const msg = err instanceof Error ? err.message : 'インポートの準備に失敗しました';
+            showToast(msg, 'error');
+        }
+    };
 
 
     const tools = useMemo(() => [
@@ -72,22 +95,39 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({ onExportProject, o
                 </div>
             </div>
 
-            {/* 全データバックアップ section moved to ProjectSelectionScreen "データ管理"
-                (issue #104) — this panel is per-project context, the export is global. */}
+            {/* 全データバックアップ section: 主導線は ProjectSelectionScreen「データ管理」へ
+                移設 (issue #104)。ここではプロジェクト編集中の動線として最小ボタンを残す。 */}
             <div>
                 <h3 className="text-sm font-semibold text-gray-400 mb-2">バックアップ</h3>
                 <p className="text-xs text-gray-400 mb-2">
                     現在のプロジェクトまたは全データを暗号化して保存できます。
                 </p>
-                <button
-                    type="button"
-                    onClick={() => openModal('exportEncrypt')}
-                    disabled={isExporting}
-                    className="w-full text-sm px-3 py-2 bg-emerald-700 hover:bg-emerald-600 rounded-md transition flex items-center gap-2 btn-pressable text-white disabled:opacity-50"
-                >
-                    <Icons.DownloadIcon className="h-4 w-4 mr-1 flex-shrink-0" />
-                    <span>{isExporting ? 'エクスポート中…' : 'バックアップを作成'}</span>
-                </button>
+                <div className="space-y-2">
+                    <button
+                        type="button"
+                        onClick={() => openModal('exportEncrypt')}
+                        disabled={isExporting}
+                        className="w-full text-sm px-3 py-2 bg-emerald-700 hover:bg-emerald-600 rounded-md transition flex items-center gap-2 btn-pressable text-white disabled:opacity-50"
+                    >
+                        <Icons.DownloadIcon className="h-4 w-4 mr-1 flex-shrink-0" />
+                        <span>{isExporting ? 'エクスポート中…' : 'バックアップを作成'}</span>
+                    </button>
+                    <button
+                        type="button"
+                        onClick={() => importInputRef.current?.click()}
+                        className="w-full text-sm px-3 py-2 bg-gray-700 hover:bg-gray-600 rounded-md transition flex items-center gap-2 btn-pressable text-gray-300"
+                    >
+                        <Icons.UploadIcon className="h-4 w-4 mr-1 flex-shrink-0" />
+                        <span>バックアップから復元</span>
+                    </button>
+                    <input
+                        type="file"
+                        ref={importInputRef}
+                        onChange={handleImportFile}
+                        accept=".json,application/json"
+                        className="hidden"
+                    />
+                </div>
             </div>
         </div>
     );

--- a/db/backupRepository.ts
+++ b/db/backupRepository.ts
@@ -45,8 +45,12 @@ export const readSnapshot = async (): Promise<ExportSnapshot> => {
 export interface WriteImportPayload {
     toUpsert: Project[];
     toCreate: Project[];
-    tutorialState: BackupV1['tutorialState'];
-    analysisHistory: BackupV1['analysisHistory'];
+    // Issue #104: subset (per-project) backups intentionally omit these side
+    // stores so that importing a shared/migration file does not wipe the
+    // receiver's tutorial progress or analysis history. Treat both as
+    // optional — when omitted, the existing IndexedDB record is left intact.
+    tutorialState?: BackupV1['tutorialState'];
+    analysisHistory?: BackupV1['analysisHistory'];
 }
 
 // Single Dexie transaction so a partial failure never leaves IndexedDB in a
@@ -59,14 +63,18 @@ export const writeImport = async (payload: WriteImportPayload): Promise<void> =>
         async () => {
             for (const p of payload.toUpsert) await db.projects.put(sanitizeForImport(p));
             for (const p of payload.toCreate) await db.projects.put(sanitizeForImport(p));
-            await db.tutorialState.put({
-                version: TUTORIAL_STATE_VERSION,
-                ...payload.tutorialState,
-            });
-            await db.analysisHistory.put({
-                key: ANALYSIS_HISTORY_KEY,
-                history: payload.analysisHistory,
-            });
+            if (payload.tutorialState !== undefined) {
+                await db.tutorialState.put({
+                    version: TUTORIAL_STATE_VERSION,
+                    ...payload.tutorialState,
+                });
+            }
+            if (payload.analysisHistory !== undefined) {
+                await db.analysisHistory.put({
+                    key: ANALYSIS_HISTORY_KEY,
+                    history: payload.analysisHistory,
+                });
+            }
         },
     );
 };

--- a/store/backupSlice.test.ts
+++ b/store/backupSlice.test.ts
@@ -220,6 +220,39 @@ describe('exportAllData scope (#104)', () => {
         expect(lastCall[1]).toBe('error');
     });
 
+    // Issue #104 evaluator HIGH: a subset backup (empty side stores) must NOT
+    // wipe the receiver's tutorial progress / analysis history on import.
+    // The fix lives in executeImport (`store/backupSlice.ts`), which passes
+    // `undefined` to writeImport for empty side stores. Mirror it with a
+    // regression test that imports a subset-shaped BackupV1 and asserts the
+    // sidecar fields land as `undefined`, so writeImport (real db layer)
+    // skips the destructive put.
+    it('subset import (empty tutorialState + empty analysisHistory): skips both writes (#104 regression)', async () => {
+        readSnapshot.mockResolvedValue({
+            projects: [],
+            tutorialState: { hasCompletedGlobalTutorial: true },
+            analysisHistory: [],
+        });
+        // writeImport is the mock from the outer beforeEach; we just need to
+        // observe what executeImport hands it.
+        (writeImport as any).mockResolvedValue(undefined);
+        const fake = createFakeStore();
+        const raw = JSON.stringify({
+            schemaVersion: 1,
+            exportedAt: '2026-05-17T00:00:00.000Z',
+            appVersion: '0.0.0',
+            projects: [makeProject({ id: 'p-shared', name: '共有プロジェクト' })],
+            tutorialState: {},
+            analysisHistory: [],
+        });
+        await fake.state.prepareImport(raw);
+        await fake.state.executeImport();
+        expect(writeImport).toHaveBeenCalledOnce();
+        const payload = (writeImport as any).mock.calls[0][0];
+        expect(payload.tutorialState).toBeUndefined();
+        expect(payload.analysisHistory).toBeUndefined();
+    });
+
     // Defensive guard: an accidental `projectIds: []` should hit the same
     // empty-subset abort path (the comment in backupSlice.ts mentions this
     // explicitly, so pin it with its own test rather than relying on the
@@ -469,10 +502,13 @@ describe('prepareImport / executeImport (AC-3, AC-5)', () => {
             const payload = writeImport.mock.calls[0][0];
             expect(payload.toUpsert.map((p: Project) => p.id)).toEqual(['p-new']);
             expect(payload.toCreate).toEqual([]);
-            // Non-project sidecar fields must travel atomically with the
-            // project payload (writeImport is the single transaction).
+            // Non-project sidecar fields travel atomically with the project
+            // payload (writeImport is a single transaction). Issue #104 added
+            // a guard: empty side stores are signalled by `undefined` so that
+            // writeImport skips the put — preserving the receiver's existing
+            // tutorial / analysis state when subset backups are imported.
             expect(payload.tutorialState).toEqual({ hasCompletedGlobalTutorial: true });
-            expect(payload.analysisHistory).toEqual([]);
+            expect(payload.analysisHistory).toBeUndefined();
             expect(result).toEqual({ upserted: 1, created: 0, skipped: 1 });
         });
 

--- a/store/backupSlice.test.ts
+++ b/store/backupSlice.test.ts
@@ -219,6 +219,26 @@ describe('exportAllData scope (#104)', () => {
         const lastCall = calls[calls.length - 1];
         expect(lastCall[1]).toBe('error');
     });
+
+    // Defensive guard: an accidental `projectIds: []` should hit the same
+    // empty-subset abort path (the comment in backupSlice.ts mentions this
+    // explicitly, so pin it with its own test rather than relying on the
+    // 'nonexistent' case alone).
+    it('subset scope with empty array: aborts with error toast (no silent empty download)', async () => {
+        readSnapshot.mockResolvedValue({
+            projects: [makeProject({ id: 'p-1' })],
+            tutorialState: {},
+            analysisHistory: [],
+        });
+        const fake = createFakeStore();
+        await fake.state.exportAllData({ projectIds: [] });
+        expect(saveLastExportedAt).not.toHaveBeenCalled();
+        expect(blobParts).toEqual([]);
+        const toast = fake.state.showToast as any;
+        const calls = toast.mock.calls as any[][];
+        const lastCall = calls[calls.length - 1];
+        expect(lastCall[1]).toBe('error');
+    });
 });
 
 describe('prepareImport / executeImport (AC-3, AC-5)', () => {

--- a/store/backupSlice.test.ts
+++ b/store/backupSlice.test.ts
@@ -142,6 +142,85 @@ describe('exportAllData (AC-1, AC-6)', () => {
     });
 });
 
+describe('exportAllData scope (#104)', () => {
+    // Captures the latest Blob payload (the JSON string handed to triggerDownload).
+    let blobParts: any[] = [];
+
+    beforeEach(() => {
+        blobParts = [];
+        (globalThis as any).Blob = class {
+            constructor(parts: any[]) {
+                blobParts = parts;
+            }
+        } as any;
+    });
+
+    const lastBackup = () => JSON.parse(blobParts[0]) as {
+        projects: { id: string }[];
+        tutorialState: Record<string, boolean>;
+        analysisHistory: unknown[];
+    };
+
+    it('full scope (projectIds undefined): includes all projects + tutorialState + analysisHistory', async () => {
+        readSnapshot.mockResolvedValue({
+            projects: [makeProject({ id: 'p-1' }), makeProject({ id: 'p-2' })],
+            tutorialState: { hasCompletedGlobalTutorial: true },
+            analysisHistory: [{ characters: { match: [], similar: [], new: [], extractedDetails: [] }, worldContext: { worldKeywords: [], genre: 'g', tone: 't' }, worldTerms: { match: [], similar: [], new: [] }, dialogues: [], notes: [] }],
+        });
+        const fake = createFakeStore();
+        await fake.state.exportAllData();
+        const b = lastBackup();
+        expect(b.projects.map(p => p.id)).toEqual(['p-1', 'p-2']);
+        expect(b.tutorialState.hasCompletedGlobalTutorial).toBe(true);
+        expect(b.analysisHistory).toHaveLength(1);
+        // Full scope advances the banner timestamp.
+        expect(saveLastExportedAt).toHaveBeenCalledOnce();
+        expect(fake.state.lastExportedAt).toBeTruthy();
+    });
+
+    it('subset scope (projectIds: ["p-2"]): includes only p-2, drops tutorialState + analysisHistory', async () => {
+        readSnapshot.mockResolvedValue({
+            projects: [makeProject({ id: 'p-1' }), makeProject({ id: 'p-2', name: 'Two' })],
+            tutorialState: { hasCompletedGlobalTutorial: true },
+            analysisHistory: [{ characters: { match: [], similar: [], new: [], extractedDetails: [] }, worldContext: { worldKeywords: [], genre: 'g', tone: 't' }, worldTerms: { match: [], similar: [], new: [] }, dialogues: [], notes: [] }],
+        });
+        const fake = createFakeStore();
+        await fake.state.exportAllData({ projectIds: ['p-2'] });
+        const b = lastBackup();
+        expect(b.projects.map(p => p.id)).toEqual(['p-2']);
+        expect(b.tutorialState).toEqual({});
+        expect(b.analysisHistory).toEqual([]);
+    });
+
+    it('subset scope does NOT advance lastExportedAt (banner stays based on full backup)', async () => {
+        readSnapshot.mockResolvedValue({
+            projects: [makeProject({ id: 'p-1' })],
+            tutorialState: {},
+            analysisHistory: [],
+        });
+        const fake = createFakeStore();
+        await fake.state.exportAllData({ projectIds: ['p-1'] });
+        expect(saveLastExportedAt).not.toHaveBeenCalled();
+        expect(fake.state.lastExportedAt).toBeNull();
+    });
+
+    it('subset scope with no matching id: aborts with error toast and no download', async () => {
+        readSnapshot.mockResolvedValue({
+            projects: [makeProject({ id: 'p-1' })],
+            tutorialState: {},
+            analysisHistory: [],
+        });
+        const fake = createFakeStore();
+        await fake.state.exportAllData({ projectIds: ['nonexistent'] });
+        expect(saveLastExportedAt).not.toHaveBeenCalled();
+        expect(blobParts).toEqual([]);
+        const toast = fake.state.showToast as any;
+        const calls = toast.mock.calls as any[][];
+        const lastCall = calls[calls.length - 1];
+        expect(lastCall[1]).toBe('error');
+    });
+});
+
 describe('prepareImport / executeImport (AC-3, AC-5)', () => {
     it('detects conflicts against existing IndexedDB ids', async () => {
         readSnapshot.mockResolvedValue({

--- a/store/backupSlice.ts
+++ b/store/backupSlice.ts
@@ -80,7 +80,15 @@ export interface BackupSlice {
     isImporting: boolean;
 
     initBackupState: () => Promise<void>;
-    exportAllData: (opts?: { encrypt?: { passphrase: string }; signal?: AbortSignal }) => Promise<void>;
+    // `projectIds` (issue #104): when provided, export only the listed projects
+    // and drop `tutorialState` / `analysisHistory` (which are inherently
+    // all-data side stores). When omitted, the export contains the full
+    // snapshot — preserving the M6 PR-D contract.
+    exportAllData: (opts?: {
+        encrypt?: { passphrase: string };
+        signal?: AbortSignal;
+        projectIds?: string[];
+    }) => Promise<void>;
     prepareImport: (raw: string) => Promise<PrepareImportResult>;
     setImportResolution: (incomingId: string, resolution: ImportConflictResolution) => void;
     cancelImport: () => void;
@@ -169,10 +177,30 @@ export const createBackupSlice = (set, get): BackupSlice => ({
         set({ isExporting: true });
         try {
             const snapshot = await readSnapshot();
+
+            // Scope filter (issue #104). When `projectIds` is provided we
+            // export only those projects, and the side stores (tutorial
+            // progress / analysis history) are intentionally NOT included —
+            // both are user-global state that does not belong in a
+            // per-project export. The full-scope path is unchanged.
+            const scope: 'full' | 'subset' = opts?.projectIds ? 'subset' : 'full';
+            const scopedProjects = scope === 'subset'
+                ? snapshot.projects.filter(p => opts!.projectIds!.includes(p.id))
+                : snapshot.projects;
+            // Refuse empty subset early so an accidental `projectIds: []`
+            // does not silently produce a backup with zero projects.
+            if (scope === 'subset' && scopedProjects.length === 0) {
+                (get() as WithToast).showToast?.(
+                    'エクスポート対象のプロジェクトが見つかりませんでした。',
+                    'error',
+                );
+                return;
+            }
+
             const backup: BackupV1 = buildBackupV1({
-                projects: snapshot.projects,
-                tutorialState: snapshot.tutorialState,
-                analysisHistory: snapshot.analysisHistory,
+                projects: scopedProjects,
+                tutorialState: scope === 'full' ? snapshot.tutorialState : {},
+                analysisHistory: scope === 'full' ? snapshot.analysisHistory : [],
                 appVersion: APP_VERSION,
             });
 
@@ -210,12 +238,27 @@ export const createBackupSlice = (set, get): BackupSlice => ({
             // AC-5: 暗号化経路は専用 toast「暗号化バックアップを作成しました」を表示
             // (平文 export と区別、ユーザーに encrypt 成功を伝える)。文言契約は slice 側に
             // 集約 (state-diagram.md エラー文言契約と同じ所在)。
-            const successMsg = encryptOpt
-                ? `暗号化バックアップを作成しました（${count} 件）`
-                : `${count} 件のプロジェクトをエクスポートしました`;
+            // Issue #104: subset scope は別文言。full scope の文言は M6 PR-D contract で
+            // pinned されているため変更しない。
+            let successMsg: string;
+            if (scope === 'subset') {
+                successMsg = encryptOpt
+                    ? `選択したプロジェクトを暗号化してエクスポートしました（${count} 件）`
+                    : `選択したプロジェクトをエクスポートしました（${count} 件）`;
+            } else {
+                successMsg = encryptOpt
+                    ? `暗号化バックアップを作成しました（${count} 件）`
+                    : `${count} 件のプロジェクトをエクスポートしました`;
+            }
             try {
-                await saveLastExportedAt(backup.exportedAt);
-                set({ lastExportedAt: backup.exportedAt, backupMetaStatus: 'loaded' });
+                // `lastExportedAt` represents the most-recent FULL backup. A
+                // subset export does not satisfy the "I have a backup" promise
+                // for the rest of the data, so we deliberately do not move
+                // the banner timestamp forward in that case.
+                if (scope === 'full') {
+                    await saveLastExportedAt(backup.exportedAt);
+                    set({ lastExportedAt: backup.exportedAt, backupMetaStatus: 'loaded' });
+                }
                 (get() as WithToast).showToast?.(successMsg, 'success');
             } catch (e: unknown) {
                 console.error('saveLastExportedAt failed (download succeeded):', e);

--- a/store/backupSlice.ts
+++ b/store/backupSlice.ts
@@ -405,11 +405,21 @@ export const createBackupSlice = (set, get): BackupSlice => ({
                 existingIds,
                 resolutions,
             );
+            // Issue #104: skip overwriting tutorial / analysis state when the
+            // incoming backup carries no entries. This is the import-side
+            // counterpart of the subset export (which writes `{}` / `[]` to
+            // mark the side stores as "not part of this backup"). Without
+            // this guard, a shared per-project file would wipe the receiver's
+            // tutorial progress on import. A full backup with genuinely empty
+            // state imports as a no-op for these stores either way.
+            const hasTutorialKeys = Object.keys(plan.backup.tutorialState).length > 0;
+            const hasAnalysisEntries = plan.backup.analysisHistory.length > 0;
+
             await writeImport({
                 toUpsert,
                 toCreate,
-                tutorialState: plan.backup.tutorialState,
-                analysisHistory: plan.backup.analysisHistory,
+                tutorialState: hasTutorialKeys ? plan.backup.tutorialState : undefined,
+                analysisHistory: hasAnalysisEntries ? plan.backup.analysisHistory : undefined,
             });
 
             // Re-hydrate in-memory state from IndexedDB. Without this,


### PR DESCRIPTION
## Summary

Issue #104 の二重課題 (配置 + 粒度) を 1 PR で解消し、Evaluator 分離プロトコルで検出された HIGH (subset import の tutorial 全消去バグ) と MEDIUM (SettingsPanel 復元 regression / a11y) も同 PR 内で修正。

- **A 配置**: 「全データバックアップ」の主導線を ProjectSelectionScreen の新セクション「データ管理」へ移設。SettingsPanel には編集中の安全弁としてエクスポート + 復元のコンパクトリンクを残置
- **B-1 粒度**: ExportEncryptModal に scope chooser (全データ / 現在のプロジェクトのみ) を追加。activeProjectId なしの起点では「現在のプロジェクトのみ」を disabled + 案内文
- **HIGH 修正**: subset export を import すると受け手の tutorial 進捗が全消去されるバグを修正。executeImport が空 sidecar を \`undefined\` で writeImport に渡し、writeImport は undefined のときは put を skip
- **MEDIUM 修正**: SettingsPanel から「バックアップから復元」が削除されていた regression / scope chooser radio の \`aria-disabled\` 欠落

Closes #104

## 変更内容

| ファイル | 変更 |
|---------|------|
| \`components/ProjectSelectionScreen.tsx\` | 「データ管理」セクション新設 (export + 復元 + last-backup 表示) |
| \`components/modals/ExportEncryptModal.tsx\` | scope chooser radio 追加 + \`aria-disabled\` |
| \`components/panels/SettingsPanel.tsx\` | 全データバックアップを縮小、編集中の export + 復元リンク残置 |
| \`store/backupSlice.ts\` | \`exportAllData(opts.projectIds?)\` 拡張、executeImport で空 sidecar → undefined ガード |
| \`db/backupRepository.ts\` | \`WriteImportPayload.tutorialState\` / \`analysisHistory\` を optional 化、writeImport で undefined skip |
| \`store/backupSlice.test.ts\` | 6 new regression tests (full / subset scope + empty projectIds / subset import safety + skip-resolution sidecar contract update) |

## Test plan

- [x] \`npm run lint\`: tsc 0 errors
- [x] \`npm run test\`: 474/474 PASS (468 baseline + 6 new)
- [x] Playwright 動作確認 (dev server localhost:3100):
  - [x] ProjectSelectionScreen に「データ管理」セクション + last-backup 表示 ✓
  - [x] ProjectSelectionScreen からの modal で「現在のプロジェクトのみ」disabled + 案内文 ✓
  - [x] Banner 経由の modal で「現在のプロジェクトのみ「テスト用」」enabled ✓
  - [x] subset scope 実 download: \`projects.length=1 + tutorialState={} + analysisHistory=[]\` ✓
- [x] Evaluator agent (rules/quality-gate.md): HIGH 1 件 + MEDIUM 2 件を検出 → 同 PR 内ですべて修正

## Evaluator 報告

- **HIGH**: subset import が受け手の tutorial 全消去 → 修正済
- **MEDIUM (1)**: SettingsPanel から復元経路消失 → 復元ボタン残置で修正済
- **MEDIUM (2)**: scope chooser radio に \`aria-disabled\` なし → 追加済
- **LOW** (scope creep のため別 PR 予定): ProjectSelectionScreen の 2 つの file input が混同しやすい (旧来の single-project import と全データ BackupV1 import の accept 属性が同一)

## scope 外

- 複数プロジェクト選択 export (チェックボックス UI) → 別 Issue 候補
- ProjectSelectionScreen の file input 混同問題 → 別 Issue 候補

🤖 Generated with [Claude Code](https://claude.com/claude-code)