### PR TITLE
chore(knowledge): remove auto-seed of help entries on new project

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -10,7 +10,6 @@ import { ModalManager } from './components/ModalManager';
 import { CommandPalette } from './components/CommandPalette';
 import { FloatingWindow } from './components/FloatingWindow';
 import { useStore } from './store/index';
-import { helpTexts } from './helpTexts';
 import { useKeybindings } from './hooks/useKeybindings';
 import { useSidebarResize } from './hooks/useSidebarResize';
 import { ProjectSelectionScreen } from './components/ProjectSelectionScreen';
@@ -138,33 +137,6 @@ export default function App() {
             setIsRightSidebarOpen(true);
         }
     }, [activeProjectId, activeProjectData?.isSimpleMode, setIsRightSidebarOpen]);
-
-    // ヘルプをナレッジベースに自動追加
-    useEffect(() => {
-        if (!activeProjectId || !activeProjectData) return;
-        
-        const { handleSaveSetting } = useStore.getState();
-        const existingKnowledge = activeProjectData.knowledgeBase || [];
-
-        // ヘルプ項目は初回（ナレッジが空の場合）のみ自動追加
-        // 削除後に再追加されるのを防ぐため、1件でも存在すればスキップ
-        if (existingKnowledge.length > 0) return;
-
-        const helpKnowledgeItems = Object.entries(helpTexts).map(([key, modes]) => {
-            const content = Object.entries(modes).map(([mode, content]) => {
-                return `【${mode}モード】\nタイトル: ${content.title}\n説明: ${content.desc}${content.shortcut ? `\nショートカット: ${content.shortcut}` : ''}${content.tech ? `\n技術: ${content.tech}` : ''}\n`;
-            }).join('\n');
-            return {
-                name: `ヘルプ: ${modes.standard.title}`,
-                content: content,
-                isAutoFilled: true
-            };
-        });
-
-        helpKnowledgeItems.forEach(item => {
-            handleSaveSetting(item, 'knowledge');
-        });
-    }, [activeProjectId]);
 
     // Handle knowledge link clicks globally
     useEffect(() => {


### PR DESCRIPTION
## Summary
- 新規プロジェクト作成時に「ヘルプ: テキスト解析」「ヘルプ: 設定に反映」等のナレッジカード約15件を自動投入していた useEffect を削除
- ナレッジベースは初期空になり、ユーザーが 0 から作っていく想定に統一
- ユーザー指示「初期はブランクであってほしい。何も無いところから、ユーザーが０から作っていく想定です」への対応

## Changes
- `App.tsx`:
  - `import { helpTexts } from './helpTexts';` 削除 (App.tsx 内では本 useEffect のみで使用していた)
  - 旧 l.142-167 のヘルプ自動追加 useEffect 全体を削除 (`existingKnowledge.length === 0` 時のみ発火していたガード付き処理)

## 既存プロジェクトへの影響
- 旧 useEffect は `existingKnowledge.length > 0` で skip していたため、既にヘルプを持つ既存プロジェクトには元々再投入していなかった
- 今回の削除でも既存ナレッジは一切変更されない (**migration 不要・破壊なし**)
- 既存プロジェクトでヘルプを消したい場合は、これまで通り手動でゴミ箱アイコンから削除可能

## helpTexts 本体は保持
`helpTexts` 自体は `components/Tooltip.tsx` で UI tooltip 用に使われているため import 維持。今回の削除は「ナレッジベースへの自動投入」だけを止める。

## Diff stats
1 file changed, 28 deletions(-)

## Test plan
- [x] \`npm run lint\` (tsc --noEmit) 0 errors
- [x] \`npm run test\` (vitest) 482 / 482 PASS
- [ ] 本番デプロイ後の実機目視: 新規プロジェクト作成 → ナレッジベース が空であること、既存プロジェクトでヘルプエントリが消えていないこと (ユーザー本人確認)

🤖 Generated with [Claude Code](https://claude.com/claude-code)