### PR TITLE
fix(character): プロンプトから base64 画像 dataURI を除外しトークン上限超過を解消

### DIFF
--- a/server/services/characterPrompt.test.ts
+++ b/server/services/characterPrompt.test.ts
@@ -8,6 +8,8 @@ import {
   trimHistory,
   buildCharacterContents,
   sanitizeCharacterPatch,
+  stripPromptHeavyFields,
+  IMAGE_OMITTED_MARKER,
 } from './characterPrompt';
 
 const u = (text: string, mode: 'write' | 'consult' = 'write'): ChatMessage => ({ role: 'user', text, mode });
@@ -83,6 +85,53 @@ describe('sanitizeCharacterPatch', () => {
   it('keeps falsy-but-meaningful values like empty string, 0, false', () => {
     const patch = { a: '', b: 0, c: false };
     expect(sanitizeCharacterPatch(patch)).toEqual({ a: '', b: 0, c: false });
+  });
+});
+
+describe('stripPromptHeavyFields (token-bomb 対策: base64 dataURI を除外)', () => {
+  it('replaces base64 data: URI in appearance.imageUrl with an omission marker', () => {
+    const big = `data:image/png;base64,${'A'.repeat(1_000_000)}`;
+    const data = { name: 'Alice', appearance: { imageUrl: big, traits: [{ key: '髪', value: '金' }] } };
+    const stripped = stripPromptHeavyFields(data) as typeof data;
+    expect(stripped.appearance.imageUrl).toBe(IMAGE_OMITTED_MARKER);
+    expect(stripped.appearance.traits).toEqual([{ key: '髪', value: '金' }]);
+    expect(stripped.name).toBe('Alice');
+  });
+
+  it('keeps non-dataURI imageUrl (http URL) intact', () => {
+    const data = { appearance: { imageUrl: 'https://example.com/a.png' } };
+    expect((stripPromptHeavyFields(data) as typeof data).appearance.imageUrl).toBe('https://example.com/a.png');
+  });
+
+  it('returns null/undefined/primitive unchanged', () => {
+    expect(stripPromptHeavyFields(null)).toBe(null);
+    expect(stripPromptHeavyFields(undefined)).toBe(undefined);
+    expect(stripPromptHeavyFields('x')).toBe('x');
+    expect(stripPromptHeavyFields(42)).toBe(42);
+  });
+
+  it('does not mutate the original input', () => {
+    const big = `data:image/png;base64,${'A'.repeat(100)}`;
+    const data = { appearance: { imageUrl: big, traits: [{ key: 'k', value: 'v' }] } };
+    stripPromptHeavyFields(data);
+    expect(data.appearance.imageUrl).toBe(big);
+  });
+
+  it('handles data missing appearance gracefully', () => {
+    const data = { name: 'Alice', personality: 'gentle' };
+    expect(stripPromptHeavyFields(data)).toEqual(data);
+  });
+});
+
+describe('buildCharacterContents (token-bomb 対策統合)', () => {
+  it('strips base64 dataURI from currentCharacterData before embedding into RUNTIME_CONTEXT', () => {
+    const big = `data:image/png;base64,${'A'.repeat(500_000)}`;
+    const data = { appearance: { imageUrl: big } };
+    const contents = buildCharacterContents([u('describe her')], data, 'update');
+    const text = contents[0].parts[0].text;
+    expect(text).not.toContain('AAAAA');
+    expect(text).toContain(IMAGE_OMITTED_MARKER);
+    expect(text.length).toBeLessThan(5_000);
   });
 });
 

--- a/server/services/characterPrompt.ts
+++ b/server/services/characterPrompt.ts
@@ -72,11 +72,45 @@ export function trimHistory(history: ChatMessage[], maxTurns: number = MAX_HISTO
 }
 
 /**
+ * 生成済み base64 dataURI をプロンプトから除外する際のマーカー。
+ * AI には「画像が存在する」という事実だけ伝え、bytes 本体は送らない。
+ */
+export const IMAGE_OMITTED_MARKER = '[generated-image: omitted from prompt to fit token budget]';
+
+/**
+ * Gemini に送る currentCharacterData から、プロンプト圧迫源を取り除く（token-bomb 対策）。
+ *
+ * Imagen 経由で生成されたキャラ画像は `appearance.imageUrl` に `data:image/png;base64,...` の
+ * 形で保存される。これを JSON.stringify して RUNTIME_CONTEXT に埋め込むと、1MB の dataURI が
+ * 約 90 万トークンに展開され、Gemini 2.5 flash の入力上限 (131,072 tokens) を一発で超える。
+ * 結果として全 `character/update` 呼び出しが 400 INVALID_ARGUMENT で永久 fail する
+ * (2026-06-01 12:21 JST 観測の本番障害)。
+ *
+ * dataURI のみ omission marker に置換し、http/https URL や空文字はそのまま保持する。
+ * 引数を mutate しない (純粋関数)。
+ */
+export function stripPromptHeavyFields(data: unknown): unknown {
+  if (!data || typeof data !== 'object') return data;
+  const obj = data as Record<string, unknown>;
+  const result: Record<string, unknown> = { ...obj };
+  const appearance = obj.appearance;
+  if (appearance && typeof appearance === 'object') {
+    const app = appearance as Record<string, unknown>;
+    const imageUrl = app.imageUrl;
+    if (typeof imageUrl === 'string' && imageUrl.startsWith('data:')) {
+      result.appearance = { ...app, imageUrl: IMAGE_OMITTED_MARKER };
+    }
+  }
+  return result;
+}
+
+/**
  * 会話履歴をマルチターン contents に変換する（症状A対策の中核）。
  *
  * - 最終 user ターンには <RUNTIME_CONTEXT>（今回の intent + 現在のキャラデータ）を付記。
  * - それ以前の user ターンには当時の <TURN_INTENT> を付記（過去の文脈として保持）。
  * - assistant ターンはそのまま model ロールへ。
+ * - currentCharacterData は stripPromptHeavyFields で base64 dataURI を omit してから埋め込む。
  */
 export function buildCharacterContents(
   history: ChatMessage[],
@@ -84,13 +118,14 @@ export function buildCharacterContents(
   intent: 'consult' | 'update'
 ): GeminiContent[] {
   const trimmed = trimHistory(history);
+  const safeCurrent = stripPromptHeavyFields(currentCharacterData ?? {});
   return trimmed.map((message, index) => {
     const isLast = index === trimmed.length - 1;
     let text = message.text;
 
     if (isLast) {
       text = `${message.text}\n\n<RUNTIME_CONTEXT>\nintent: ${intent}\ncurrentCharacterData: ${JSON.stringify(
-        currentCharacterData ?? {}
+        safeCurrent
       )}\n</RUNTIME_CONTEXT>`;
     } else if (message.role === 'user') {
       const turnIntent = message.mode === 'write' ? 'update' : 'consult';


### PR DESCRIPTION
## Summary

- 本番 dev (revision 00109-2r5, commit bd6ac64) で 2026-06-01 12:21〜12:23 JST、`AIキャラクター生成アシスタント` 内の `character/update` が **3 回連続 400 INVALID_ARGUMENT** で失敗 → FE には context='ai' generic 500「AI処理でエラーが発生しました」と表示
- 原因: `currentCharacterData.appearance.imageUrl` に Imagen 生成画像の **base64 dataURI** (~1MB) が入っており、`buildCharacterContents` で `JSON.stringify` して `<RUNTIME_CONTEXT>` に丸ごと埋め込んでいた → Gemini 2.5 Flash の入力上限 **131,072 tokens** に対して **917,455 tokens** で爆発
- 修正: `stripPromptHeavyFields` pure helper を `characterPrompt.ts` に追加し、`appearance.imageUrl` が `data:` で始まる場合のみ `IMAGE_OMITTED_MARKER` に置換 (http URL / 空文字 / 他フィールドは素通し、引数 mutate なし)

## なぜ data: のみ omission するか

- AI に「画像が存在する」事実だけ伝え、bytes 本体は送らない
- `consult` / `update` 双方で十分 (AI は imageUrl の中身を直接利用しない、必要な context は `traits` / `personality` 等)
- http/https URL は通常 1KB 未満なのでそのまま温存

## 観測ログ抜粋 (Cloud Run dev)

```
ApiError: {"error":{"code":400,
  "message":"The input token count (917455) exceeds the maximum number of tokens allowed (131072).",
  "status":"INVALID_ARGUMENT"}}
  at Models.generateContent (/app/node_modules/@google/genai/src/models.ts:123:14)
  at async updateCharacterData (/app/server/services/characterService.ts:71:47)
```

`httpRequest.requestSize: 1320600` (約 1.3 MB) の異常リクエストが 3 回連続。

## Test plan

- [x] `npx vitest run server/services/characterPrompt.test.ts` → 18 passed (+7 新規ケース)
- [x] `npx vitest run` 全体 → 515 passed / 5 skipped
- [x] `npm run lint` (tsc --noEmit) → 0 error
- [ ] マージ後 Cloud Run dev に反映、画像付きキャラで `character/update` を実機リプレイ (Token budget 内で 200 返却を確認)

## 関連

- 影響範囲: `server/services/characterPrompt.ts` (pure helper) + テストのみ。`characterService.ts` / `character.ts` は無改変
- FE 側 (`CharacterGenerationModal.tsx` 等) は無改変。サーバー側で root-cause を断つ方が、他経路 (将来 import / batch 等) でも自動的にカバーされるため
- 同根の問題が `world` / `analysis` 等他 route にもあるかは別 PR で監査検討余地あり (画像 dataURI を含むデータをプロンプト送信している箇所のみ対象)

🤖 Generated with [Claude Code](https://claude.com/claude-code)