### PR TITLE
refactor(prompt-safety): createWarnAggregator factory の altitude 補強 (Refs #137 #4 残り a-d)

### DIFF
--- a/server/utils/promptSafety.test.ts
+++ b/server/utils/promptSafety.test.ts
@@ -7,6 +7,7 @@ import {
   stripPromptHeavyFields,
   truncateOversizedStrings,
   sanitizeForPrompt,
+  createWarnAggregator,
 } from './promptSafety';
 
 describe('stripPromptHeavyFields - content-based 画像 dataURI 検出 (Issue #134)', () => {
@@ -570,5 +571,93 @@ describe('sanitizeForPrompt - composite (whitelist + size guard)', () => {
     const serialized = JSON.stringify(sanitizeForPrompt(data));
     expect(serialized.length).toBeLessThan(1_000);
     expect(serialized).toContain(IMAGE_OMITTED_MARKER);
+  });
+});
+
+describe('createWarnAggregator factory unit (Issue #137 #4 残り)', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+  });
+
+  it('flush() emits nothing when tick() was never called (totalCount === 0)', () => {
+    const agg = createWarnAggregator('test-event', 'promptSafety: test event');
+    agg.flush();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('flush() emits nothing when tick() was called exactly MAX_WARN_PER_CALL (50) times (boundary 直下)', () => {
+    const agg = createWarnAggregator('test-event', 'promptSafety: test event');
+    for (let i = 0; i < 50; i++) agg.tick(() => ({ idx: i }));
+    agg.flush();
+    // 個別 warn 50 件、batch 0 件
+    const batchCalls = warnSpy.mock.calls.filter(
+      (c) => (c[0] as { safetyEvent?: string }).safetyEvent === 'test-event-batch'
+    );
+    expect(batchCalls).toHaveLength(0);
+    const individualCalls = warnSpy.mock.calls.filter(
+      (c) => (c[0] as { safetyEvent?: string }).safetyEvent === 'test-event'
+    );
+    expect(individualCalls).toHaveLength(50);
+  });
+
+  it('flush() emits 1 batch when tick() was called 51 times (boundary 直上)', () => {
+    const agg = createWarnAggregator('test-event', 'promptSafety: test event');
+    for (let i = 0; i < 51; i++) agg.tick(() => ({ idx: i }));
+    agg.flush();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        safetyEvent: 'test-event-batch',
+        message: 'promptSafety: test-event warn amplification suppressed',
+        totalCount: 51,
+        loggedCount: 50,
+        omittedCount: 1,
+      })
+    );
+  });
+
+  it('individual warn payload cannot override message or safetyEvent (payload spread shadowing 構造的閉鎖、Issue #137 #4 残り a)', () => {
+    const agg = createWarnAggregator('test-event', 'promptSafety: test event');
+    // 型上は `message?: never` / `safetyEvent?: never` で禁止されているが、
+    // 実行時の構造的防御 (spread 順) も pin する。`as any` で型 guard を bypass して悪意 payload を作る。
+    agg.tick(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      () => ({ message: 'HIJACKED', safetyEvent: 'HIJACKED-event', path: 'a' } as any)
+    );
+    // factory 固定値が必ず残ることを pin
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'promptSafety: test event',
+        safetyEvent: 'test-event',
+      })
+    );
+    // HIJACKED が message / safetyEvent に入っていないことを pin
+    const call = warnSpy.mock.calls[0][0] as { message: string; safetyEvent: string };
+    expect(call.message).not.toBe('HIJACKED');
+    expect(call.safetyEvent).not.toBe('HIJACKED-event');
+  });
+
+  it('derives batchEvent and batchMessage from individualEvent (Issue #137 #4 残り b)', () => {
+    const agg = createWarnAggregator('demo-omitted', 'promptSafety: demo something');
+    for (let i = 0; i < 51; i++) agg.tick(() => ({}));
+    agg.flush();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        safetyEvent: 'demo-omitted-batch',
+        message: 'promptSafety: demo-omitted warn amplification suppressed',
+      })
+    );
+  });
+
+  it('tick() lazy builder is NOT called when threshold exceeded (PR #140 regression fix)', () => {
+    const agg = createWarnAggregator('test-event', 'promptSafety: test event');
+    let buildCalls = 0;
+    const buildPayload = () => {
+      buildCalls++;
+      return { idx: buildCalls };
+    };
+    for (let i = 0; i < 100; i++) agg.tick(buildPayload);
+    // 最初の 50 件のみ builder が呼ばれる
+    expect(buildCalls).toBe(50);
   });
 });

--- a/server/utils/promptSafety.test.ts
+++ b/server/utils/promptSafety.test.ts
@@ -491,7 +491,6 @@ describe('observability (silent fail paired signal)', () => {
     let byteLengthCalls = 0;
     // Buffer.byteLength は多 overload (string / Buffer / TypedArray ...) のため any 経由で差し替え。
     // 検証目的の単純 spy なので型安全性は犠牲にする。
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (Buffer as any).byteLength = (str: any, encoding?: BufferEncoding) => {
       byteLengthCalls++;
       return originalByteLength(str, encoding as BufferEncoding);
@@ -499,7 +498,6 @@ describe('observability (silent fail paired signal)', () => {
     try {
       stripPromptHeavyFields({ gallery: items });
     } finally {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (Buffer as any).byteLength = originalByteLength;
     }
 
@@ -621,7 +619,6 @@ describe('createWarnAggregator factory unit (Issue #137 #4 残り)', () => {
     // 型上は `message?: never` / `safetyEvent?: never` で禁止されているが、
     // 実行時の構造的防御 (spread 順) も pin する。`as any` で型 guard を bypass して悪意 payload を作る。
     agg.tick(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       () => ({ message: 'HIJACKED', safetyEvent: 'HIJACKED-event', path: 'a' } as any)
     );
     // factory 固定値が必ず残ることを pin

--- a/server/utils/promptSafety.ts
+++ b/server/utils/promptSafety.ts
@@ -149,7 +149,7 @@ function joinPath(parent: string, segment: string | number): string {
  * `message` / `safetyEvent` を `never` 制約することで compile-time 防御し、server/utils/logger.ts の
  * 確立規律 (`{ ...payload, severity, timestamp, service }` で予約キー保護) と同じ altitude を保つ。
  */
-type WarnAggregatorPayload = Record<string, unknown> & {
+export type WarnAggregatorPayload = Record<string, unknown> & {
   message?: never;
   safetyEvent?: never;
 };
@@ -177,6 +177,18 @@ type WarnAggregatorPayload = Record<string, unknown> & {
  *   `${individualEvent}-batch` で派生 (Issue #137 #4 残り b)
  * @param individualMessage 個別 warn の message (例: 'promptSafety: image dataURI stripped')。集約 warn の
  *   message は `promptSafety: ${individualEvent} warn amplification suppressed` で派生
+ *
+ * ## individualEvent の制約 (派生衝突回避)
+ *
+ * factory が batchEvent / batchMessage を機械生成する性質上、以下の値を渡すと degenerate な
+ * 集約 log になる:
+ * - **空文字 `''`**: `batchEvent = '-batch'` / `batchMessage = 'promptSafety:  warn amplification suppressed'` (double space)
+ * - **`-batch` suffix 付き** (例 `'image-omitted-batch'`): `batchEvent = 'image-omitted-batch-batch'` で個別と batch の区別が曖昧化、
+ *   かつ別 aggregator (例 `image-omitted`) の batchEvent と衝突する
+ *
+ * 現状 callsite はすべて hardcoded literal で degenerate input を渡していないが、factory が
+ * `export` されているため外部 caller では渡さないこと。defensive runtime guard は overkill のため
+ * 入れていない (内部 only かつ 3 callsite で抑止)。
  */
 export interface WarnAggregator {
   /**

--- a/server/utils/promptSafety.ts
+++ b/server/utils/promptSafety.ts
@@ -141,7 +141,21 @@ function joinPath(parent: string, segment: string | number): string {
 }
 
 /**
- * per-call warn 集約を行う aggregator (Issue #137 #4 / code-review PR #139 CONFIRMED 対応)。
+ * tick payload で渡せないキー (factory が固定する予約 key)。
+ *
+ * (a) payload spread shadowing 防御 (Issue #137 #4 残り a):
+ * tick の logger.warn では `{ ...buildPayload(), message: individualMessage, safetyEvent: individualEvent }` の
+ * 順で spread し、callsite からの payload が固定 key を上書きできない構造にしている。型レベルでも
+ * `message` / `safetyEvent` を `never` 制約することで compile-time 防御し、server/utils/logger.ts の
+ * 確立規律 (`{ ...payload, severity, timestamp, service }` で予約キー保護) と同じ altitude を保つ。
+ */
+type WarnAggregatorPayload = Record<string, unknown> & {
+  message?: never;
+  safetyEvent?: never;
+};
+
+/**
+ * per-call warn 集約を行う aggregator (Issue #137 #4 / code-review PR #139 / #140 CONFIRMED 対応)。
  *
  * 旧設計 (PR #139 直後): stripPromptHeavyFields と truncateOversizedStrings の各 recurse closure
  * 内に `totalCount` / `loggedCount` を持ち、3 種類の safetyEvent (image-omitted /
@@ -150,20 +164,21 @@ function joinPath(parent: string, segment: string | number): string {
  * log aggregation 層で再発する原因だった。
  *
  * 本 factory に括り出すことで:
- * - callsite は `aggregator.tick(payload)` 1 行で個別 warn (上限超は自動 skip)
+ * - callsite は `aggregator.tick(buildPayload)` 1 行で個別 warn (上限超は自動 skip)
  * - 関数末尾で `aggregator.flush()` 1 行で集約 log emit
  * - 新規 sanitize 関数 / 新規 safetyEvent 追加時に counter scaffolding をコピペする必要なし
  *
  * 不変条件:
  * - `tick()` 呼出は totalCount を必ず inc、loggedCount は MAX_WARN_PER_CALL 超で打ち止め
  * - `flush()` は totalCount > MAX_WARN_PER_CALL の時のみ 1 件 emit (totalCount=0 や ≤MAX では何もしない)
+ * - callsite payload で `message` / `safetyEvent` を上書き不可 (型 + 実行時 spread 順)
  *
- * @param individualEvent 個別 warn の safetyEvent (例: 'image-omitted')
- * @param batchEvent 集約 warn の safetyEvent (例: 'image-omitted-batch')
- * @param individualMessage 個別 warn の message (例: 'promptSafety: image dataURI stripped')
- * @param batchMessage 集約 warn の message
+ * @param individualEvent 個別 warn の safetyEvent (例: 'image-omitted')。集約 warn の safetyEvent は
+ *   `${individualEvent}-batch` で派生 (Issue #137 #4 残り b)
+ * @param individualMessage 個別 warn の message (例: 'promptSafety: image dataURI stripped')。集約 warn の
+ *   message は `promptSafety: ${individualEvent} warn amplification suppressed` で派生
  */
-interface WarnAggregator {
+export interface WarnAggregator {
   /**
    * 1 件検出時に呼ぶ。totalCount は必ず inc、loggedCount は MAX_WARN_PER_CALL 超で打ち止め。
    *
@@ -173,27 +188,28 @@ interface WarnAggregator {
    * regression があった。`tick(() => ({ ... }))` に変えることで threshold 内のみ closure を
    * 呼び出し、上限超後は closure 自体を skip (Buffer.byteLength も走らない)。
    */
-  tick: (buildPayload: () => Record<string, unknown>) => void;
+  tick: (buildPayload: () => WarnAggregatorPayload) => void;
   /** 関数末尾で 1 回呼ぶ。totalCount > MAX_WARN_PER_CALL の時のみ 1 件集約 log を emit。 */
   flush: () => void;
 }
 
-function createWarnAggregator(
-  individualEvent: string,
-  batchEvent: string,
-  individualMessage: string,
-  batchMessage: string,
-): WarnAggregator {
+export function createWarnAggregator(individualEvent: string, individualMessage: string): WarnAggregator {
+  // (b) batchEvent / batchMessage は individualEvent から機械生成 (Issue #137 #4 残り b)。
+  // 旧設計の 4 引数 positional 渡しは batch 名 typo の register-or-forget リスクが残っていた。
+  const batchEvent = `${individualEvent}-batch`;
+  const batchMessage = `promptSafety: ${individualEvent} warn amplification suppressed`;
+
   let totalCount = 0;
   let loggedCount = 0;
   return {
-    tick(buildPayload: () => Record<string, unknown>) {
+    tick(buildPayload: () => WarnAggregatorPayload) {
       totalCount++;
       if (loggedCount < MAX_WARN_PER_CALL) {
+        // (a) spread 順反転で固定 message / safetyEvent が payload から上書きされない構造を保証。
         logger.warn({
+          ...buildPayload(),
           message: individualMessage,
           safetyEvent: individualEvent,
-          ...buildPayload(),
         });
         loggedCount++;
       }
@@ -213,6 +229,17 @@ function createWarnAggregator(
 }
 
 /**
+ * (c) recursion-depth-exceeded aggregator の helper (Issue #137 #4 残り c)。
+ *
+ * stripPromptHeavyFields / truncateOversizedStrings の両方で同じ event + message の aggregator が
+ * 必要なため、helper 経由で literal の重複を避ける。新規 sanitize 関数が増えても 1 行で同じ
+ * depth-exceeded 集約を継承できる。
+ */
+function createDepthExceededAggregator(): WarnAggregator {
+  return createWarnAggregator('recursion-depth-exceeded', 'promptSafety: recursion depth exceeded');
+}
+
+/**
  * 任意 path の `data:image/` 始まり文字列 (一定 byte 数以上) を omission marker に置換する
  * content-based scanner (Issue #134)。
  *
@@ -223,18 +250,8 @@ function createWarnAggregator(
  * - 不変性: 入力を mutate せず、変更がなければ same reference を返す (perf hint)
  */
 export function stripPromptHeavyFields(data: unknown): unknown {
-  const imageAggregator = createWarnAggregator(
-    'image-omitted',
-    'image-omitted-batch',
-    'promptSafety: image dataURI stripped',
-    'promptSafety: image-omitted warn amplification suppressed',
-  );
-  const depthAggregator = createWarnAggregator(
-    'recursion-depth-exceeded',
-    'recursion-depth-exceeded-batch',
-    'promptSafety: recursion depth exceeded',
-    'promptSafety: recursion-depth-exceeded warn amplification suppressed',
-  );
+  const imageAggregator = createWarnAggregator('image-omitted', 'promptSafety: image dataURI stripped');
+  const depthAggregator = createDepthExceededAggregator();
 
   function recurse(value: unknown, path: string, depth: number): unknown {
     if (depth > MAX_RECURSION_DEPTH) {
@@ -294,18 +311,8 @@ export function stripPromptHeavyFields(data: unknown): unknown {
  * 不変性: 入力を mutate しない。
  */
 export function truncateOversizedStrings(data: unknown, maxBytes: number = MAX_FIELD_BYTES): unknown {
-  const oversizedAggregator = createWarnAggregator(
-    'oversized-truncated',
-    'oversized-truncated-batch',
-    'promptSafety: oversized string truncated',
-    'promptSafety: oversized-truncated warn amplification suppressed',
-  );
-  const depthAggregator = createWarnAggregator(
-    'recursion-depth-exceeded',
-    'recursion-depth-exceeded-batch',
-    'promptSafety: recursion depth exceeded',
-    'promptSafety: recursion-depth-exceeded warn amplification suppressed',
-  );
+  const oversizedAggregator = createWarnAggregator('oversized-truncated', 'promptSafety: oversized string truncated');
+  const depthAggregator = createDepthExceededAggregator();
 
   function recurse(value: unknown, depth: number): unknown {
     if (depth > MAX_RECURSION_DEPTH) {


### PR DESCRIPTION
## Summary

PR #140 code-review medium で CONFIRMED された factory 周りの cleanup 4 件 (a-d) をまとめて解消する PR。

- **(a)** payload spread shadowing 構造的閉鎖 (spread 順反転 + 型 narrow)
- **(b)** factory 4-arg → 2-arg 縮約 (batchEvent/Message 派生)
- **(c)** depthAggregator helper 集約 (literal 重複解消)
- **(d)** factory export + 単体 test 追加

## 変更点

### (a) payload spread shadowing

旧 `{ message, safetyEvent, ...buildPayload() }` で payload が固定値を上書き可能 (latent footgun)。

- spread 順反転: `{ ...buildPayload(), message, safetyEvent }`
- 型に \`WarnAggregatorPayload = Record<string, unknown> & { message?: never; safetyEvent?: never }\`
- compile-time + runtime の二重防御で \`tick(() => ({ message: 'HIJACKED' }))\` が無効化
- \`server/utils/logger.ts:90-97\` の確立規律と同じ altitude

### (b) factory 4-arg → 2-arg

\`createWarnAggregator(individualEvent, batchEvent, individualMessage, batchMessage)\` (4 引数) → \`createWarnAggregator(individualEvent, individualMessage)\` (2 引数)

factory 内で \`batchEvent = \\\`\\\${individualEvent}-batch\\\`\` / \`batchMessage = \\\`promptSafety: \\\${individualEvent} warn amplification suppressed\\\`\` を機械生成。新規 safetyEvent 追加時の batch 名 typo を構造的に排除。

### (c) depthAggregator helper

両関数で 4 引数 (旧) → 2 引数 (新) literal が完全重複していたため、module-level \`function createDepthExceededAggregator()\` 1 行 wrapper に集約。各 callsite は 1 行参照。

### (d) factory export + 単体 test

- \`createWarnAggregator\` と \`WarnAggregator\` を \`export\` 化
- factory 単体 test 6 件追加 (totalCount === 0 で no-op / boundary 直下/直上 / shadowing 防御の runtime pin / event 派生 pin / lazy builder pin)

## Test plan

- [x] \`npm run test -- server/utils/promptSafety.test.ts\` (51 件 PASS、factory 単体 +6)
- [x] \`npm run test\` 全件 (569 件 PASS / 5 skipped、backupSlice 1 件は flaky で本 PR 無関係)
- [x] \`npm run lint\` (tsc 0 errors)
- [ ] マージ後 dev デプロイで既存 \`safetyEvent: image-omitted\` ログがいつも通り単発で出ることを確認 (refactor で挙動不変を実機確認)

## Cloud Logging side への影響

spread 順反転で warn log の key 順序が変わるが、Cloud Logging は key-based なので本田様の手動 grep ベース運用に影響なし。test は \`objectContaining\` で順序非依存。

## Issue #137 残課題 (open 維持)

- **#137 #1** non-image dataURI gap
- **#137 #2 残り** collection-level guard
- **#137 #5** batch log の path 喪失、pathPrefixes histogram
- **#137 #6** logger.ts altitude (logger.warnSampled future work)

Refs #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)