### PR TITLE
ui(auth): hide email text from header avatar button (keep in dropdown)

### DIFF
--- a/components/AuthButton.tsx
+++ b/components/AuthButton.tsx
@@ -50,9 +50,11 @@ export const AuthButton: React.FC = () => {
             <button
                 type="button"
                 onClick={() => setIsMenuOpen((p) => !p)}
-                className="flex items-center gap-2 px-2 py-1 rounded-md hover:bg-panel-bg transition btn-pressable"
+                className="flex items-center px-1 py-1 rounded-md hover:bg-panel-bg transition btn-pressable"
                 aria-haspopup="menu"
                 aria-expanded={isMenuOpen}
+                aria-label={`アカウントメニュー (${displayLabel})`}
+                title={displayLabel}
             >
                 {currentUser.photoURL ? (
                     <img
@@ -66,7 +68,6 @@ export const AuthButton: React.FC = () => {
                         {(currentUser.email ?? '?').slice(0, 1).toUpperCase()}
                     </div>
                 )}
-                <span className="text-sm text-text-main truncate max-w-[180px] hidden sm:inline">{displayLabel}</span>
             </button>
             {isMenuOpen && (
                 <div role="menu" className="absolute top-full right-0 mt-2 w-56 bg-panel-bg border border-border rounded-lg shadow-xl z-50 overflow-hidden">


### PR DESCRIPTION
## Summary
- ヘッダー右上のアカウント email 全文表示 (例: `hy.unimail.11@gmail.com`) を非表示化し、アバター画像のみに集約
- email はドロップダウンメニューを開いた時に確認できる (l.73-75 不変)
- ユーザー指示「ここのアカウントのアドレスの表示については、ここまでの全表示は不要」への対応

## Changes
- `components/AuthButton.tsx`:
  - 旧: `<span className="text-sm ... hidden sm:inline">{displayLabel}</span>` (sm 以上で email 全文表示) を削除
  - 新: button に `aria-label="アカウントメニュー (email)"` + `title={displayLabel}` を追加し、accessibility/hover tooltip で email 情報を保持
  - button の `gap-2 px-2` → `px-1` で視覚ノイズも削減 (アバター単独表示に最適化)

## Accessibility
- screen reader: `aria-label` で email 情報は保持 (NVDA / VoiceOver で読み上げ可)
- hover tooltip: `title={displayLabel}` でマウスホバー時に email 確認可能
- ドロップダウンメニュー内 email 表示は不変 (アカウント切替時の確認用)

Mobile (sm 未満) は元々 `hidden sm:inline` で email 非表示だったため UX 不変。

## Diff stats
1 file changed, 3 insertions(+), 2 deletions(-)

## Test plan
- [x] \`npm run lint\` (tsc --noEmit) 0 errors
- [x] \`npm run test\` (vitest) 482 / 482 PASS
- [ ] 本番デプロイ後の実機目視: ヘッダー右上が「シンプルモードへ ボタン + アバター + サイドバー切替」のみになっているか + アバター hover で email tooltip 表示か (ユーザー本人確認)

🤖 Generated with [Claude Code](https://claude.com/claude-code)