### PR TITLE
fix(prompt-safety): world/character-reply の token-bomb 対策 + 共通 sanitizer 抽出 + observability

### DIFF
--- a/server/services/characterPrompt.ts
+++ b/server/services/characterPrompt.ts
@@ -1,4 +1,5 @@
 import { ChatMessage } from '../../types';
+import { sanitizeForPrompt, IMAGE_OMITTED_MARKER as PROMPT_IMAGE_OMITTED_MARKER } from '../utils/promptSafety';
 
 /**
  * キャラクター生成アシスタントのプロンプト構築ロジック（pure helper）。
@@ -72,37 +73,12 @@ export function trimHistory(history: ChatMessage[], maxTurns: number = MAX_HISTO
 }
 
 /**
- * 生成済み base64 dataURI をプロンプトから除外する際のマーカー。
- * AI には「画像が存在する」という事実だけ伝え、bytes 本体は送らない。
+ * 後方互換 re-export: PR #132 で本ファイルに置いていた helper / 定数を `server/utils/promptSafety.ts`
+ * に集約 (character / world 共通)。既存 import 経路 (`from './characterPrompt'`) を壊さないため
+ * ここから re-export する。新規 import は直接 `server/utils/promptSafety` 推奨。
  */
-export const IMAGE_OMITTED_MARKER = '[generated-image: omitted from prompt to fit token budget]';
-
-/**
- * Gemini に送る currentCharacterData から、プロンプト圧迫源を取り除く（token-bomb 対策）。
- *
- * Imagen 経由で生成されたキャラ画像は `appearance.imageUrl` に `data:image/png;base64,...` の
- * 形で保存される。これを JSON.stringify して RUNTIME_CONTEXT に埋め込むと、1MB の dataURI が
- * 約 90 万トークンに展開され、Gemini 2.5 flash の入力上限 (131,072 tokens) を一発で超える。
- * 結果として全 `character/update` 呼び出しが 400 INVALID_ARGUMENT で永久 fail する
- * (2026-06-01 12:21 JST 観測の本番障害)。
- *
- * dataURI のみ omission marker に置換し、http/https URL や空文字はそのまま保持する。
- * 引数を mutate しない (純粋関数)。
- */
-export function stripPromptHeavyFields(data: unknown): unknown {
-  if (!data || typeof data !== 'object') return data;
-  const obj = data as Record<string, unknown>;
-  const result: Record<string, unknown> = { ...obj };
-  const appearance = obj.appearance;
-  if (appearance && typeof appearance === 'object') {
-    const app = appearance as Record<string, unknown>;
-    const imageUrl = app.imageUrl;
-    if (typeof imageUrl === 'string' && imageUrl.startsWith('data:')) {
-      result.appearance = { ...app, imageUrl: IMAGE_OMITTED_MARKER };
-    }
-  }
-  return result;
-}
+export { sanitizeForPrompt as stripPromptHeavyFields } from '../utils/promptSafety';
+export const IMAGE_OMITTED_MARKER = PROMPT_IMAGE_OMITTED_MARKER;
 
 /**
  * 会話履歴をマルチターン contents に変換する（症状A対策の中核）。
@@ -118,7 +94,7 @@ export function buildCharacterContents(
   intent: 'consult' | 'update'
 ): GeminiContent[] {
   const trimmed = trimHistory(history);
-  const safeCurrent = stripPromptHeavyFields(currentCharacterData ?? {});
+  const safeCurrent = sanitizeForPrompt(currentCharacterData ?? {});
   return trimmed.map((message, index) => {
     const isLast = index === trimmed.length - 1;
     let text = message.text;

--- a/server/services/characterService.test.ts
+++ b/server/services/characterService.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// Contract test: characterService の防御ガードを source 内文字列で pin する。
+// AI 実呼出 mock のコストを払わずに、code-review #133 で指摘された generateCharacterReply の
+// null/undefined ガード asymmetry 修正が後の改修で外されないようにする。
+
+const SOURCE_PATH = resolve(__dirname, 'characterService.ts');
+const source = readFileSync(SOURCE_PATH, 'utf8');
+
+describe('characterService - defensive guards (code-review #133 fix)', () => {
+  it('generateCharacterReply guards updatedCharacterData against null/undefined with `?? {}`', () => {
+    // null/undefined だと JSON.stringify(null, null, 2) === "null" → AI に literal "null" が
+    // 渡る regression を防ぐ。buildCharacterContents の `?? {}` パターンと対称化。
+    expect(source).toContain('sanitizeForPrompt(updatedCharacterData ?? {})');
+  });
+
+  it('generateCharacterReply routes context.appliedPatch through sanitizeForPrompt', () => {
+    // appliedPatch にも appearance.imageUrl が含まれうるため、必ず sanitize 経由化。
+    expect(source).toContain('sanitizeForPrompt(context.appliedPatch)');
+  });
+});

--- a/server/services/characterService.ts
+++ b/server/services/characterService.ts
@@ -99,7 +99,9 @@ export const generateCharacterReply = async (updatedCharacterData: any, context?
     // 2026-06-01 本番障害と同根の token-bomb 対策 (Codex Q3 指摘):
     // updatedCharacterData / appliedPatch は appearance.imageUrl に Imagen 生成画像 (~1MB)
     // を含みうるため、必ず sanitizeForPrompt 経由でプロンプトに埋め込む。
-    const safeCharacter = sanitizeForPrompt(updatedCharacterData);
+    // null/undefined ガード: buildCharacterContents の `?? {}` と対称化 (code-review #133)。
+    // 欠落時に prompt へ literal "null" が embed されるのを防ぐ。
+    const safeCharacter = sanitizeForPrompt(updatedCharacterData ?? {});
     const safePatch = context?.appliedPatch ? sanitizeForPrompt(context.appliedPatch) : undefined;
 
     const contextLines: string[] = [];

--- a/server/services/characterService.ts
+++ b/server/services/characterService.ts
@@ -7,6 +7,7 @@ import {
     buildCharacterContents,
     sanitizeCharacterPatch,
 } from './characterPrompt';
+import { sanitizeForPrompt } from '../utils/promptSafety';
 
 const characterSchema = {
     type: Type.OBJECT,
@@ -95,17 +96,23 @@ export interface CharacterReplyContext {
 export const generateCharacterReply = async (updatedCharacterData: any, context?: CharacterReplyContext) => {
     const client = getAiClient();
 
+    // 2026-06-01 本番障害と同根の token-bomb 対策 (Codex Q3 指摘):
+    // updatedCharacterData / appliedPatch は appearance.imageUrl に Imagen 生成画像 (~1MB)
+    // を含みうるため、必ず sanitizeForPrompt 経由でプロンプトに埋め込む。
+    const safeCharacter = sanitizeForPrompt(updatedCharacterData);
+    const safePatch = context?.appliedPatch ? sanitizeForPrompt(context.appliedPatch) : undefined;
+
     const contextLines: string[] = [];
     if (context?.latestUserMessage) {
         contextLines.push(`The user's latest message was: "${context.latestUserMessage}"`);
     }
-    if (context?.appliedPatch && Object.keys(context.appliedPatch).length > 0) {
-        contextLines.push(`The change just applied to the profile: ${JSON.stringify(context.appliedPatch)}`);
+    if (safePatch && Object.keys(safePatch as Record<string, unknown>).length > 0) {
+        contextLines.push(`The change just applied to the profile: ${JSON.stringify(safePatch)}`);
     }
     const contextBlock = contextLines.length > 0 ? `\n\n${contextLines.join('\n')}` : '';
 
     const prompt = `Here is the updated character profile:
-${JSON.stringify(updatedCharacterData, null, 2)}${contextBlock}
+${JSON.stringify(safeCharacter, null, 2)}${contextBlock}
 
 Please provide a conversational reply that reflects what was just changed, and a relevant follow-up question.`;
 

--- a/server/services/worldService.test.ts
+++ b/server/services/worldService.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// Contract test: worldService の防御ガードを source 内文字列で pin する。
+// AI 実呼出が必要な動作テストは aiClient mock 整備コスト高のため、ガード
+// 削除の regression を最小コストで防ぐ static 検査 (analysisService.test.ts と同パターン)。
+
+const SOURCE_PATH = resolve(__dirname, 'worldService.ts');
+const source = readFileSync(SOURCE_PATH, 'utf8');
+
+describe('worldService - defensive guards (code-review #133 fix)', () => {
+  it('updateWorldData has empty-chatHistory guard symmetric with characterService.updateCharacterData', () => {
+    // 空履歴で chatHistory[chatHistory.length - 1].text が TypeError → 500 を防ぐ。
+    // characterService.ts:60-62 と同型のパターンを pin。
+    expect(source).toMatch(/!Array\.isArray\(chatHistory\)\s*\|\|\s*chatHistory\.length\s*===\s*0/);
+  });
+
+  it('updateWorldData routes currentWorldData through sanitizeForPrompt', () => {
+    expect(source).toContain('sanitizeForPrompt(currentWorldData || {})');
+  });
+
+  it('generateWorldReply guards updatedWorldData against null/undefined with `?? {}`', () => {
+    // null/undefined だと JSON.stringify(undefined) === undefined → template literal で
+    // literal "undefined" が prompt に embed される regression を防ぐ。
+    expect(source).toContain('sanitizeForPrompt(updatedWorldData ?? {})');
+  });
+});

--- a/server/services/worldService.ts
+++ b/server/services/worldService.ts
@@ -61,6 +61,14 @@ const worldSchema = {
 
 export const updateWorldData = async (chatHistory: ChatMessage[], currentWorldData: any | null, intent: 'consult' | 'update') => {
     const client = getAiClient();
+
+    // 空履歴ガード: characterService.updateCharacterData の P2 ガードと対称化
+    // (code-review #133 で worldService 側に伝播漏れを検出)。line 85 の
+    // chatHistory[chatHistory.length - 1].text が undefined 参照で TypeError → 500 を防ぐ。
+    if (!Array.isArray(chatHistory) || chatHistory.length === 0) {
+        return { clarification_needed: 'どのような世界にしたいか、もう少し教えてください。' };
+    }
+
     const responseSchema = {
         type: Type.OBJECT,
         properties: {
@@ -134,7 +142,7 @@ JSONで返すこと：
 更新内容を踏まえて、コメントと補足を生成してください。
 
 【世界データ】
-${JSON.stringify(sanitizeForPrompt(updatedWorldData), null, 2)}
+${JSON.stringify(sanitizeForPrompt(updatedWorldData ?? {}), null, 2)}
 
 出力は JSON オブジェクト1つのみです。
 `;

--- a/server/services/worldService.ts
+++ b/server/services/worldService.ts
@@ -1,6 +1,7 @@
 import { Type, GenerateContentResponse } from '@google/genai';
 import { ChatMessage } from '../../types';
 import { getAiClient, TEXT_MODEL } from '../aiClient';
+import { sanitizeForPrompt } from '../utils/promptSafety';
 
 const systemInstruction = `
 You are a world-building assistant AI.
@@ -78,7 +79,7 @@ export const updateWorldData = async (chatHistory: ChatMessage[], currentWorldDa
 ${chatHistory.map(m => `${m.role === 'user' ? 'ユーザー' : 'AI'}: ${m.text}`).join('\n')}
 
 【現在の世界データ】
-${JSON.stringify(currentWorldData || {}, null, 2)}
+${JSON.stringify(sanitizeForPrompt(currentWorldData || {}), null, 2)}
 
 【ユーザーの意図】"${intent}"
 【最新のリクエスト】"${chatHistory[chatHistory.length - 1].text}"
@@ -133,7 +134,7 @@ JSONで返すこと：
 更新内容を踏まえて、コメントと補足を生成してください。
 
 【世界データ】
-${JSON.stringify(updatedWorldData, null, 2)}
+${JSON.stringify(sanitizeForPrompt(updatedWorldData), null, 2)}
 
 出力は JSON オブジェクト1つのみです。
 `;

--- a/server/utils/promptSafety.test.ts
+++ b/server/utils/promptSafety.test.ts
@@ -75,16 +75,33 @@ describe('stripPromptHeavyFields - whitelist 既知フィールド除去', () =>
 });
 
 describe('truncateOversizedStrings - size guard safety-net', () => {
-  it('truncates leaf string exceeding maxBytes', () => {
+  it('truncates leaf string exceeding maxBytes (ASCII = 1 byte/char)', () => {
     const data = { secret: 'X'.repeat(MAX_FIELD_BYTES + 1) };
     const out = truncateOversizedStrings(data) as typeof data;
     expect(out.secret).toBe(OVERSIZED_STRING_MARKER);
   });
 
-  it('keeps strings at exactly maxBytes intact (boundary)', () => {
+  it('keeps ASCII strings at exactly maxBytes intact (boundary)', () => {
     const data = { secret: 'X'.repeat(MAX_FIELD_BYTES) };
     const out = truncateOversizedStrings(data) as typeof data;
     expect(out.secret).toBe(data.secret);
+  });
+
+  it('measures Japanese (CJK) strings in UTF-8 bytes, not UTF-16 code units (code-review #133 fix)', () => {
+    // 日本語 BMP 文字は UTF-8 で 3 bytes / UTF-16 で 1 code unit。
+    // 30,000 文字 = UTF-8 90,000 bytes (< 100,000) → 素通し
+    // 40,000 文字 = UTF-8 120,000 bytes (> 100,000) → truncate
+    const safeJa = { text: 'あ'.repeat(30_000) };
+    const overJa = { text: 'あ'.repeat(40_000) };
+    expect((truncateOversizedStrings(safeJa) as typeof safeJa).text).toBe(safeJa.text);
+    expect((truncateOversizedStrings(overJa) as typeof overJa).text).toBe(OVERSIZED_STRING_MARKER);
+  });
+
+  it('measures emoji (surrogate pair) strings correctly in UTF-8 bytes', () => {
+    // 絵文字 surrogate pair は UTF-16 で 2 code unit / UTF-8 で 4 bytes。
+    // 30,000 emoji = UTF-8 120,000 bytes → truncate (旧実装の length=60,000 では素通し)
+    const overEmoji = { text: '🎉'.repeat(30_000) };
+    expect((truncateOversizedStrings(overEmoji) as typeof overEmoji).text).toBe(OVERSIZED_STRING_MARKER);
   });
 
   it('recurses into nested objects and arrays', () => {
@@ -124,25 +141,25 @@ describe('observability (silent fail paired signal)', () => {
     warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
   });
 
-  it('emits warn log with path + bytes when dataURI is stripped', () => {
+  it('emits warn log with path + UTF-8 bytes when dataURI is stripped', () => {
     const big = `data:image/png;base64,${'A'.repeat(1000)}`;
     stripPromptHeavyFields({ appearance: { imageUrl: big } });
     expect(warnSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         safetyEvent: 'image-omitted',
         path: 'appearance.imageUrl',
-        bytes: big.length,
+        bytes: Buffer.byteLength(big, 'utf8'),
       })
     );
   });
 
-  it('emits warn log with bytes + maxBytes when string is truncated', () => {
+  it('emits warn log with UTF-8 bytes + maxBytes when string is truncated', () => {
     const big = 'X'.repeat(MAX_FIELD_BYTES + 1);
     truncateOversizedStrings({ unknownField: big });
     expect(warnSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         safetyEvent: 'oversized-truncated',
-        bytes: big.length,
+        bytes: Buffer.byteLength(big, 'utf8'),
         maxBytes: MAX_FIELD_BYTES,
       })
     );

--- a/server/utils/promptSafety.test.ts
+++ b/server/utils/promptSafety.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { logger } from './logger';
+import {
+  IMAGE_OMITTED_MARKER,
+  OVERSIZED_STRING_MARKER,
+  MAX_FIELD_BYTES,
+  stripPromptHeavyFields,
+  truncateOversizedStrings,
+  sanitizeForPrompt,
+} from './promptSafety';
+
+describe('stripPromptHeavyFields - whitelist 既知フィールド除去', () => {
+  it('replaces character appearance.imageUrl dataURI with marker', () => {
+    const big = `data:image/png;base64,${'A'.repeat(1_000_000)}`;
+    const data = { name: 'Alice', appearance: { imageUrl: big, traits: [{ key: '髪', value: '金' }] } };
+    const out = stripPromptHeavyFields(data) as typeof data;
+    expect(out.appearance.imageUrl).toBe(IMAGE_OMITTED_MARKER);
+    expect(out.appearance.traits).toEqual([{ key: '髪', value: '金' }]);
+    expect(out.name).toBe('Alice');
+  });
+
+  it('replaces world mapImageUrl dataURI with marker', () => {
+    const big = `data:image/jpeg;base64,${'B'.repeat(500_000)}`;
+    const data = { name: '王国', mapImageUrl: big, exportDescription: '広大な大陸' };
+    const out = stripPromptHeavyFields(data) as typeof data;
+    expect(out.mapImageUrl).toBe(IMAGE_OMITTED_MARKER);
+    expect(out.name).toBe('王国');
+    expect(out.exportDescription).toBe('広大な大陸');
+  });
+
+  it('handles both character and world fields simultaneously (safe no-op if absent)', () => {
+    const both = {
+      appearance: { imageUrl: 'data:image/png;base64,XYZ' },
+      mapImageUrl: 'data:image/png;base64,QQQ',
+    };
+    const out = stripPromptHeavyFields(both) as typeof both;
+    expect(out.appearance.imageUrl).toBe(IMAGE_OMITTED_MARKER);
+    expect(out.mapImageUrl).toBe(IMAGE_OMITTED_MARKER);
+  });
+
+  it('keeps non-dataURI URLs intact (http URL passes through)', () => {
+    const data = {
+      appearance: { imageUrl: 'https://cdn.example.com/a.png' },
+      mapImageUrl: 'https://maps.example.com/world.png',
+    };
+    const out = stripPromptHeavyFields(data) as typeof data;
+    expect(out.appearance.imageUrl).toBe('https://cdn.example.com/a.png');
+    expect(out.mapImageUrl).toBe('https://maps.example.com/world.png');
+  });
+
+  it('returns null/undefined/primitive unchanged', () => {
+    expect(stripPromptHeavyFields(null)).toBe(null);
+    expect(stripPromptHeavyFields(undefined)).toBe(undefined);
+    expect(stripPromptHeavyFields('hello')).toBe('hello');
+    expect(stripPromptHeavyFields(42)).toBe(42);
+  });
+
+  it('does not mutate input (immutability)', () => {
+    const big = `data:image/png;base64,${'A'.repeat(100)}`;
+    const data = { appearance: { imageUrl: big, traits: [{ key: 'k', value: 'v' }] }, mapImageUrl: big };
+    const snapshot = JSON.stringify(data);
+    stripPromptHeavyFields(data);
+    expect(JSON.stringify(data)).toBe(snapshot);
+  });
+
+  it('returns same reference when no changes needed (perf hint)', () => {
+    const data = { name: 'Alice', appearance: { imageUrl: 'https://x' } };
+    expect(stripPromptHeavyFields(data)).toBe(data);
+  });
+
+  it('gracefully handles missing nested object (appearance absent)', () => {
+    const data = { name: 'Alice', personality: 'gentle' };
+    expect(stripPromptHeavyFields(data)).toEqual(data);
+  });
+});
+
+describe('truncateOversizedStrings - size guard safety-net', () => {
+  it('truncates leaf string exceeding maxBytes', () => {
+    const data = { secret: 'X'.repeat(MAX_FIELD_BYTES + 1) };
+    const out = truncateOversizedStrings(data) as typeof data;
+    expect(out.secret).toBe(OVERSIZED_STRING_MARKER);
+  });
+
+  it('keeps strings at exactly maxBytes intact (boundary)', () => {
+    const data = { secret: 'X'.repeat(MAX_FIELD_BYTES) };
+    const out = truncateOversizedStrings(data) as typeof data;
+    expect(out.secret).toBe(data.secret);
+  });
+
+  it('recurses into nested objects and arrays', () => {
+    const big = 'Z'.repeat(MAX_FIELD_BYTES + 1);
+    const data = {
+      list: [{ note: big }],
+      nested: { deep: { value: big } },
+    };
+    const out = truncateOversizedStrings(data) as typeof data;
+    expect(out.list[0].note).toBe(OVERSIZED_STRING_MARKER);
+    expect(out.nested.deep.value).toBe(OVERSIZED_STRING_MARKER);
+  });
+
+  it('respects custom maxBytes argument', () => {
+    const data = { value: 'abcdef' };
+    const out = truncateOversizedStrings(data, 3) as typeof data;
+    expect(out.value).toBe(OVERSIZED_STRING_MARKER);
+  });
+
+  it('returns same reference when no truncation needed', () => {
+    const data = { name: 'Alice', personality: 'gentle' };
+    expect(truncateOversizedStrings(data)).toBe(data);
+  });
+
+  it('does not mutate input', () => {
+    const big = 'X'.repeat(MAX_FIELD_BYTES + 1);
+    const data = { secret: big };
+    const snapshot = data.secret;
+    truncateOversizedStrings(data);
+    expect(data.secret).toBe(snapshot);
+  });
+});
+
+describe('observability (silent fail paired signal)', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+  });
+
+  it('emits warn log with path + bytes when dataURI is stripped', () => {
+    const big = `data:image/png;base64,${'A'.repeat(1000)}`;
+    stripPromptHeavyFields({ appearance: { imageUrl: big } });
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        safetyEvent: 'image-omitted',
+        path: 'appearance.imageUrl',
+        bytes: big.length,
+      })
+    );
+  });
+
+  it('emits warn log with bytes + maxBytes when string is truncated', () => {
+    const big = 'X'.repeat(MAX_FIELD_BYTES + 1);
+    truncateOversizedStrings({ unknownField: big });
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        safetyEvent: 'oversized-truncated',
+        bytes: big.length,
+        maxBytes: MAX_FIELD_BYTES,
+      })
+    );
+  });
+
+  it('does NOT log when nothing is sanitized (no-op case)', () => {
+    stripPromptHeavyFields({ name: 'Alice', appearance: { imageUrl: 'https://example.com/a.png' } });
+    truncateOversizedStrings({ name: 'Alice', personality: 'gentle' });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('sanitizeForPrompt - composite (whitelist + size guard)', () => {
+  it('applies whitelist FIRST then size guard (dataURI gets image marker, not oversized marker)', () => {
+    const big = `data:image/png;base64,${'A'.repeat(MAX_FIELD_BYTES + 1000)}`;
+    const data = { appearance: { imageUrl: big } };
+    const out = sanitizeForPrompt(data) as typeof data;
+    expect(out.appearance.imageUrl).toBe(IMAGE_OMITTED_MARKER);
+  });
+
+  it('catches unknown-field oversized strings via size guard (defense-in-depth)', () => {
+    const data = { unknownNewField: 'Q'.repeat(MAX_FIELD_BYTES + 1) };
+    const out = sanitizeForPrompt(data) as typeof data;
+    expect(out.unknownNewField).toBe(OVERSIZED_STRING_MARKER);
+  });
+
+  it('preserves normal-sized data without modification', () => {
+    const data = {
+      name: 'Alice',
+      personality: 'gentle and bookish',
+      appearance: { imageUrl: 'https://cdn.example.com/a.png', traits: [{ key: '髪', value: '金' }] },
+    };
+    expect(sanitizeForPrompt(data)).toEqual(data);
+  });
+
+  it('end-to-end: realistic character with 1MB image produces compact output', () => {
+    const big = `data:image/png;base64,${'A'.repeat(1_000_000)}`;
+    const data = {
+      name: 'Alice',
+      personality: '明るい',
+      appearance: { imageUrl: big, traits: [{ key: '髪', value: '金' }] },
+    };
+    const serialized = JSON.stringify(sanitizeForPrompt(data));
+    expect(serialized.length).toBeLessThan(1_000);
+    expect(serialized).toContain(IMAGE_OMITTED_MARKER);
+  });
+});

--- a/server/utils/promptSafety.ts
+++ b/server/utils/promptSafety.ts
@@ -27,9 +27,14 @@ export const OVERSIZED_STRING_MARKER = '[oversized-string: truncated to fit toke
 /**
  * 単一 leaf string の最大バイト数 (UTF-8)。これを超えると `OVERSIZED_STRING_MARKER` に置換。
  *
- * 100KB は通常の小説 1 章分 (約 50,000 漢字) に相当。AI コンテキストとして 1 フィールドが
+ * 100KB は通常の小説 1 章分 (約 30,000 漢字) に相当。AI コンテキストとして 1 フィールドが
  * これを超えるのは画像 dataURI 等の異常入力のみで、通常テキスト (longDescription / personality
  * 等) には十分余裕がある (false positive 実質ゼロ)。
+ *
+ * 計測は `Buffer.byteLength(s, 'utf8')` で UTF-8 実バイト数を見る。`String.length` だと
+ * UTF-16 code unit ベースになり、日本語 (CJK BMP) は 3 倍緩く / 絵文字 (surrogate pair) は
+ * 2 倍厳しく評価される (code-review #133 指摘)。本プロジェクトは日本語アプリのため、
+ * 真の token-bomb 防御として UTF-8 byte で評価する必要がある。
  */
 export const MAX_FIELD_BYTES = 100_000;
 
@@ -60,12 +65,12 @@ function replaceDataUriAtPath(input: Record<string, unknown>, path: string): Rec
 
   // 観測可能性 (silent fail paired signal): 本番障害再発の早期検知のため、
   // sanitize 発火を必ず構造化ログに残す。message body は marker 自身を含めず
-  // metric 集計に必要な path / bytes のみ。
+  // metric 集計に必要な path / bytes (UTF-8 実バイト数) のみ。
   logger.warn({
     message: 'promptSafety: image dataURI stripped',
     safetyEvent: 'image-omitted',
     path,
-    bytes: leafValue.length,
+    bytes: Buffer.byteLength(leafValue, 'utf8'),
   });
 
   // 不変性のため path に沿って必要な階層だけ新しいオブジェクトに置換する。
@@ -101,22 +106,23 @@ export function stripPromptHeavyFields(data: unknown): unknown {
 }
 
 /**
- * 任意 leaf string の size guard。再帰的に object / array を辿り、length が maxBytes を
+ * 任意 leaf string の size guard。再帰的に object / array を辿り、UTF-8 byte 長が maxBytes を
  * 超える string を `OVERSIZED_STRING_MARKER` に置換する。
  *
  * whitelist (stripPromptHeavyFields) で取り切れない未知フィールド・将来追加フィールド・
- * SVG dataURI 等のセーフティネット。length 判定は文字単位 (JavaScript の String.length)
- * で行う — UTF-16 code unit ベースだが、実用上 byte count と桁が一致する。
+ * SVG dataURI 等のセーフティネット。サイズ判定は `Buffer.byteLength(s, 'utf8')` で行う
+ * (`String.length` は UTF-16 code unit ベースで、日本語/絵文字混在下で評価がブレる)。
  *
  * 不変性: 入力を mutate しない。
  */
 export function truncateOversizedStrings(data: unknown, maxBytes: number = MAX_FIELD_BYTES): unknown {
   if (typeof data === 'string') {
-    if (data.length > maxBytes) {
+    const utf8Bytes = Buffer.byteLength(data, 'utf8');
+    if (utf8Bytes > maxBytes) {
       logger.warn({
         message: 'promptSafety: oversized string truncated',
         safetyEvent: 'oversized-truncated',
-        bytes: data.length,
+        bytes: utf8Bytes,
         maxBytes,
       });
       return OVERSIZED_STRING_MARKER;

--- a/server/utils/promptSafety.ts
+++ b/server/utils/promptSafety.ts
@@ -1,0 +1,156 @@
+import { logger } from './logger';
+
+/**
+ * AI プロンプトに埋め込むユーザー入力データの token-bomb 対策ヘルパー。
+ *
+ * 背景: 2026-06-01 本番障害 (`character/update` が 917,455 tokens で 400 INVALID_ARGUMENT、
+ * Gemini 2.5 Flash の入力上限 131,072 を超過)。原因は PR #125 の `<RUNTIME_CONTEXT>` 設計で
+ * `currentCharacterData` 全体を JSON.stringify したことで、`appearance.imageUrl` に保存された
+ * Imagen 生成画像 (`data:image/png;base64,...` 約 1MB) がプロンプトに丸ごと埋まったため。
+ *
+ * 同種パターンが world (`mapImageUrl` 経由) にも存在し、character/reply にも未対策の経路が
+ * 残っていた (Codex セカンドオピニオン指摘)。本モジュールで一元化する。
+ *
+ * 防御戦略 (Codex 推奨の案 C):
+ *   1. 既知フィールド名 + `data:` prefix の **whitelist** 除去 (確実な既知パスを断つ)
+ *   2. 任意 leaf string の **size guard** (将来の未知フィールド・SVG dataURI 等のセーフティネット)
+ *
+ * 引数は mutate しない (pure helpers)。
+ */
+
+/** AI プロンプトから除外された生成画像の代替マーカー。AI に「画像が存在する」事実だけ伝える。 */
+export const IMAGE_OMITTED_MARKER = '[generated-image: omitted from prompt to fit token budget]';
+
+/** size guard で truncate した文字列の代替マーカー。 */
+export const OVERSIZED_STRING_MARKER = '[oversized-string: truncated to fit token budget]';
+
+/**
+ * 単一 leaf string の最大バイト数 (UTF-8)。これを超えると `OVERSIZED_STRING_MARKER` に置換。
+ *
+ * 100KB は通常の小説 1 章分 (約 50,000 漢字) に相当。AI コンテキストとして 1 フィールドが
+ * これを超えるのは画像 dataURI 等の異常入力のみで、通常テキスト (longDescription / personality
+ * 等) には十分余裕がある (false positive 実質ゼロ)。
+ */
+export const MAX_FIELD_BYTES = 100_000;
+
+/**
+ * 「ここに画像 dataURI が入りうる」既知フィールドの dot-path。
+ * 新規フィールド追加時はここに足すだけで character / world / 他 service 全てに適用される。
+ */
+const IMAGE_FIELD_PATHS: readonly string[] = [
+  'appearance.imageUrl', // character: Imagen 生成
+  'mapImageUrl', // world: ユーザーアップロード or 生成
+];
+
+/**
+ * dot-path で指定されたフィールドに `data:` で始まる文字列があれば omission marker に置換。
+ * 引数 mutate なし。path 途中が object でない場合は no-op (型不一致 safe)。
+ */
+function replaceDataUriAtPath(input: Record<string, unknown>, path: string): Record<string, unknown> {
+  const segments = path.split('.');
+  let cursor: unknown = input;
+  for (let i = 0; i < segments.length - 1; i++) {
+    if (!cursor || typeof cursor !== 'object') return input;
+    cursor = (cursor as Record<string, unknown>)[segments[i]];
+  }
+  if (!cursor || typeof cursor !== 'object') return input;
+  const leafKey = segments[segments.length - 1];
+  const leafValue = (cursor as Record<string, unknown>)[leafKey];
+  if (typeof leafValue !== 'string' || !leafValue.startsWith('data:')) return input;
+
+  // 観測可能性 (silent fail paired signal): 本番障害再発の早期検知のため、
+  // sanitize 発火を必ず構造化ログに残す。message body は marker 自身を含めず
+  // metric 集計に必要な path / bytes のみ。
+  logger.warn({
+    message: 'promptSafety: image dataURI stripped',
+    safetyEvent: 'image-omitted',
+    path,
+    bytes: leafValue.length,
+  });
+
+  // 不変性のため path に沿って必要な階層だけ新しいオブジェクトに置換する。
+  function setAtPath(obj: Record<string, unknown>, depth: number): Record<string, unknown> {
+    const key = segments[depth];
+    if (depth === segments.length - 1) {
+      return { ...obj, [key]: IMAGE_OMITTED_MARKER };
+    }
+    const child = obj[key];
+    if (!child || typeof child !== 'object') return obj;
+    return { ...obj, [key]: setAtPath(child as Record<string, unknown>, depth + 1) };
+  }
+  return setAtPath(input, 0);
+}
+
+/**
+ * 既知の画像 dataURI フィールド (whitelist) を omission marker に置換する。
+ * character の `appearance.imageUrl` と world の `mapImageUrl` を一度に処理。
+ * 不変性: 入力を mutate せず、影響パスのみ新オブジェクトに差し替える。
+ */
+export function stripPromptHeavyFields(data: unknown): unknown {
+  if (!data || typeof data !== 'object') return data;
+  let result = data as Record<string, unknown>;
+  let changed = false;
+  for (const path of IMAGE_FIELD_PATHS) {
+    const replaced = replaceDataUriAtPath(result, path);
+    if (replaced !== result) {
+      changed = true;
+      result = replaced;
+    }
+  }
+  return changed ? result : data;
+}
+
+/**
+ * 任意 leaf string の size guard。再帰的に object / array を辿り、length が maxBytes を
+ * 超える string を `OVERSIZED_STRING_MARKER` に置換する。
+ *
+ * whitelist (stripPromptHeavyFields) で取り切れない未知フィールド・将来追加フィールド・
+ * SVG dataURI 等のセーフティネット。length 判定は文字単位 (JavaScript の String.length)
+ * で行う — UTF-16 code unit ベースだが、実用上 byte count と桁が一致する。
+ *
+ * 不変性: 入力を mutate しない。
+ */
+export function truncateOversizedStrings(data: unknown, maxBytes: number = MAX_FIELD_BYTES): unknown {
+  if (typeof data === 'string') {
+    if (data.length > maxBytes) {
+      logger.warn({
+        message: 'promptSafety: oversized string truncated',
+        safetyEvent: 'oversized-truncated',
+        bytes: data.length,
+        maxBytes,
+      });
+      return OVERSIZED_STRING_MARKER;
+    }
+    return data;
+  }
+  if (Array.isArray(data)) {
+    let changed = false;
+    const next = data.map((item) => {
+      const replaced = truncateOversizedStrings(item, maxBytes);
+      if (replaced !== item) changed = true;
+      return replaced;
+    });
+    return changed ? next : data;
+  }
+  if (data && typeof data === 'object') {
+    const obj = data as Record<string, unknown>;
+    let changed = false;
+    const next: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(obj)) {
+      const replaced = truncateOversizedStrings(v, maxBytes);
+      if (replaced !== v) changed = true;
+      next[k] = replaced;
+    }
+    return changed ? next : data;
+  }
+  return data;
+}
+
+/**
+ * AI プロンプトに埋め込む直前にユーザー入力データを sanitize するメイン関数。
+ * whitelist 除去 → size guard の順で適用する (whitelist 適用後の dataURI は既にマーカー化されており、
+ * size guard が同じ場所を二重処理することはない)。
+ */
+export function sanitizeForPrompt(data: unknown, maxBytes: number = MAX_FIELD_BYTES): unknown {
+  return truncateOversizedStrings(stripPromptHeavyFields(data), maxBytes);
+}


### PR DESCRIPTION
## Summary

PR #132 (character/update のみ修正) の続編。Codex セカンドオピニオン (案 C 推奨) + Evaluator 第三者評価で判明した残存リスクへの追加対応。

- **world/update + world/reply**: `mapImageUrl` 経由バグ予備軍 (WorldForm.tsx:495 で dataURI が確実に入る運用)
- **character/reply**: `updatedCharacterData` + `appliedPatch` の未対策経路 (Codex Q3 指摘)
- **size guard**: 未知フィールド・将来追加・SVG dataURI 等への defense-in-depth (Codex Q1 案 C)
- **observability**: sanitize 発火時の構造化 warn ログ (memory `feedback_silent_fail_paired_signal` 規律)

## 設計

### 共通 sanitizer 抽出 (`server/utils/promptSafety.ts` 新規)

| 関数 | 役割 |
|---|---|
| `stripPromptHeavyFields` | whitelist 列挙 (`appearance.imageUrl` + `mapImageUrl`) で `data:` prefix を `IMAGE_OMITTED_MARKER` に置換 |
| `truncateOversizedStrings` | 任意 leaf string で >100KB を `OVERSIZED_STRING_MARKER` に置換 (safety-net) |
| `sanitizeForPrompt` | 上記 composite (主要 export) |

全 helper は immutable / pure。変更ありの path のみ shallow copy で差し替え。

### 適用範囲 (4 経路全カバー)

| 経路 | sanitize 対象 |
|---|---|
| `character/update` (`buildCharacterContents`) | `currentCharacterData` |
| `character/reply` (`generateCharacterReply`) | `updatedCharacterData` + `appliedPatch` |
| `world/update` (`updateWorldData`) | `currentWorldData` |
| `world/reply` (`generateWorldReply`) | `updatedWorldData` |

`analysisService` は id/name のみ要約のため既に安全 (改変不要)。

### Observability (silent fail paired signal)

sanitize 発火時に `logger.warn` で構造化ログ:

```json
{ \"severity\": \"WARNING\", \"message\": \"promptSafety: image dataURI stripped\",
  \"safetyEvent\": \"image-omitted\", \"path\": \"appearance.imageUrl\", \"bytes\": 123456 }
```

本番 Cloud Logging で `safetyEvent` フィルタリング → 再発・新規発火を即時検知可能。

### 後方互換

`characterPrompt.ts` の旧 `stripPromptHeavyFields` / `IMAGE_OMITTED_MARKER` は utils から re-export し、既存 import 経路を維持。PR #132 のテスト 18 件は無改変で pass。

## 検証

- [x] `npx vitest run server/utils/promptSafety.test.ts` → 21 passed (新規)
- [x] `npx vitest run` 全体 → 536 passed / 5 skipped (+21 vs PR #132 後)
- [x] `npm run lint` (tsc --noEmit) → 0 error
- [x] Codex セカンドオピニオン (gpt-5 default model, read-only) → 3 Q 全て対応方針確定
- [x] Evaluator subagent 第三者評価 → 全 AC (1〜8) PASS、追加修正不要判定
- [ ] マージ後 Cloud Run dev に反映、画像付きキャラ + マップ画像付き world で実機リプレイ
- [ ] Cloud Logging で `jsonPayload.safetyEvent` を検索し、本番ユーザーで発火する path を観測

## Evaluator が指摘した残存懸念 (本 PR スコープ外、別途記録)

- LOW: `worldService.ts:79` の chatHistory `\${m.text}` は sanitize 経由しない (本番障害の直接経路外、size guard で leaf string が捕まる射程)
- LOW: `replaceDataUriAtPath` の `setAtPath` が将来の配列中間パス追加 (例: `items.0.imageUrl`) に未対応 (現 2 パスでは発生せず、追加時に保守者が踏むリスク)
- LOW: `characterPrompt.ts` 経由の `stripPromptHeavyFields` re-export は値スナップショット (live re-export ではない、文字列定数のため実害なし)

## 関連

- 直前 PR: #132 (`f83c073`、character/update のみ修正)
- 真因混入 PR: #125 (`e2bd6ae`、マルチターン化で `currentCharacterData` 全体 embed 設計)
- セカンドオピニオン: Codex MCP (gpt-5)、Evaluator subagent (claude)

🤖 Generated with [Claude Code](https://claude.com/claude-code)