### PR TITLE
fix(character): AIキャラ生成チャットの文脈喪失と内部名露出を修正

### DIFF
--- a/characterApi.ts
+++ b/characterApi.ts
@@ -9,8 +9,13 @@ export const updateCharacterData = async (
     return apiCall('/character/update', { chatHistory, currentCharacterData, intent });
 };
 
-export const generateCharacterReply = async (updatedCharacterData: any) => {
-    return apiCall<{ reply: string }>('/character/reply', { updatedCharacterData });
+export interface CharacterReplyContext {
+    latestUserMessage?: string;
+    appliedPatch?: Record<string, unknown>;
+}
+
+export const generateCharacterReply = async (updatedCharacterData: any, context?: CharacterReplyContext) => {
+    return apiCall<{ reply: string }>('/character/reply', { updatedCharacterData, context });
 };
 
 export const generateCharacterImagePrompt = async (chatHistory: ChatMessage[]) => {

--- a/components/CharacterGenerationModal.tsx
+++ b/components/CharacterGenerationModal.tsx
@@ -115,6 +115,8 @@ export const CharacterGenerationModal = ({ isOpen, onClose, onApply, initialData
     const [currentCharacterData, setCurrentCharacterData] = useState<Partial<SettingItem> | null>(null);
     const [mode, setMode] = useState<'create' | 'update'>('create');
     const [isHelpOpen, setIsHelpOpen] = useState(false);
+    // clarification 直後の通常送信が consult に化ける問題対策: 直前の update intent を次の通常送信に引き継ぐ
+    const [pendingUpdateIntent, setPendingUpdateIntent] = useState(false);
     const chatEndRef = useRef(null);
     const userInputRef = useRef(null);
     const isMac = useMemo(() => navigator.platform.toUpperCase().indexOf('MAC') >= 0, []);
@@ -191,10 +193,14 @@ export const CharacterGenerationModal = ({ isOpen, onClose, onApply, initialData
     
         // Case 1 & 2: AI gives a direct reply (consultation or clarification)
         if ('consultation_reply' in resultData || 'clarification_needed' in resultData) {
-            const reply = ('consultation_reply' in resultData) 
-                ? resultData.consultation_reply 
+            const isClarification = 'clarification_needed' in resultData;
+            const reply = ('consultation_reply' in resultData)
+                ? resultData.consultation_reply
                 : resultData.clarification_needed;
-            
+
+            // update 中に聞き返された場合は、次の通常送信(Enter)を update intent に引き継ぐ
+            setPendingUpdateIntent(isClarification && intent === 'update');
+
             setChatHistory(prev => [...prev, { role: 'assistant', text: reply, mode: 'consult' }]);
             setIsLoading(false); // All done
             return;
@@ -202,9 +208,10 @@ export const CharacterGenerationModal = ({ isOpen, onClose, onApply, initialData
         
         // Case 3: AI gives a data patch. We need to update the preview and then get a confirmation reply.
         const patch = resultData;
-    
+        setPendingUpdateIntent(false);
+
         // Show spinner in preview pane while merging/updating
-        setIsUpdatingPreview(true); 
+        setIsUpdatingPreview(true);
         const newCharacterData = mergeCharacterData(currentCharacterData, patch);
         setCurrentCharacterData(newCharacterData);
         setIsUpdatingPreview(false);
@@ -224,7 +231,10 @@ export const CharacterGenerationModal = ({ isOpen, onClose, onApply, initialData
         }
     
         // Now, get a confirmation reply. The main spinner is still active.
-        const replyResult = await generateCharacterReply(newCharacterData);
+        const replyResult = await generateCharacterReply(newCharacterData, {
+            latestUserMessage: trimmedInput,
+            appliedPatch: patch as Record<string, unknown>,
+        });
         
         if (replyResult.success === false) {
             console.error(replyResult.error);
@@ -239,6 +249,11 @@ export const CharacterGenerationModal = ({ isOpen, onClose, onApply, initialData
         setIsLoading(false); // End of all operations
     };
     
+    // 通常送信(Ctrl/Cmd+Enter・送信ボタン)の intent を決める。
+    // pendingUpdateIntent が立っていれば update を優先（clarification 直後の引き継ぎ）。
+    const resolveNormalIntent = (): 'consult' | 'update' =>
+        pendingUpdateIntent ? 'update' : (mode === 'update' ? 'consult' : 'update');
+
     const handleKeyDown = (e) => {
         if (e.key === 'Enter') {
             if (e.altKey) {
@@ -246,7 +261,7 @@ export const CharacterGenerationModal = ({ isOpen, onClose, onApply, initialData
                 handleSendMessage('update');
             } else if (e.ctrlKey || e.metaKey) {
                 e.preventDefault();
-                handleSendMessage(mode === 'update' ? 'consult' : 'update');
+                handleSendMessage(resolveNormalIntent());
             }
         }
     };
@@ -340,7 +355,7 @@ export const CharacterGenerationModal = ({ isOpen, onClose, onApply, initialData
                                 {isLoading && <div className="flex items-start gap-3"><Icons.BotIcon className="h-6 w-6 text-teal-400 flex-shrink-0" /><div className="px-4 py-3 rounded-xl bg-gray-700/50"><div className="flex items-center space-x-2"><div className="h-2 w-2 bg-teal-300 rounded-full animate-pulse"></div><div className="h-2 w-2 bg-teal-300 rounded-full animate-pulse [animation-delay:-0.15s]"></div><div className="h-2 w-2 bg-teal-300 rounded-full animate-pulse [animation-delay:-0.3s]"></div></div></div></div>}
                                 <div ref={chatEndRef} />
                             </div>
-                            <form onSubmit={(e) => { e.preventDefault(); handleSendMessage(mode === 'update' ? 'consult' : 'update'); }} className="pt-4 border-t border-gray-700">
+                            <form onSubmit={(e) => { e.preventDefault(); handleSendMessage(resolveNormalIntent()); }} className="pt-4 border-t border-gray-700">
                                 <div className="flex-1 bg-gray-900 border border-gray-600 rounded-lg overflow-hidden flex flex-col">
                                     <textarea
                                         ref={userInputRef}

--- a/server/routes/character.ts
+++ b/server/routes/character.ts
@@ -10,8 +10,8 @@ router.post('/update', withUsageQuota('character/update', async (req) => {
 }));
 
 router.post('/reply', withUsageQuota('character/reply', async (req) => {
-    const { updatedCharacterData } = req.body;
-    const reply = await generateCharacterReply(updatedCharacterData);
+    const { updatedCharacterData, context } = req.body;
+    const reply = await generateCharacterReply(updatedCharacterData, context);
     return { reply };
 }));
 

--- a/server/services/characterPrompt.test.ts
+++ b/server/services/characterPrompt.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import { ChatMessage } from '../../types';
+import {
+  MAX_HISTORY_TURNS,
+  USER_FACING_LANGUAGE_RULES,
+  CHARACTER_UPDATE_SYSTEM_INSTRUCTION,
+  CHARACTER_REPLY_SYSTEM_INSTRUCTION,
+  trimHistory,
+  buildCharacterContents,
+  sanitizeCharacterPatch,
+} from './characterPrompt';
+
+const u = (text: string, mode: 'write' | 'consult' = 'write'): ChatMessage => ({ role: 'user', text, mode });
+const a = (text: string): ChatMessage => ({ role: 'assistant', text, mode: 'consult' });
+
+describe('trimHistory', () => {
+  it('returns [] for non-array input', () => {
+    expect(trimHistory(undefined as unknown as ChatMessage[])).toEqual([]);
+    expect(trimHistory(null as unknown as ChatMessage[])).toEqual([]);
+  });
+
+  it('drops leading assistant turns so contents start with a user turn', () => {
+    const history = [a('init'), u('first'), a('reply'), u('latest')];
+    const trimmed = trimHistory(history);
+    expect(trimmed[0].role).toBe('user');
+    expect(trimmed[0].text).toBe('first');
+  });
+
+  it('keeps only the most recent MAX_HISTORY_TURNS turns', () => {
+    const history: ChatMessage[] = [];
+    for (let i = 0; i < MAX_HISTORY_TURNS + 10; i++) history.push(u(`m${i}`));
+    const trimmed = trimHistory(history);
+    expect(trimmed.length).toBe(MAX_HISTORY_TURNS);
+    expect(trimmed[trimmed.length - 1].text).toBe(`m${MAX_HISTORY_TURNS + 9}`);
+  });
+});
+
+describe('buildCharacterContents', () => {
+  it('includes the ENTIRE conversation, not just the last message (症状A regression)', () => {
+    const history = [a('init'), u('first'), a('reply'), u('latest')];
+    const joined = buildCharacterContents(history, {}, 'update')
+      .map((c) => c.parts[0].text)
+      .join('\n');
+    expect(joined).toContain('first');
+    expect(joined).toContain('reply');
+    expect(joined).toContain('latest');
+  });
+
+  it('maps roles to user/model', () => {
+    const contents = buildCharacterContents([u('A'), a('B'), u('C')], {}, 'consult');
+    expect(contents.map((c) => c.role)).toEqual(['user', 'model', 'user']);
+  });
+
+  it('appends RUNTIME_CONTEXT (intent + current data) only to the last user turn', () => {
+    const data = { personality: 'X1' };
+    const contents = buildCharacterContents([u('A'), u('B')], data, 'update');
+    const last = contents[contents.length - 1].parts[0].text;
+    const first = contents[0].parts[0].text;
+    expect(last).toContain('<RUNTIME_CONTEXT>');
+    expect(last).toContain('intent: update');
+    expect(last).toContain('X1');
+    expect(first).not.toContain('<RUNTIME_CONTEXT>');
+  });
+
+  it('tags earlier user turns with their original mode as TURN_INTENT', () => {
+    const contents = buildCharacterContents([u('older', 'consult'), u('latest')], {}, 'update');
+    expect(contents[0].parts[0].text).toContain('<TURN_INTENT>consult</TURN_INTENT>');
+    expect(contents[1].parts[0].text).not.toContain('<TURN_INTENT>');
+  });
+
+  it('handles empty/null data as {} in RUNTIME_CONTEXT', () => {
+    const contents = buildCharacterContents([u('X')], null, 'update');
+    expect(contents[0].parts[0].text).toContain('currentCharacterData: {}');
+  });
+});
+
+describe('sanitizeCharacterPatch', () => {
+  it('removes null and undefined to protect existing values', () => {
+    const patch = { personality: 'X', age: null, name: undefined, gender: 'Y' };
+    expect(sanitizeCharacterPatch(patch)).toEqual({ personality: 'X', gender: 'Y' });
+  });
+
+  it('keeps falsy-but-meaningful values like empty string, 0, false', () => {
+    const patch = { a: '', b: 0, c: false };
+    expect(sanitizeCharacterPatch(patch)).toEqual({ a: '', b: 0, c: false });
+  });
+});
+
+describe('system instructions (症状B: 内部名禁止ルール埋め込み)', () => {
+  it('both instructions embed the user-facing language rules', () => {
+    const marker = USER_FACING_LANGUAGE_RULES.trim().slice(0, 30);
+    expect(CHARACTER_UPDATE_SYSTEM_INSTRUCTION).toContain(marker);
+    expect(CHARACTER_REPLY_SYSTEM_INSTRUCTION).toContain(marker);
+  });
+
+  it('forbids exposing internal field names', () => {
+    expect(USER_FACING_LANGUAGE_RULES).toContain('longDescription');
+    expect(USER_FACING_LANGUAGE_RULES).toContain('traits');
+  });
+});

--- a/server/services/characterPrompt.ts
+++ b/server/services/characterPrompt.ts
@@ -1,0 +1,115 @@
+import { ChatMessage } from '../../types';
+
+/**
+ * キャラクター生成アシスタントのプロンプト構築ロジック（pure helper）。
+ *
+ * AI クライアントに依存しない純粋関数のみを置く。characterService.ts は
+ * aiClient (@google/genai) を import するため、ここを分離するとロジックを
+ * モックなしで単体テストできる（pure helper 分離パターン）。
+ */
+
+/** Gemini に渡す会話履歴の最大ターン数。短いキャラ作成セッション想定の防御上限。 */
+export const MAX_HISTORY_TURNS = 20;
+
+/**
+ * ユーザー向けテキストに内部スキーマ名を出させないための共通ルール（症状B対策）。
+ * update / reply 両方の systemInstruction 末尾に連結する。
+ */
+export const USER_FACING_LANGUAGE_RULES = `
+
+***USER-FACING LANGUAGE RULES (MANDATORY):***
+- Any text shown to the user (the "consultation_reply", "clarification_needed", or "reply" string) MUST be natural, conversational Japanese.
+- NEVER expose internal schema keys or implementation jargon to the user, such as: longDescription, traits, appearance, personality, firstPersonPronoun, themeColor, JSON, field, list, patch, property, schema, object.
+- NEVER ask the user which internal field or data structure to store information in. Decide the appropriate place yourself.
+- If clarification is genuinely needed, ask ONLY about the character concept in plain Japanese (e.g. "どんな性格にしますか？" "外見の特徴も決めておきますか？"). Do not surface storage or format choices.`;
+
+/**
+ * updateCharacterData 用 systemInstruction。
+ * intent は履歴最終ターンの <RUNTIME_CONTEXT> から読む方針（マルチターン化対応）。
+ */
+export const CHARACTER_UPDATE_SYSTEM_INSTRUCTION = `You are a multi-modal assistant for character creation. You receive the full conversation as a sequence of turns and must respond in the correct JSON format.
+
+***CRITICAL RULES:***
+
+1.  **DETERMINE INTENT FROM RUNTIME CONTEXT:** The authoritative intent ('update' or 'consult') for THIS response is given in the <RUNTIME_CONTEXT> block appended to the LAST user turn, together with the current character data. Earlier user turns are tagged with <TURN_INTENT> for context ONLY; never let an old turn's intent override the current <RUNTIME_CONTEXT>. Always read the whole conversation so that short replies such as a simple agreement are interpreted against what was just discussed.
+
+2.  **IF INTENT IS 'update':**
+    *   The user wants to modify the character data. Generate a JSON "patch" or ask a clarifying question.
+    *   **If the request is clear:** Generate a JSON "patch" object containing ONLY the modified or new fields. NEVER return the full character object.
+    *   **If the request is ambiguous:** ask for clarification with a single key "clarification_needed" (plain Japanese, about the character itself).
+    *   Under the 'update' intent, you MUST NOT use the "consultation_reply" field.
+
+3.  **IF INTENT IS 'consult':**
+    *   The user wants to brainstorm or talk. You MUST NOT generate a data patch or data-entry style clarification.
+    *   Respond conversationally as a creative partner via a single key "consultation_reply" (Japanese).
+    *   Under the 'consult' intent, you MUST NOT generate a JSON patch or use the "clarification_needed" field.
+
+4.  **Output Format:** Your entire output MUST BE a single, valid JSON object matching one of the three structures above. No other text is allowed. All string values inside the JSON must be in Japanese.${USER_FACING_LANGUAGE_RULES}`;
+
+/** generateCharacterReply 用 systemInstruction。直近の更新内容を踏まえた確認返答を生成する。 */
+export const CHARACTER_REPLY_SYSTEM_INSTRUCTION = `You are a friendly and helpful assistant for novel writing. Your task is to generate a conversational reply that acknowledges what was JUST updated and moves the conversation forward.
+
+***RULES***
+1.  **INPUT:** You receive the character's current profile, and (when available) the user's latest message and the change that was just applied.
+2.  **TASK:** Formulate a brief, engaging reply in Japanese that naturally reflects what was just changed, then ask ONE relevant follow-up question.
+3.  **OUTPUT:** Your response MUST be ONLY a JSON object with a single key "reply" containing the conversational text in Japanese.${USER_FACING_LANGUAGE_RULES}`;
+
+/** Gemini contents の 1 ターン表現。 */
+export type GeminiContent = { role: 'user' | 'model'; parts: { text: string }[] };
+
+/**
+ * 会話履歴を直近 maxTurns に制限する。
+ * Gemini の contents は user ロール始まりが要求されるため、先頭に並ぶ
+ * assistant（初期メッセージ等）は落とす。
+ */
+export function trimHistory(history: ChatMessage[], maxTurns: number = MAX_HISTORY_TURNS): ChatMessage[] {
+  if (!Array.isArray(history)) return [];
+  let trimmed = history.slice(-maxTurns);
+  while (trimmed.length > 0 && trimmed[0].role !== 'user') {
+    trimmed = trimmed.slice(1);
+  }
+  return trimmed;
+}
+
+/**
+ * 会話履歴をマルチターン contents に変換する（症状A対策の中核）。
+ *
+ * - 最終 user ターンには <RUNTIME_CONTEXT>（今回の intent + 現在のキャラデータ）を付記。
+ * - それ以前の user ターンには当時の <TURN_INTENT> を付記（過去の文脈として保持）。
+ * - assistant ターンはそのまま model ロールへ。
+ */
+export function buildCharacterContents(
+  history: ChatMessage[],
+  currentCharacterData: unknown,
+  intent: 'consult' | 'update'
+): GeminiContent[] {
+  const trimmed = trimHistory(history);
+  return trimmed.map((message, index) => {
+    const isLast = index === trimmed.length - 1;
+    let text = message.text;
+
+    if (isLast) {
+      text = `${message.text}\n\n<RUNTIME_CONTEXT>\nintent: ${intent}\ncurrentCharacterData: ${JSON.stringify(
+        currentCharacterData ?? {}
+      )}\n</RUNTIME_CONTEXT>`;
+    } else if (message.role === 'user') {
+      const turnIntent = message.mode === 'write' ? 'update' : 'consult';
+      text = `<TURN_INTENT>${turnIntent}</TURN_INTENT>\n${message.text}`;
+    }
+
+    return { role: message.role === 'user' ? 'user' : 'model', parts: [{ text }] };
+  });
+}
+
+/**
+ * AI が返した patch から null / undefined を除去する（既存値の意図しない消去対策, P2）。
+ *
+ * responseSchema が全フィールド nullable のため、AI が無関係なフィールドに null を
+ * 入れて返すと、FE 側 mergeCharacterData で既存値を null 上書きしてしまう。
+ * patch には「実際に変更したいフィールド」だけを残す。
+ */
+export function sanitizeCharacterPatch<T extends Record<string, unknown>>(patch: T): Partial<T> {
+  return Object.fromEntries(
+    Object.entries(patch).filter(([, v]) => v !== null && v !== undefined)
+  ) as Partial<T>;
+}

--- a/server/services/characterService.ts
+++ b/server/services/characterService.ts
@@ -1,28 +1,12 @@
 import { Type, GenerateContentResponse } from '@google/genai';
 import { ChatMessage, SettingItem } from '../../types';
 import { getAiClient, TEXT_MODEL } from '../aiClient';
-
-const systemInstruction = `You are a multi-modal assistant for character creation. Your task is to analyze a user's request based on their specified **intent** and respond in the correct JSON format.
-
-***CRITICAL RULES:***
-
-1.  **CHECK THE USER'S INTENT:** The user will explicitly state their intent as either 'update' or 'consult'. You MUST follow the instructions for that intent precisely.
-
-2.  **IF INTENT IS 'update':**
-    *   The user wants to modify the character data. Your goal is to generate a JSON "patch" or ask a clarifying question.
-    *   **If the request is clear:** Generate a JSON "patch" object containing ONLY the modified or new fields. NEVER return the full character object.
-        -   Example: User says "彼の性格を『冷酷非道』に変更して". Output MUST be: \`{"personality": "冷酷非道"}\`.
-    *   **If the request is ambiguous:** If the user's request to update data is vague (e.g., "彼の外見を更新して"), you MUST ask for clarification. Generate a JSON object with a single key: \`"clarification_needed"\`.
-        -   Example Output: \`{"clarification_needed": "承知しました。外見のどの部分を更新しますか？（例：髪の色、目の色、服装など）"}\`.
-    *   Under the 'update' intent, you MUST NOT use the "consultation_reply" field.
-
-3.  **IF INTENT IS 'consult':**
-    *   The user wants to brainstorm or have a conversation. You MUST NOT generate a data patch or ask for data-entry style clarification.
-    *   Your role is to be a creative partner. Respond conversationally.
-    *   To do this, generate a JSON object with a single key: \`"consultation_reply"\`. The value will be your creative, conversational response in Japanese.
-    *   Under the 'consult' intent, you MUST NOT generate a JSON patch or use the "clarification_needed" field.
-
-4.  **Output Format:** Your entire output MUST BE a single, valid JSON object matching one of the three structures described above. No other text is allowed. All string values inside the JSON must be in Japanese.`;
+import {
+    CHARACTER_UPDATE_SYSTEM_INSTRUCTION,
+    CHARACTER_REPLY_SYSTEM_INSTRUCTION,
+    buildCharacterContents,
+    sanitizeCharacterPatch,
+} from './characterPrompt';
 
 const characterSchema = {
     type: Type.OBJECT,
@@ -71,26 +55,24 @@ export const updateCharacterData = async (chatHistory: ChatMessage[], currentCha
         required: [],
     };
 
-    const singlePrompt = `
-**Current Character Data (JSON):**
-\`\`\`json
-${JSON.stringify(currentCharacterData || {}, null, 2)}
-\`\`\`
+    // 空履歴ガード（P2）: 従来は配列末尾参照で例外になっていた。
+    if (!Array.isArray(chatHistory) || chatHistory.length === 0) {
+        return { clarification_needed: 'どのようなキャラクターにしたいか、もう少し教えてください。' };
+    }
 
-**User's Intent:** "${intent}"
+    // 症状A の中核: 最後の1件だけでなく会話履歴全体をマルチターンで渡す。
+    const contents = buildCharacterContents(chatHistory, currentCharacterData, intent);
 
-**User's Request:**
-"${chatHistory[chatHistory.length - 1].text}"
-
-**Your Task:**
-Based on your system instructions, the user's intent, and their request, generate the appropriate JSON output.
-`;
+    // 履歴がすべて assistant 等で user ターンが残らなかった場合のガード（空 contents で API を呼ばない）。
+    if (contents.length === 0) {
+        return { clarification_needed: 'どのようなキャラクターにしたいか、もう少し教えてください。' };
+    }
 
     const response: GenerateContentResponse = await client.models.generateContent({
         model: TEXT_MODEL,
-        contents: singlePrompt,
+        contents,
         config: {
-            systemInstruction,
+            systemInstruction: CHARACTER_UPDATE_SYSTEM_INSTRUCTION,
             responseMimeType: 'application/json',
             responseSchema
         }
@@ -101,28 +83,37 @@ Based on your system instructions, the user's intent, and their request, generat
     if (parsedJson.consultation_reply) return { consultation_reply: parsedJson.consultation_reply };
     delete parsedJson.clarification_needed;
     delete parsedJson.consultation_reply;
-    return parsedJson;
+    // null/undefined を除去し、既存値の意図しない上書きを防ぐ（P2）。
+    return sanitizeCharacterPatch(parsedJson);
 };
 
-export const generateCharacterReply = async (updatedCharacterData: any) => {
-    const client = getAiClient();
-    const replySystemInstruction = `You are a friendly and helpful assistant for novel writing. Your task is to generate a conversational reply based on the character data provided.
+export interface CharacterReplyContext {
+    latestUserMessage?: string;
+    appliedPatch?: Record<string, unknown>;
+}
 
-***RULES***
-1.  **INPUT:** You will receive a JSON object with a character's current profile.
-2.  **TASK:** Formulate a brief, engaging reply in Japanese. Acknowledge the recent updates and ask a relevant follow-up question.
-3.  **OUTPUT:** Your response MUST be ONLY a JSON object with a single key "reply" containing the conversational text in Japanese.`;
+export const generateCharacterReply = async (updatedCharacterData: any, context?: CharacterReplyContext) => {
+    const client = getAiClient();
+
+    const contextLines: string[] = [];
+    if (context?.latestUserMessage) {
+        contextLines.push(`The user's latest message was: "${context.latestUserMessage}"`);
+    }
+    if (context?.appliedPatch && Object.keys(context.appliedPatch).length > 0) {
+        contextLines.push(`The change just applied to the profile: ${JSON.stringify(context.appliedPatch)}`);
+    }
+    const contextBlock = contextLines.length > 0 ? `\n\n${contextLines.join('\n')}` : '';
 
     const prompt = `Here is the updated character profile:
-${JSON.stringify(updatedCharacterData, null, 2)}
+${JSON.stringify(updatedCharacterData, null, 2)}${contextBlock}
 
-Please provide a conversational reply and a follow-up question based on this data.`;
+Please provide a conversational reply that reflects what was just changed, and a relevant follow-up question.`;
 
     const response: GenerateContentResponse = await client.models.generateContent({
         model: TEXT_MODEL,
         contents: prompt,
         config: {
-            systemInstruction: replySystemInstruction,
+            systemInstruction: CHARACTER_REPLY_SYSTEM_INSTRUCTION,
             responseMimeType: 'application/json',
             responseSchema: {
                 type: Type.OBJECT,


### PR DESCRIPTION
## 背景 / 症状
ユーザー報告: AIキャラクター生成アシスタントが会話の流れを保持できない。

- **症状A（文脈忘れ）**: 「どんな性格がいい？」→AI「○○はどう？」→「じゃあそれで」→AIが「それ」を理解できず的外れに聞き返す。
- **症状B（内部名露出）**: AIの聞き返しに `longDescription` / `traits` 等の内部フィールド名が日本語UIに混ざりユーザーを混乱させる。

## 根本原因
- `server/services/characterService.ts` の `updateCharacterData` が会話履歴を受け取りながら、プロンプトに **最後の1件 (`chatHistory[length-1]`)** しか埋めていなかった（症状Aの主因）。
- `systemInstruction` に「ユーザー向け応答へ内部名を出すな」というガードが無かった（症状Bの素地）。
- **Codexセカンドオピニオン**で追加判明: 「設定に反映」モードで聞き返された直後、通常送信(Enter)が `consult` に化け、更新が空回りする（FEの intent 取り違え）。

## 変更内容
- **A1**: `updateCharacterData` をマルチターン `contents` 化し履歴全体を渡す。`intent`/現在データは最終ユーザーターンに `<RUNTIME_CONTEXT>`、過去ユーザーターンは `<TURN_INTENT>` で当時の mode を文脈保持。
- **B1**: update / reply 両 `systemInstruction` に内部名露出禁止ルールを追加。
- **P1(FE)**: `clarification` 直後の通常送信を元の `update` intent に引き継ぐ（`pendingUpdateIntent` state）。
- **A2**: `generateCharacterReply` に「最新発言 + 適用patch」を渡し確認返答を文脈に沿わせる（`characterApi.ts` / route / service の3層）。
- **P2**: 空履歴ガード / 履歴20ターン上限 / patch の null除去（既存値の意図しない上書き防止）。
- プロンプト構築ロジックを pure helper `characterPrompt.ts` に分離（AI依存ゼロで単体テスト可能）。

## Test plan
**自動（実行済み）**
- [x] `npx tsc --noEmit` → **0 errors**
- [x] `npx vitest run`（全スイート）→ **509 passed / 5 skipped（失敗0）**。うち新規 `characterPrompt.test.ts` **12件**（履歴全積み回帰・RUNTIME_CONTEXT付与・TURN_INTENT保持・null除去・内部名禁止埋め込み）

**手動（要・実機確認）**
- [ ] キャラ生成チャットで「性格を相談→『じゃあそれで』」が文脈通り通じる（症状A解消）
- [ ] AI応答に英語の内部フィールド名が出ない（症状B解消）
- [ ] 「設定に反映」で聞き返された後、通常Enterで答えると更新が反映される（intent引き継ぎ）

## 補足
- 修正方針は実装前に Codex でレビュー済み（見落とし2点を反映）。
- 6ファイル変更（修正4 + 新規 helper/test 2）、+284 / -58。

🤖 Generated with [Claude Code](https://claude.com/claude-code)