### PR TITLE
fix(chart): 相関図ドラッグ中に関係線・矢印が遅延追従する問題を修正

### DIFF
--- a/components/CharacterChart.tsx
+++ b/components/CharacterChart.tsx
@@ -296,7 +296,7 @@ export const CharacterChartModal = ({ isOpen, onClose, characters, relations, no
                                 return (
                                     <g key={`${getRelId(rel)}-${i}`} className="cursor-pointer group" onClick={handleClick}>
                                         <path d={path} stroke="transparent" strokeWidth="25" fill="none" />
-                                        <path d={path} stroke={color} strokeWidth={mode === 'delete_relation' ? "4" : "2"} fill="none" markerEnd={`url(#arrow-${rel.id})`} className="transition-all duration-200 group-hover:stroke-white" />
+                                        <path d={path} stroke={color} strokeWidth={mode === 'delete_relation' ? "4" : "2"} fill="none" markerEnd={`url(#arrow-${rel.id})`} className="transition-[stroke] duration-200 group-hover:stroke-white" />
                                         <rect x={cx-25} y={cy-10} width="50" height="20" fill="#1f2937" rx="4" className="stroke-gray-600 border" />
                                         <text x={cx} y={cy} fill="white" fontSize="10" textAnchor="middle" dy=".3em" pointerEvents="none">{rel.label}</text>
                                         <defs>


### PR DESCRIPTION
## 概要

キャラクター相関図の移動モードでキャラクターノードをドラッグすると、関係を表す線・矢印がカーソルに約 200ms 遅れて追従し、アイコンを離した後に付いてくる現象を修正する。

## 原因

関係線 `<path>` (`components/CharacterChart.tsx`) の `className` に付いていた **`transition-all duration-200`**。

CSS `d` プロパティ対応ブラウザ (Chrome / Firefox 97+) では SVG path の `d` 属性変化が補間アニメーションされる。ドラッグ中は `onMouseMove` → `setLocalNodes` で座標が連続更新されるため、その都度 `d` が 200ms かけて補間され、線・矢印がカーソルに遅延追従していた。Safari は `d` 未対応のため再現せず、ユーザー報告「**パソコン環境により**」と一致する。

ノード本体 (`<g transform>`) は transition 無しで即時移動していたため、ノードだけ滑らかでフレームがずれて見えていた。

## 修正

```diff
- className="transition-all duration-200 group-hover:stroke-white"
+ className="transition-[stroke] duration-200 group-hover:stroke-white"
```

- `transition-[stroke]` により遷移対象を `stroke` 色のみに限定 → `d`(形状) は即時反映され、ノードと同フレームで線・矢印が追従
- hover 時の白色化 (`group-hover:stroke-white`) の色遷移は維持
- `fill="none"` のため塗りは無関係。`transition-colors` より限定的で、将来このパスに別プロパティを足したときの予期せぬ遷移も防ぐ最小権限指定 (Codex セカンドオピニオンでも推奨)

## 影響範囲

- 1 ファイル / 1 行 (className のみ)。ロジック・型・データフロー変更なし。
- 実際に使用されているのは `CharacterChart.tsx` の `CharacterChartModal` (`ModalManager` が import)。同名のデッドファイル `components/CharacterChartModal.tsx` は本 PR の対象外 (未使用、別途整理候補)。

## Test plan

- [x] `npm run lint` (tsc --noEmit) PASS, 0 errors
- [ ] `npm run dev` で相関図を開き、移動モードでノードをドラッグ → 関係線・矢印が遅延なくノードに追従することを目視確認 (Chrome)
- [ ] ノードホバー時に関係線が白色化する演出が維持されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)