### PR TITLE
ui(tooltip): fall back pro mode to standard tooltip (novelist-friendly text)

### DIFF
--- a/components/Tooltip.tsx
+++ b/components/Tooltip.tsx
@@ -19,7 +19,8 @@ export const Tooltip: React.FC<TooltipProps> = ({ helpId, children, placement = 
     const isMac = useMemo(() => navigator.platform.toUpperCase().indexOf('MAC') >= 0, []);
     const modifier = isMac ? '⌘' : 'Ctrl';
 
-    const data = helpTexts[helpId]?.[userMode];
+    // pro モードは standard モードの tooltip にフォールバック (小説家向け表記で統一)
+    const data = helpTexts[helpId]?.[userMode === 'pro' ? 'standard' : userMode];
 
     // クリーンアップ処理
     useEffect(() => {


### PR DESCRIPTION
## Summary
- 「プロモード」選択時の tooltip が英語タイトル + tech フィールド (engineer 寄り表記) になっていた問題を修正
- pro モードでも標準モードと同じ日本語ベースの tooltip を表示するよう `Tooltip` コンポーネントでフォールバック
- ユーザー指示「プロモードに書いてあるツールチップの内容が小説家のためではなく、エンジニアのためのものになっているのは意図していない」「標準モード側に統一」への対応

## Changes
- `components/Tooltip.tsx` l.22:
  - 旧: \`helpTexts[helpId]?.[userMode]\`
  - 新: \`helpTexts[helpId]?.[userMode === 'pro' ? 'standard' : userMode]\`

## 例: 「相関図」 tooltip
| モード | 旧 | 新 |
|---|---|---|
| simple | (変更なし) | (変更なし) |
| standard | (変更なし) | (変更なし) |
| **pro** | "Relation Chart" / "Ctrl+Shift+C" / dev: なし | "相関図を表示" / ⌘+Shift+C / "人物の関係を可視化。" (standard と完全一致) |

## 設計判断
- `helpTexts.ts` の pro エントリ自体は **温存** (可逆)。将来 pro モード固有の小説家向け表記が必要になった場合、本フォールバック行を外せば復活する
- pro データの一括削除は型定義変更が広範囲に及ぶため見送り (UserMode 型 / helpTexts Record / 既存 Settings UI 等)
- 変更コスト 1 行 vs データ削除 数十行 + 型変更で、最小変更原則に従い前者を採用

## Diff stats
1 file changed, 2 insertions(+), 1 deletion(-)

## Test plan
- [x] \`npm run lint\` (tsc --noEmit) 0 errors
- [x] \`npm run test\` (vitest) 482 / 482 PASS
- [ ] 本番デプロイ後の実機目視: ユーザーモード設定 → プロモード選択 → 任意の機能 (相関図/ナレッジ等) tooltip が日本語表記になっているか (ユーザー本人確認)

🤖 Generated with [Claude Code](https://claude.com/claude-code)