### PR TITLE
fix(prompt-safety): MIN_IMAGE_DATA_URI_BYTES を 100 → 500 に引き上げ (Refs #137 #2)

### DIFF
--- a/server/utils/promptSafety.test.ts
+++ b/server/utils/promptSafety.test.ts
@@ -77,12 +77,13 @@ describe('stripPromptHeavyFields - content-based 画像 dataURI 検出 (Issue #1
   });
 
   it('detects multiple image variants (png / jpeg / webp / svg+xml / gif)', () => {
+    // payload は MIN_IMAGE_DATA_URI_BYTES (500) を超える必要があるため 600 chars に統一。
     const variants = [
-      `data:image/png;base64,${'A'.repeat(200)}`,
-      `data:image/jpeg;base64,${'B'.repeat(200)}`,
-      `data:image/webp;base64,${'C'.repeat(200)}`,
-      `data:image/svg+xml;base64,${'D'.repeat(200)}`,
-      `data:image/gif;base64,${'E'.repeat(200)}`,
+      `data:image/png;base64,${'A'.repeat(600)}`,
+      `data:image/jpeg;base64,${'B'.repeat(600)}`,
+      `data:image/webp;base64,${'C'.repeat(600)}`,
+      `data:image/svg+xml;base64,${'D'.repeat(600)}`,
+      `data:image/gif;base64,${'E'.repeat(600)}`,
     ];
     for (const v of variants) {
       const out = stripPromptHeavyFields({ field: v }) as { field: string };
@@ -107,7 +108,7 @@ describe('stripPromptHeavyFields - content-based 画像 dataURI 検出 (Issue #1
 
   it('does NOT replace short strings that incidentally start with "data:image/" (false positive guard)', () => {
     // ナレッジ等に「`data:image/png` という形式の文字列」が短文として含まれる可能性。
-    // 100 bytes 未満は素通し (real dataURI は base64 payload で必ず数百 bytes 以上)。
+    // 500 bytes 未満は素通し (Issue #137 #2 で 100 → 500 へ引き上げ、cumulative bypass 縮小)。
     const data = {
       knowledge: 'data:image/png は base64 形式',
       hint: 'data:image/jpeg;base64,QQ==', // 構文的には有効だが極小
@@ -115,6 +116,33 @@ describe('stripPromptHeavyFields - content-based 画像 dataURI 検出 (Issue #1
     const out = stripPromptHeavyFields(data) as typeof data;
     expect(out.knowledge).toBe('data:image/png は base64 形式');
     expect(out.hint).toBe('data:image/jpeg;base64,QQ==');
+  });
+
+  // === Issue #137 #2: 境界値テスト (MIN_IMAGE_DATA_URI_BYTES = 500) ===
+
+  it('boundary: dataURI of exactly MIN_IMAGE_DATA_URI_BYTES bytes IS replaced', () => {
+    // prefix `data:image/png;base64,` = 22 bytes, payload 478 bytes → total 500 bytes ちょうど。
+    // 仕様 `>= MIN_IMAGE_DATA_URI_BYTES` で marker 化される。
+    const exactlyMin = `data:image/png;base64,${'A'.repeat(478)}`;
+    expect(Buffer.byteLength(exactlyMin, 'utf8')).toBe(500);
+    const out = stripPromptHeavyFields({ field: exactlyMin }) as { field: string };
+    expect(out.field).toBe(IMAGE_OMITTED_MARKER);
+  });
+
+  it('boundary: dataURI 1 byte below MIN_IMAGE_DATA_URI_BYTES passes through unchanged', () => {
+    // 499 bytes = prefix 22 + payload 477 → 素通し。
+    const justBelow = `data:image/png;base64,${'A'.repeat(477)}`;
+    expect(Buffer.byteLength(justBelow, 'utf8')).toBe(499);
+    const out = stripPromptHeavyFields({ field: justBelow }) as { field: string };
+    expect(out.field).toBe(justBelow);
+  });
+
+  it('boundary: dataURI 1 byte above MIN_IMAGE_DATA_URI_BYTES IS replaced', () => {
+    // 501 bytes = prefix 22 + payload 479 → marker 化される。
+    const justAbove = `data:image/png;base64,${'A'.repeat(479)}`;
+    expect(Buffer.byteLength(justAbove, 'utf8')).toBe(501);
+    const out = stripPromptHeavyFields({ field: justAbove }) as { field: string };
+    expect(out.field).toBe(IMAGE_OMITTED_MARKER);
   });
 
   it('returns null/undefined/primitive unchanged', () => {
@@ -167,8 +195,9 @@ describe('stripPromptHeavyFields - content-based 画像 dataURI 検出 (Issue #1
     // Simulate JSON.parse output where __proto__ is an own enumerable property
     // (Object.defineProperty is needed because object literal `{ __proto__: ... }` uses the setter,
     // not creating an own property; JSON.parse however does create the own property).
+    // appearance.imageUrl payload は MIN_IMAGE_DATA_URI_BYTES (500) を超える必要があるため 600 chars。
     const malicious: Record<string, unknown> = JSON.parse(
-      '{"__proto__":{"polluted":true},"name":"Alice","appearance":{"imageUrl":"data:image/png;base64,' + 'A'.repeat(200) + '"}}'
+      '{"__proto__":{"polluted":true},"name":"Alice","appearance":{"imageUrl":"data:image/png;base64,' + 'A'.repeat(600) + '"}}'
     );
     const out = stripPromptHeavyFields(malicious) as Record<string, unknown>;
 

--- a/server/utils/promptSafety.ts
+++ b/server/utils/promptSafety.ts
@@ -49,10 +49,18 @@ const IMAGE_DATA_URI_PREFIX = 'data:image/';
 
 /**
  * false positive 防止: この byte 長未満の `data:image/` 始まり文字列は素通しする。
+ *
  * 理由: ナレッジや description に「`data:image/png` という形式の文字列」が短文として
- * 含まれる可能性があるため。実 dataURI は base64 payload で必ず数百〜数千 bytes 以上。
+ * 含まれる可能性があるため。実 dataURI は base64 payload で必ず数百〜数千 bytes 以上で、
+ * 500B 未満では pixel 数十個レベルの絵にしかならず実用画像にはならない (1×1 transparent
+ * GIF が ~78 bytes だが、実プロダクトデータには登場しない極限値)。
+ *
+ * 100 → 500 への引き上げ (Issue #137 #2): 99B 弱の `data:image/...` を array で多数並べる
+ * cumulative token-bomb の bypass 帯域を 99B/個 → 499B/個 に狭め、同じ累積 token 量を
+ * 出すために必要な array 要素数を ~5 倍に押し上げる。size guard backstop (MAX_FIELD_BYTES)
+ * との 200 倍 gap を維持しつつ false positive ゼロを保つ妥協点。
  */
-const MIN_IMAGE_DATA_URI_BYTES = 100;
+const MIN_IMAGE_DATA_URI_BYTES = 500;
 
 /**
  * 再帰の深さ上限。これを超えるネストは `OVERSIZED_STRING_MARKER` 相当に置換して終端する。


### PR DESCRIPTION
## Summary

- Issue #137 #2 (cumulative token-bomb bypass) の部分対応として、content-based 検出の最小閾値を **100 → 500 bytes** に引き上げ
- 99B array bypass の帯域を 99B → 499B/個 に狭め、同じ累積 token 量を出すのに必要な array 要素数を ~5 倍に押し上げる
- false positive ゼロを維持 (実 dataURI は base64 payload で必ず数百〜数千 bytes 以上、500B 未満は実プロダクトに登場しない pixel 数十個レベルの極限値)

## 変更点

- `MIN_IMAGE_DATA_URI_BYTES`: 100 → 500
- JSDoc に Issue #137 #2 の意図と false positive ゼロの根拠を追記
- 既存テスト 2 件の payload を 200 → 500+ chars に調整 (variants test / prototype pollution test)
- **境界値テスト 3 件追加** (499B / 500B / 501B) — CLAUDE.md Test First「境界値 (最小/最大/±1) を必ず含める」要件に対応

## Test plan

- [x] `npm run test -- server/utils/promptSafety.test.ts` (35 件 PASS)
- [x] `npm run test` 全件 (555 件 PASS / 5 skipped、旧 552 → 555)
- [x] `npm run lint` (tsc 0 errors)
- [ ] マージ後 dev デプロイで Cloud Logging に `safetyEvent: image-omitted` がいつも通り発火することを確認 (閾値変更後の regression check)

## Issue #137 の残り (open 維持)

部分対応のため Issue #137 は close しません。残り:
- **#137 #1** non-image dataURI gap (PDF/audio dataURI 100B-100KB 帯素通し)
- **#137 #3** log amplification (warn 発火数上限なし)

Refs #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)