### PR TITLE
fix(prompt-safety): per-call warn aggregation で log amplification を抑制 (Refs #137 #3)

### DIFF
--- a/server/utils/promptSafety.test.ts
+++ b/server/utils/promptSafety.test.ts
@@ -329,6 +329,84 @@ describe('observability (silent fail paired signal)', () => {
     truncateOversizedStrings({ name: 'Alice', personality: 'gentle' });
     expect(warnSpy).not.toHaveBeenCalled();
   });
+
+  // === Issue #137 #3: log amplification 対策 (per-call warn 集約) ===
+
+  it('emits individual warn for each finding when total ≤ MAX_WARN_PER_CALL (50)', () => {
+    // 50 個ちょうど = 全件個別 warn、集約 log 出ない (boundary 直下)。
+    const big = `data:image/png;base64,${'A'.repeat(600)}`;
+    const items = Array.from({ length: 50 }, () => ({ url: big }));
+    stripPromptHeavyFields({ gallery: items });
+    expect(warnSpy).toHaveBeenCalledTimes(50);
+    expect(warnSpy).not.toHaveBeenCalledWith(
+      expect.objectContaining({ safetyEvent: 'image-omitted-batch' })
+    );
+  });
+
+  it('suppresses individual warns and emits aggregate log when total > MAX_WARN_PER_CALL (boundary 51)', () => {
+    // 51 個 = 50 件個別 warn + 1 件集約 log (boundary 直上)。
+    const big = `data:image/png;base64,${'A'.repeat(600)}`;
+    const items = Array.from({ length: 51 }, () => ({ url: big }));
+    stripPromptHeavyFields({ gallery: items });
+    // 個別 image-omitted は 50 件で打ち止め
+    const individualCalls = warnSpy.mock.calls.filter(
+      (c) => (c[0] as { safetyEvent?: string }).safetyEvent === 'image-omitted'
+    );
+    expect(individualCalls).toHaveLength(50);
+    // 集約 log が 1 件出る
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        safetyEvent: 'image-omitted-batch',
+        totalCount: 51,
+        loggedCount: 50,
+        omittedCount: 1,
+      })
+    );
+  });
+
+  it('aggregate log carries accurate totalCount / omittedCount for large bursts (100 items)', () => {
+    const big = `data:image/png;base64,${'A'.repeat(600)}`;
+    const items = Array.from({ length: 100 }, () => ({ url: big }));
+    stripPromptHeavyFields({ gallery: items });
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        safetyEvent: 'image-omitted-batch',
+        totalCount: 100,
+        loggedCount: 50,
+        omittedCount: 50,
+      })
+    );
+  });
+
+  it('truncateOversizedStrings also aggregates oversized-truncated warns', () => {
+    // truncate 側も同じ pattern: 51 件超で集約 log。
+    const big = 'Y'.repeat(MAX_FIELD_BYTES + 1);
+    const items = Array.from({ length: 51 }, () => ({ note: big }));
+    truncateOversizedStrings({ list: items });
+    const individualCalls = warnSpy.mock.calls.filter(
+      (c) => (c[0] as { safetyEvent?: string }).safetyEvent === 'oversized-truncated'
+    );
+    expect(individualCalls).toHaveLength(50);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        safetyEvent: 'oversized-truncated-batch',
+        totalCount: 51,
+        loggedCount: 50,
+        omittedCount: 1,
+      })
+    );
+  });
+
+  it('boundary: exactly 49 items emits 49 individual warns and NO aggregate log', () => {
+    // 49 = 集約しきい値手前 -1
+    const big = `data:image/png;base64,${'A'.repeat(600)}`;
+    const items = Array.from({ length: 49 }, () => ({ url: big }));
+    stripPromptHeavyFields({ gallery: items });
+    expect(warnSpy).toHaveBeenCalledTimes(49);
+    expect(warnSpy).not.toHaveBeenCalledWith(
+      expect.objectContaining({ safetyEvent: 'image-omitted-batch' })
+    );
+  });
 });
 
 describe('sanitizeForPrompt - composite (whitelist + size guard)', () => {

--- a/server/utils/promptSafety.test.ts
+++ b/server/utils/promptSafety.test.ts
@@ -407,6 +407,71 @@ describe('observability (silent fail paired signal)', () => {
       expect.objectContaining({ safetyEvent: 'image-omitted-batch' })
     );
   });
+
+  // === Issue #137 #3 code-review CONFIRMED: depth-exceeded amplification も同 counter 対象 ===
+
+  /** depth > MAX_RECURSION_DEPTH を確実に踏む payload (1500 段ネスト object) */
+  function buildDeepChain(levels: number): Record<string, unknown> {
+    let node: Record<string, unknown> = { leaf: 'end' };
+    for (let i = 0; i < levels; i++) node = { a: node };
+    return node;
+  }
+
+  it('depth-exceeded warns are aggregated when total > MAX_WARN_PER_CALL (sibling × 51 deep chains)', () => {
+    // 51 個の sibling subtree が各々 depth 1001 超に到達 → 50 件個別 warn + 1 件 batch。
+    const deep = buildDeepChain(1500);
+    const payload: Record<string, unknown> = {};
+    for (let i = 0; i < 51; i++) payload[`sib${i}`] = deep;
+    stripPromptHeavyFields(payload);
+
+    const individualCalls = warnSpy.mock.calls.filter(
+      (c) => (c[0] as { safetyEvent?: string }).safetyEvent === 'recursion-depth-exceeded'
+    );
+    expect(individualCalls).toHaveLength(50);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        safetyEvent: 'recursion-depth-exceeded-batch',
+        totalCount: 51,
+        loggedCount: 50,
+        omittedCount: 1,
+      })
+    );
+  });
+
+  it('depth-exceeded boundary: 50 sibling deep chains emits 50 individual, NO batch', () => {
+    const deep = buildDeepChain(1500);
+    const payload: Record<string, unknown> = {};
+    for (let i = 0; i < 50; i++) payload[`sib${i}`] = deep;
+    stripPromptHeavyFields(payload);
+
+    const individualCalls = warnSpy.mock.calls.filter(
+      (c) => (c[0] as { safetyEvent?: string }).safetyEvent === 'recursion-depth-exceeded'
+    );
+    expect(individualCalls).toHaveLength(50);
+    expect(warnSpy).not.toHaveBeenCalledWith(
+      expect.objectContaining({ safetyEvent: 'recursion-depth-exceeded-batch' })
+    );
+  });
+
+  it('truncateOversizedStrings also aggregates recursion-depth-exceeded warns', () => {
+    const deep = buildDeepChain(1500);
+    const payload: Record<string, unknown> = {};
+    for (let i = 0; i < 51; i++) payload[`sib${i}`] = deep;
+    truncateOversizedStrings(payload);
+
+    const individualCalls = warnSpy.mock.calls.filter(
+      (c) => (c[0] as { safetyEvent?: string }).safetyEvent === 'recursion-depth-exceeded'
+    );
+    expect(individualCalls).toHaveLength(50);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        safetyEvent: 'recursion-depth-exceeded-batch',
+        totalCount: 51,
+        loggedCount: 50,
+        omittedCount: 1,
+      })
+    );
+  });
 });
 
 describe('sanitizeForPrompt - composite (whitelist + size guard)', () => {

--- a/server/utils/promptSafety.ts
+++ b/server/utils/promptSafety.ts
@@ -79,7 +79,7 @@ const MAX_RECURSION_DEPTH = 1000;
 export const RECURSION_DEPTH_EXCEEDED_MARKER = '[recursion-depth-exceeded: nested data truncated to fit safety limit]';
 
 /**
- * 単一 sanitize 呼出あたりの個別 warn ログ発火上限。これを超えると個別 warn を抑制し、
+ * 単一 sanitize 関数呼出あたりの個別 warn ログ発火上限。これを超えると個別 warn を抑制し、
  * 関数末尾で集約 log 1 件 (`*-batch`) に切替える。
  *
  * 理由 (Issue #137 #3): 旧 PR #136 の content-based 再帰スキャンは O(N leaves) で全 leaf に
@@ -90,6 +90,21 @@ export const RECURSION_DEPTH_EXCEEDED_MARKER = '[recursion-depth-exceeded: neste
  * 50 は通常の character / world データで発火する image-omitted 件数 (実用 0〜2 件) に十分
  * 余裕があり、攻撃 amplification 上限としても観測上の代表性 (最初の 50 件で path 分布が
  * 十分わかる) を保つ妥協点。
+ *
+ * ## 量的上限 (1 sanitize 関数呼出 vs 1 sanitizeForPrompt 呼出 vs 1 HTTP request)
+ *
+ * - **1 関数呼出 (stripPromptHeavyFields or truncateOversizedStrings)**:
+ *   - image-omitted 個別 ≤ 50 件 + image-omitted-batch 1 件
+ *   - recursion-depth-exceeded 個別 ≤ 50 件 + recursion-depth-exceeded-batch 1 件
+ *   - 合計 ≤ 102 件
+ * - **1 `sanitizeForPrompt` 呼出**: 2 関数を直列に走らせるため最大 ≤ 204 件
+ *   - (stripPromptHeavyFields の depth-exceeded marker は短文なので truncate 側の oversized
+ *     経路は通常発火せず、実測上は ~100 件帯)
+ * - **1 HTTP request**: `character/reply` は `sanitizeForPrompt` を 2 回呼ぶため最大 ≤ 408 件
+ *
+ * いずれも旧 amplification 経路の数千〜数万件と比べ 1-2 桁削減。本上限は per-function-call
+ * での design であり per-request の構造的 cap ではない (per-request cap を求める場合は
+ * logger 側の rate-limited wrapper が altitude を上げる方向、Issue #137 で別途検討)。
  */
 const MAX_WARN_PER_CALL = 50;
 
@@ -137,17 +152,25 @@ function joinPath(parent: string, segment: string | number): string {
  */
 export function stripPromptHeavyFields(data: unknown): unknown {
   // Issue #137 #3: per-call warn 集約のためのカウンタ。closure で共有。
+  // image-omitted / recursion-depth-exceeded はそれぞれ独立カウンタで管理し、
+  // batch log の safetyEvent を分離して観測上明確にする (code-review #139 CONFIRMED 対応)。
   let totalCount = 0;
   let loggedCount = 0;
+  let depthExceededCount = 0;
+  let depthExceededLogged = 0;
 
   function recurse(value: unknown, path: string, depth: number): unknown {
     if (depth > MAX_RECURSION_DEPTH) {
-      logger.warn({
-        message: 'promptSafety: recursion depth exceeded',
-        safetyEvent: 'recursion-depth-exceeded',
-        path,
-        depth,
-      });
+      depthExceededCount++;
+      if (depthExceededLogged < MAX_WARN_PER_CALL) {
+        logger.warn({
+          message: 'promptSafety: recursion depth exceeded',
+          safetyEvent: 'recursion-depth-exceeded',
+          path,
+          depth,
+        });
+        depthExceededLogged++;
+      }
       return RECURSION_DEPTH_EXCEEDED_MARKER;
     }
     if (typeof value === 'string') {
@@ -202,6 +225,15 @@ export function stripPromptHeavyFields(data: unknown): unknown {
       omittedCount: totalCount - loggedCount,
     });
   }
+  if (depthExceededCount > MAX_WARN_PER_CALL) {
+    logger.warn({
+      message: 'promptSafety: recursion-depth-exceeded warn amplification suppressed',
+      safetyEvent: 'recursion-depth-exceeded-batch',
+      totalCount: depthExceededCount,
+      loggedCount: depthExceededLogged,
+      omittedCount: depthExceededCount - depthExceededLogged,
+    });
+  }
   return result;
 }
 
@@ -221,16 +253,24 @@ export function stripPromptHeavyFields(data: unknown): unknown {
  */
 export function truncateOversizedStrings(data: unknown, maxBytes: number = MAX_FIELD_BYTES): unknown {
   // Issue #137 #3: per-call warn 集約のためのカウンタ。closure で共有。
+  // oversized-truncated / recursion-depth-exceeded はそれぞれ独立カウンタで管理
+  // (code-review #139 CONFIRMED: depth-exceeded amplification も対称化)。
   let totalCount = 0;
   let loggedCount = 0;
+  let depthExceededCount = 0;
+  let depthExceededLogged = 0;
 
   function recurse(value: unknown, depth: number): unknown {
     if (depth > MAX_RECURSION_DEPTH) {
-      logger.warn({
-        message: 'promptSafety: recursion depth exceeded',
-        safetyEvent: 'recursion-depth-exceeded',
-        depth,
-      });
+      depthExceededCount++;
+      if (depthExceededLogged < MAX_WARN_PER_CALL) {
+        logger.warn({
+          message: 'promptSafety: recursion depth exceeded',
+          safetyEvent: 'recursion-depth-exceeded',
+          depth,
+        });
+        depthExceededLogged++;
+      }
       return RECURSION_DEPTH_EXCEEDED_MARKER;
     }
     if (typeof value === 'string') {
@@ -286,6 +326,15 @@ export function truncateOversizedStrings(data: unknown, maxBytes: number = MAX_F
       totalCount,
       loggedCount,
       omittedCount: totalCount - loggedCount,
+    });
+  }
+  if (depthExceededCount > MAX_WARN_PER_CALL) {
+    logger.warn({
+      message: 'promptSafety: recursion-depth-exceeded warn amplification suppressed',
+      safetyEvent: 'recursion-depth-exceeded-batch',
+      totalCount: depthExceededCount,
+      loggedCount: depthExceededLogged,
+      omittedCount: depthExceededCount - depthExceededLogged,
     });
   }
   return result;

--- a/server/utils/promptSafety.ts
+++ b/server/utils/promptSafety.ts
@@ -79,6 +79,21 @@ const MAX_RECURSION_DEPTH = 1000;
 export const RECURSION_DEPTH_EXCEEDED_MARKER = '[recursion-depth-exceeded: nested data truncated to fit safety limit]';
 
 /**
+ * 単一 sanitize 呼出あたりの個別 warn ログ発火上限。これを超えると個別 warn を抑制し、
+ * 関数末尾で集約 log 1 件 (`*-batch`) に切替える。
+ *
+ * 理由 (Issue #137 #3): 旧 PR #136 の content-based 再帰スキャンは O(N leaves) で全 leaf に
+ * 対し warn を emit する設計のため、攻撃者が array に多数の `data:image/...` を詰めると
+ * Cloud Logging に同名 warn が 1 リクエストで数千〜数万件発火する amplification 経路がある。
+ * 旧 whitelist 設計 (PR #132/#133) は path 2 件で暗黙の O(1) 契約だった。
+ *
+ * 50 は通常の character / world データで発火する image-omitted 件数 (実用 0〜2 件) に十分
+ * 余裕があり、攻撃 amplification 上限としても観測上の代表性 (最初の 50 件で path 分布が
+ * 十分わかる) を保つ妥協点。
+ */
+const MAX_WARN_PER_CALL = 50;
+
+/**
  * Object.prototype 汚染になりうる特殊 key (`__proto__` / `constructor` / `prototype`)。
  *
  * 理由 (Issue #134 part 1 code-review PLAUSIBLE): JSON.parse は `__proto__` を own enumerable
@@ -121,6 +136,10 @@ function joinPath(parent: string, segment: string | number): string {
  * - 不変性: 入力を mutate せず、変更がなければ same reference を返す (perf hint)
  */
 export function stripPromptHeavyFields(data: unknown): unknown {
+  // Issue #137 #3: per-call warn 集約のためのカウンタ。closure で共有。
+  let totalCount = 0;
+  let loggedCount = 0;
+
   function recurse(value: unknown, path: string, depth: number): unknown {
     if (depth > MAX_RECURSION_DEPTH) {
       logger.warn({
@@ -133,12 +152,16 @@ export function stripPromptHeavyFields(data: unknown): unknown {
     }
     if (typeof value === 'string') {
       if (!isImageDataUri(value)) return value;
-      logger.warn({
-        message: 'promptSafety: image dataURI stripped',
-        safetyEvent: 'image-omitted',
-        path,
-        bytes: Buffer.byteLength(value, 'utf8'),
-      });
+      totalCount++;
+      if (loggedCount < MAX_WARN_PER_CALL) {
+        logger.warn({
+          message: 'promptSafety: image dataURI stripped',
+          safetyEvent: 'image-omitted',
+          path,
+          bytes: Buffer.byteLength(value, 'utf8'),
+        });
+        loggedCount++;
+      }
       return IMAGE_OMITTED_MARKER;
     }
     if (Array.isArray(value)) {
@@ -167,7 +190,19 @@ export function stripPromptHeavyFields(data: unknown): unknown {
     }
     return value;
   }
-  return recurse(data, '', 0);
+  const result = recurse(data, '', 0);
+
+  // 集約 log: 上限超過時のみ 1 件 emit (個別 warn を抑制した分の omitted 数を報告)。
+  if (totalCount > MAX_WARN_PER_CALL) {
+    logger.warn({
+      message: 'promptSafety: image-omitted warn amplification suppressed',
+      safetyEvent: 'image-omitted-batch',
+      totalCount,
+      loggedCount,
+      omittedCount: totalCount - loggedCount,
+    });
+  }
+  return result;
 }
 
 /**
@@ -185,6 +220,10 @@ export function stripPromptHeavyFields(data: unknown): unknown {
  * 不変性: 入力を mutate しない。
  */
 export function truncateOversizedStrings(data: unknown, maxBytes: number = MAX_FIELD_BYTES): unknown {
+  // Issue #137 #3: per-call warn 集約のためのカウンタ。closure で共有。
+  let totalCount = 0;
+  let loggedCount = 0;
+
   function recurse(value: unknown, depth: number): unknown {
     if (depth > MAX_RECURSION_DEPTH) {
       logger.warn({
@@ -197,12 +236,16 @@ export function truncateOversizedStrings(data: unknown, maxBytes: number = MAX_F
     if (typeof value === 'string') {
       const utf8Bytes = Buffer.byteLength(value, 'utf8');
       if (utf8Bytes > maxBytes) {
-        logger.warn({
-          message: 'promptSafety: oversized string truncated',
-          safetyEvent: 'oversized-truncated',
-          bytes: utf8Bytes,
-          maxBytes,
-        });
+        totalCount++;
+        if (loggedCount < MAX_WARN_PER_CALL) {
+          logger.warn({
+            message: 'promptSafety: oversized string truncated',
+            safetyEvent: 'oversized-truncated',
+            bytes: utf8Bytes,
+            maxBytes,
+          });
+          loggedCount++;
+        }
         return OVERSIZED_STRING_MARKER;
       }
       return value;
@@ -233,7 +276,19 @@ export function truncateOversizedStrings(data: unknown, maxBytes: number = MAX_F
     }
     return value;
   }
-  return recurse(data, 0);
+  const result = recurse(data, 0);
+
+  // 集約 log: 上限超過時のみ 1 件 emit。
+  if (totalCount > MAX_WARN_PER_CALL) {
+    logger.warn({
+      message: 'promptSafety: oversized-truncated warn amplification suppressed',
+      safetyEvent: 'oversized-truncated-batch',
+      totalCount,
+      loggedCount,
+      omittedCount: totalCount - loggedCount,
+    });
+  }
+  return result;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Issue #137 #3 (log amplification) の対応として、`stripPromptHeavyFields` / `truncateOversizedStrings` に **per-call warn 集約** を導入
- `MAX_WARN_PER_CALL=50` 超で個別 warn を抑制 → 関数末尾に集約 log 1 件 (\`*-batch\`) を emit
- 攻撃者が array に多数の \`data:image/...\` を詰めた場合の Cloud Logging amplification (旧 PR #133 までは O(2) 暗黙契約、PR #136 で O(N leaves) に拡大) を構造的に閉じる

## なぜ

- PR #136 の content-based 再帰スキャンは O(N leaves) で全 leaf に warn を emit
- 攻撃者が chatHistory / fields[].value 等 unbounded array に多数の \`data:image/\` を詰めると数千〜数万件の warn が 1 リクエストで amplification
- 認証 + usage quota は call 数を抑制するが、call 単位の log volume amplification は直交軸

## 変更点

- \`MAX_WARN_PER_CALL = 50\` 定数追加
- \`stripPromptHeavyFields\` / \`truncateOversizedStrings\` の recurse closure 内に \`totalCount\` / \`loggedCount\` を持たせ、超過分は warn skip
- 関数末尾で \`totalCount > MAX_WARN_PER_CALL\` の場合 1 件の集約 log を emit:
  - \`safetyEvent: 'image-omitted-batch'\` / \`'oversized-truncated-batch'\`
  - \`totalCount\` (検出全件) / \`loggedCount\` (=50) / \`omittedCount\` (totalCount - 50)

## false positive ゼロの根拠

- 通常 character / world データの image-omitted 発火件数は実用 0〜2 件
- 50 を超えるのは攻撃 amplification のみ
- 個別 50 件で path 分布の観測代表性は十分 (集約 log で総数も把握可)

## Test plan

- [x] \`npm run test -- server/utils/promptSafety.test.ts\` (40 件 PASS、新規集約 logic 5 件含む)
- [x] \`npm run test\` 全件 (560 件 PASS / 5 skipped、旧 555 → 560)
- [x] \`npm run lint\` (tsc 0 errors)
- [ ] マージ後 dev デプロイで \`safetyEvent: image-omitted\` ログがいつも通り単発で出ることを確認 (集約閾値 50 未満は変化なし)

## Issue #137 残り (open 維持)

- **#137 #1** non-image dataURI gap (PDF/audio dataURI 100B-100KB 帯素通し)
- **#137 #2 残り** collection-level guard (array 合計 byte 閾値超で early summarize)

Refs #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)