### PR TITLE
refactor(prompt-safety): createWarnAggregator factory 抽出で log aggregation の DRY 違反解消 (Refs #137 #4)

### DIFF
--- a/server/utils/promptSafety.test.ts
+++ b/server/utils/promptSafety.test.ts
@@ -475,6 +475,40 @@ describe('observability (silent fail paired signal)', () => {
 
   // === Issue #137 #4: createWarnAggregator factory の不変条件 (cross-event 独立性) ===
 
+  it('lazy builder skips payload evaluation when threshold exceeded (Buffer.byteLength regression fix)', () => {
+    // PR #140 code-review CONFIRMED: tick({...}) の eager evaluation で旧 PR #139 から
+    // perf regression が入っていた。tick(() => ({...})) に切り替えて threshold 超後は
+    // payload builder closure を呼ばない (Buffer.byteLength も走らない) ことを pin する。
+    const big = `data:image/png;base64,${'A'.repeat(600)}`;
+    // 100 個 (= MAX_WARN_PER_CALL の 2 倍) を array に詰める
+    const items = Array.from({ length: 100 }, () => ({ url: big }));
+
+    // Buffer.byteLength の呼出回数を spy で観測
+    // (isImageDataUri 内 1 回 + tick builder 内 1 回 = 旧コードでは leaf あたり 2 回、
+    //  新コードでは threshold 超後は isImageDataUri のみ 1 回)
+    const originalByteLength = Buffer.byteLength;
+    let byteLengthCalls = 0;
+    // Buffer.byteLength は多 overload (string / Buffer / TypedArray ...) のため any 経由で差し替え。
+    // 検証目的の単純 spy なので型安全性は犠牲にする。
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (Buffer as any).byteLength = (str: any, encoding?: BufferEncoding) => {
+      byteLengthCalls++;
+      return originalByteLength(str, encoding as BufferEncoding);
+    };
+    try {
+      stripPromptHeavyFields({ gallery: items });
+    } finally {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (Buffer as any).byteLength = originalByteLength;
+    }
+
+    // 旧 eager 設計: 100 leaf × 2 回 = 200 回
+    // 新 lazy 設計: 100 leaf × 1 回 (isImageDataUri) + 50 leaf × 1 回 (tick builder) = 150 回
+    // 厳密に 150 回でなくても、200 回未満であれば lazy 化は効いている
+    expect(byteLengthCalls).toBeLessThan(200);
+    expect(byteLengthCalls).toBeGreaterThanOrEqual(150);
+  });
+
   it('image and depth aggregators are independent (one event burst does not exhaust the other quota)', () => {
     // image-omitted 51 件 + recursion-depth-exceeded 51 件を同 payload に混在させると、
     // 各 aggregator が独立 50 件 + 各 batch 1 件 = 計 102 件 (個別 100 + batch 2) emit される。

--- a/server/utils/promptSafety.test.ts
+++ b/server/utils/promptSafety.test.ts
@@ -472,6 +472,35 @@ describe('observability (silent fail paired signal)', () => {
       })
     );
   });
+
+  // === Issue #137 #4: createWarnAggregator factory の不変条件 (cross-event 独立性) ===
+
+  it('image and depth aggregators are independent (one event burst does not exhaust the other quota)', () => {
+    // image-omitted 51 件 + recursion-depth-exceeded 51 件を同 payload に混在させると、
+    // 各 aggregator が独立 50 件 + 各 batch 1 件 = 計 102 件 (個別 100 + batch 2) emit される。
+    // factory が closure 別個に counter を保持していることを cross-event burst で pin。
+    const big = `data:image/png;base64,${'A'.repeat(600)}`;
+    const deep = buildDeepChain(1500);
+    const payload: Record<string, unknown> = {};
+    for (let i = 0; i < 51; i++) payload[`img${i}`] = big;
+    for (let i = 0; i < 51; i++) payload[`deep${i}`] = deep;
+    stripPromptHeavyFields(payload);
+
+    const imageIndividual = warnSpy.mock.calls.filter(
+      (c) => (c[0] as { safetyEvent?: string }).safetyEvent === 'image-omitted'
+    );
+    const depthIndividual = warnSpy.mock.calls.filter(
+      (c) => (c[0] as { safetyEvent?: string }).safetyEvent === 'recursion-depth-exceeded'
+    );
+    expect(imageIndividual).toHaveLength(50);
+    expect(depthIndividual).toHaveLength(50);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ safetyEvent: 'image-omitted-batch', totalCount: 51 })
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ safetyEvent: 'recursion-depth-exceeded-batch', totalCount: 51 })
+    );
+  });
 });
 
 describe('sanitizeForPrompt - composite (whitelist + size guard)', () => {

--- a/server/utils/promptSafety.ts
+++ b/server/utils/promptSafety.ts
@@ -141,6 +141,70 @@ function joinPath(parent: string, segment: string | number): string {
 }
 
 /**
+ * per-call warn 集約を行う aggregator (Issue #137 #4 / code-review PR #139 CONFIRMED 対応)。
+ *
+ * 旧設計 (PR #139 直後): stripPromptHeavyFields と truncateOversizedStrings の各 recurse closure
+ * 内に `totalCount` / `loggedCount` を持ち、3 種類の safetyEvent (image-omitted /
+ * oversized-truncated / recursion-depth-exceeded) ごとに counter scaffolding を手書きしていた。
+ * これは Issue #134 で whitelist 廃止して構造的に閉じたはずの register-or-forget pattern が
+ * log aggregation 層で再発する原因だった。
+ *
+ * 本 factory に括り出すことで:
+ * - callsite は `aggregator.tick(payload)` 1 行で個別 warn (上限超は自動 skip)
+ * - 関数末尾で `aggregator.flush()` 1 行で集約 log emit
+ * - 新規 sanitize 関数 / 新規 safetyEvent 追加時に counter scaffolding をコピペする必要なし
+ *
+ * 不変条件:
+ * - `tick()` 呼出は totalCount を必ず inc、loggedCount は MAX_WARN_PER_CALL 超で打ち止め
+ * - `flush()` は totalCount > MAX_WARN_PER_CALL の時のみ 1 件 emit (totalCount=0 や ≤MAX では何もしない)
+ *
+ * @param individualEvent 個別 warn の safetyEvent (例: 'image-omitted')
+ * @param batchEvent 集約 warn の safetyEvent (例: 'image-omitted-batch')
+ * @param individualMessage 個別 warn の message (例: 'promptSafety: image dataURI stripped')
+ * @param batchMessage 集約 warn の message
+ */
+interface WarnAggregator {
+  /** 1 件検出時に呼ぶ。上限超は個別 warn を skip、totalCount だけ inc。 */
+  tick: (payload: Record<string, unknown>) => void;
+  /** 関数末尾で 1 回呼ぶ。totalCount > MAX_WARN_PER_CALL の時のみ 1 件集約 log を emit。 */
+  flush: () => void;
+}
+
+function createWarnAggregator(
+  individualEvent: string,
+  batchEvent: string,
+  individualMessage: string,
+  batchMessage: string,
+): WarnAggregator {
+  let totalCount = 0;
+  let loggedCount = 0;
+  return {
+    tick(payload: Record<string, unknown>) {
+      totalCount++;
+      if (loggedCount < MAX_WARN_PER_CALL) {
+        logger.warn({
+          message: individualMessage,
+          safetyEvent: individualEvent,
+          ...payload,
+        });
+        loggedCount++;
+      }
+    },
+    flush() {
+      if (totalCount > MAX_WARN_PER_CALL) {
+        logger.warn({
+          message: batchMessage,
+          safetyEvent: batchEvent,
+          totalCount,
+          loggedCount,
+          omittedCount: totalCount - loggedCount,
+        });
+      }
+    },
+  };
+}
+
+/**
  * 任意 path の `data:image/` 始まり文字列 (一定 byte 数以上) を omission marker に置換する
  * content-based scanner (Issue #134)。
  *
@@ -151,40 +215,27 @@ function joinPath(parent: string, segment: string | number): string {
  * - 不変性: 入力を mutate せず、変更がなければ same reference を返す (perf hint)
  */
 export function stripPromptHeavyFields(data: unknown): unknown {
-  // Issue #137 #3: per-call warn 集約のためのカウンタ。closure で共有。
-  // image-omitted / recursion-depth-exceeded はそれぞれ独立カウンタで管理し、
-  // batch log の safetyEvent を分離して観測上明確にする (code-review #139 CONFIRMED 対応)。
-  let totalCount = 0;
-  let loggedCount = 0;
-  let depthExceededCount = 0;
-  let depthExceededLogged = 0;
+  const imageAggregator = createWarnAggregator(
+    'image-omitted',
+    'image-omitted-batch',
+    'promptSafety: image dataURI stripped',
+    'promptSafety: image-omitted warn amplification suppressed',
+  );
+  const depthAggregator = createWarnAggregator(
+    'recursion-depth-exceeded',
+    'recursion-depth-exceeded-batch',
+    'promptSafety: recursion depth exceeded',
+    'promptSafety: recursion-depth-exceeded warn amplification suppressed',
+  );
 
   function recurse(value: unknown, path: string, depth: number): unknown {
     if (depth > MAX_RECURSION_DEPTH) {
-      depthExceededCount++;
-      if (depthExceededLogged < MAX_WARN_PER_CALL) {
-        logger.warn({
-          message: 'promptSafety: recursion depth exceeded',
-          safetyEvent: 'recursion-depth-exceeded',
-          path,
-          depth,
-        });
-        depthExceededLogged++;
-      }
+      depthAggregator.tick({ path, depth });
       return RECURSION_DEPTH_EXCEEDED_MARKER;
     }
     if (typeof value === 'string') {
       if (!isImageDataUri(value)) return value;
-      totalCount++;
-      if (loggedCount < MAX_WARN_PER_CALL) {
-        logger.warn({
-          message: 'promptSafety: image dataURI stripped',
-          safetyEvent: 'image-omitted',
-          path,
-          bytes: Buffer.byteLength(value, 'utf8'),
-        });
-        loggedCount++;
-      }
+      imageAggregator.tick({ path, bytes: Buffer.byteLength(value, 'utf8') });
       return IMAGE_OMITTED_MARKER;
     }
     if (Array.isArray(value)) {
@@ -214,26 +265,8 @@ export function stripPromptHeavyFields(data: unknown): unknown {
     return value;
   }
   const result = recurse(data, '', 0);
-
-  // 集約 log: 上限超過時のみ 1 件 emit (個別 warn を抑制した分の omitted 数を報告)。
-  if (totalCount > MAX_WARN_PER_CALL) {
-    logger.warn({
-      message: 'promptSafety: image-omitted warn amplification suppressed',
-      safetyEvent: 'image-omitted-batch',
-      totalCount,
-      loggedCount,
-      omittedCount: totalCount - loggedCount,
-    });
-  }
-  if (depthExceededCount > MAX_WARN_PER_CALL) {
-    logger.warn({
-      message: 'promptSafety: recursion-depth-exceeded warn amplification suppressed',
-      safetyEvent: 'recursion-depth-exceeded-batch',
-      totalCount: depthExceededCount,
-      loggedCount: depthExceededLogged,
-      omittedCount: depthExceededCount - depthExceededLogged,
-    });
-  }
+  imageAggregator.flush();
+  depthAggregator.flush();
   return result;
 }
 
@@ -252,40 +285,28 @@ export function stripPromptHeavyFields(data: unknown): unknown {
  * 不変性: 入力を mutate しない。
  */
 export function truncateOversizedStrings(data: unknown, maxBytes: number = MAX_FIELD_BYTES): unknown {
-  // Issue #137 #3: per-call warn 集約のためのカウンタ。closure で共有。
-  // oversized-truncated / recursion-depth-exceeded はそれぞれ独立カウンタで管理
-  // (code-review #139 CONFIRMED: depth-exceeded amplification も対称化)。
-  let totalCount = 0;
-  let loggedCount = 0;
-  let depthExceededCount = 0;
-  let depthExceededLogged = 0;
+  const oversizedAggregator = createWarnAggregator(
+    'oversized-truncated',
+    'oversized-truncated-batch',
+    'promptSafety: oversized string truncated',
+    'promptSafety: oversized-truncated warn amplification suppressed',
+  );
+  const depthAggregator = createWarnAggregator(
+    'recursion-depth-exceeded',
+    'recursion-depth-exceeded-batch',
+    'promptSafety: recursion depth exceeded',
+    'promptSafety: recursion-depth-exceeded warn amplification suppressed',
+  );
 
   function recurse(value: unknown, depth: number): unknown {
     if (depth > MAX_RECURSION_DEPTH) {
-      depthExceededCount++;
-      if (depthExceededLogged < MAX_WARN_PER_CALL) {
-        logger.warn({
-          message: 'promptSafety: recursion depth exceeded',
-          safetyEvent: 'recursion-depth-exceeded',
-          depth,
-        });
-        depthExceededLogged++;
-      }
+      depthAggregator.tick({ depth });
       return RECURSION_DEPTH_EXCEEDED_MARKER;
     }
     if (typeof value === 'string') {
       const utf8Bytes = Buffer.byteLength(value, 'utf8');
       if (utf8Bytes > maxBytes) {
-        totalCount++;
-        if (loggedCount < MAX_WARN_PER_CALL) {
-          logger.warn({
-            message: 'promptSafety: oversized string truncated',
-            safetyEvent: 'oversized-truncated',
-            bytes: utf8Bytes,
-            maxBytes,
-          });
-          loggedCount++;
-        }
+        oversizedAggregator.tick({ bytes: utf8Bytes, maxBytes });
         return OVERSIZED_STRING_MARKER;
       }
       return value;
@@ -317,26 +338,8 @@ export function truncateOversizedStrings(data: unknown, maxBytes: number = MAX_F
     return value;
   }
   const result = recurse(data, 0);
-
-  // 集約 log: 上限超過時のみ 1 件 emit。
-  if (totalCount > MAX_WARN_PER_CALL) {
-    logger.warn({
-      message: 'promptSafety: oversized-truncated warn amplification suppressed',
-      safetyEvent: 'oversized-truncated-batch',
-      totalCount,
-      loggedCount,
-      omittedCount: totalCount - loggedCount,
-    });
-  }
-  if (depthExceededCount > MAX_WARN_PER_CALL) {
-    logger.warn({
-      message: 'promptSafety: recursion-depth-exceeded warn amplification suppressed',
-      safetyEvent: 'recursion-depth-exceeded-batch',
-      totalCount: depthExceededCount,
-      loggedCount: depthExceededLogged,
-      omittedCount: depthExceededCount - depthExceededLogged,
-    });
-  }
+  oversizedAggregator.flush();
+  depthAggregator.flush();
   return result;
 }
 

--- a/server/utils/promptSafety.ts
+++ b/server/utils/promptSafety.ts
@@ -164,8 +164,16 @@ function joinPath(parent: string, segment: string | number): string {
  * @param batchMessage 集約 warn の message
  */
 interface WarnAggregator {
-  /** 1 件検出時に呼ぶ。上限超は個別 warn を skip、totalCount だけ inc。 */
-  tick: (payload: Record<string, unknown>) => void;
+  /**
+   * 1 件検出時に呼ぶ。totalCount は必ず inc、loggedCount は MAX_WARN_PER_CALL 超で打ち止め。
+   *
+   * payload は **lazy builder closure** で受け取る (code-review PR #140 CONFIRMED 対応):
+   * 旧 `tick(payload)` 設計だと callsite で毎 leaf object literal + 重い計算
+   * (Buffer.byteLength(50KB)) を eager 評価してしまい、threshold 超後も無駄な work が走る
+   * regression があった。`tick(() => ({ ... }))` に変えることで threshold 内のみ closure を
+   * 呼び出し、上限超後は closure 自体を skip (Buffer.byteLength も走らない)。
+   */
+  tick: (buildPayload: () => Record<string, unknown>) => void;
   /** 関数末尾で 1 回呼ぶ。totalCount > MAX_WARN_PER_CALL の時のみ 1 件集約 log を emit。 */
   flush: () => void;
 }
@@ -179,13 +187,13 @@ function createWarnAggregator(
   let totalCount = 0;
   let loggedCount = 0;
   return {
-    tick(payload: Record<string, unknown>) {
+    tick(buildPayload: () => Record<string, unknown>) {
       totalCount++;
       if (loggedCount < MAX_WARN_PER_CALL) {
         logger.warn({
           message: individualMessage,
           safetyEvent: individualEvent,
-          ...payload,
+          ...buildPayload(),
         });
         loggedCount++;
       }
@@ -230,12 +238,13 @@ export function stripPromptHeavyFields(data: unknown): unknown {
 
   function recurse(value: unknown, path: string, depth: number): unknown {
     if (depth > MAX_RECURSION_DEPTH) {
-      depthAggregator.tick({ path, depth });
+      depthAggregator.tick(() => ({ path, depth }));
       return RECURSION_DEPTH_EXCEEDED_MARKER;
     }
     if (typeof value === 'string') {
       if (!isImageDataUri(value)) return value;
-      imageAggregator.tick({ path, bytes: Buffer.byteLength(value, 'utf8') });
+      // lazy builder: threshold 超後は Buffer.byteLength(50KB級) 再計算が skip される
+      imageAggregator.tick(() => ({ path, bytes: Buffer.byteLength(value, 'utf8') }));
       return IMAGE_OMITTED_MARKER;
     }
     if (Array.isArray(value)) {
@@ -300,13 +309,14 @@ export function truncateOversizedStrings(data: unknown, maxBytes: number = MAX_F
 
   function recurse(value: unknown, depth: number): unknown {
     if (depth > MAX_RECURSION_DEPTH) {
-      depthAggregator.tick({ depth });
+      depthAggregator.tick(() => ({ depth }));
       return RECURSION_DEPTH_EXCEEDED_MARKER;
     }
     if (typeof value === 'string') {
       const utf8Bytes = Buffer.byteLength(value, 'utf8');
       if (utf8Bytes > maxBytes) {
-        oversizedAggregator.tick({ bytes: utf8Bytes, maxBytes });
+        // utf8Bytes は threshold 判定で既に必須計算済なので lazy 化しても eager 化しても同コスト
+        oversizedAggregator.tick(() => ({ bytes: utf8Bytes, maxBytes }));
         return OVERSIZED_STRING_MARKER;
       }
       return value;


### PR DESCRIPTION
## Summary

- PR #139 code-review medium effort で CONFIRMED (altitude cleanup) になった **register-or-forget at log aggregation layer** を構造的に解消
- \`createWarnAggregator(individualEvent, batchEvent, individualMessage, batchMessage)\` factory を新規 introduce
- 各 sanitize 関数の counter scaffolding (~26 行/関数) を `tick()` / `flush()` の 2 method 呼出に圧縮

## なぜ

PR #136 (Issue #134) で whitelist 廃止して「画像 dataURI 検出フィールドの register-or-forget」を構造的に閉じたが、PR #139 (Issue #137 #3) の per-call warn 集約は同型 pattern を log aggregation layer で再導入していた:

- `stripPromptHeavyFields` と `truncateOversizedStrings` に counter 2 個 + skip ガード + 末尾 batch emit の ~16 行 (× 3 safetyEvent) が byte-for-byte 同型でコピペされていた
- Issue #137 #1 (non-image dataURI gap) で新規 sanitize 関数が増える時、register-or-forget で warn 集約を忘れた regression が CI から検知できない

## 変更点

- 新規 \`interface WarnAggregator { tick, flush }\` + \`createWarnAggregator()\` factory (~30 行)
- \`stripPromptHeavyFields\`: \`imageAggregator\` + \`depthAggregator\` 2 つを生成、recurse 内の counter scaffolding を `aggregator.tick(payload)` 1 行に圧縮、関数末尾で `flush()`
- \`truncateOversizedStrings\`: \`oversizedAggregator\` + \`depthAggregator\` 2 つを生成、同じパターン
- 各 callsite から counter 宣言 8 行 + skip ガード 9 行/aggregator + 末尾 batch emit 9 行/aggregator が消える (合計 ~93 行削除 + factory 30 行追加 = net ~63 行削減)

## テスト

新規 1 ケース (cross-event 独立性):
- image-omitted 51 件 + recursion-depth-exceeded 51 件を混在させた payload で、各 aggregator が独立 50 件個別 + 各 batch 1 件を emit (closure 別個 counter pin)

## Test plan

- [x] \`npm run test -- server/utils/promptSafety.test.ts\` (44 件 PASS、cross-event 独立性 +1)
- [x] \`npm run test\` 全件 (564 件 PASS / 5 skipped、旧 563 → 564)
- [x] \`npm run lint\` (tsc 0 errors)
- [ ] マージ後 dev デプロイで既存 \`safetyEvent: image-omitted\` ログがいつも通り発火 (refactor で挙動不変を実機確認)

## Issue #137 残課題 (open 維持)

- **#137 #1** non-image dataURI gap (PDF/audio dataURI 100B-100KB 帯素通し)
- **#137 #2 残り** collection-level guard
- **#137 #5** batch log の path 喪失、pathPrefixes histogram

Refs #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)