### PR TITLE
feat(prompt-safety): 非画像 dataURI 検出層追加 + isImageDataUri を case insensitive 化 (Refs #137 #1)

### DIFF
--- a/docs/handoff/2026-06-03c-non-image-data-uri-detection.md
+++ b/docs/handoff/2026-06-03c-non-image-data-uri-detection.md
@@ -1,0 +1,100 @@
+# Handoff: Issue #137 #1 non-image dataURI 検出層追加
+
+- Session Date: 2026-06-03 (3 セッション目)
+- Owner: yasushi-honda
+- Status: 🟡 PR 作成待ち (feature/non-image-data-uri-detection ブランチ、ローカル commit 済)
+- Previous handoff: [2026-06-03b-prompt-safety-hardening.md](./2026-06-03b-prompt-safety-hardening.md)
+
+## 今セッションのトリガー
+
+前セッション末で Issue #137 が #2 残り / #4 残り / #5 / #6 を残して open 維持。本田様から `次のアクション:優先順にすすめて` の指示を受け、最大規模 (設計議論を含む) の **Issue #137 #1 (non-image dataURI gap)** を brainstorm 経由で着手。
+
+## brainstorm → impl-plan → 実装の流れ
+
+| Phase | 内容 |
+|---|---|
+| brainstorm Phase 1〜3 | 現状把握 + 視覚補助スキップ + OQ 1 件 (どこから着手) → 案 B (非画像 dataURI 検出層追加) + MIN=500 確定 |
+| brainstorm Phase 4-5 | 3 案 (A: MAX_FIELD_BYTES 引下げ / B: 検出層追加 / C: FE サニタイズ) 提示 → 案 B 採用 |
+| **codex セカンドオピニオン** | 6 観点で評価 → Medium 指摘 2 件 (case normalize / edge case test) を採用 (B-2)、Low-Medium (mimeType observability) は別 Issue へ |
+| brainstorm Phase 6-7 | 設計文書 `docs/spec/promptSafety/2026-06-03-non-image-data-uri-detection-design.md` 作成 + セルフレビュー (テスト件数 569→571 補正) |
+| brainstorm Phase 8-9 | ユーザー承認 → `/impl-plan` 遷移 |
+| impl-plan Phase 1-5 | T1-T10 計画提示 → 承認 |
+| 実装 T1-T7 | TDD + safe-refactor + code-review low 全 PASS |
+
+## 変更内容
+
+### `server/utils/promptSafety.ts` (+50 行、改修 1 関数)
+
+新規:
+- `NON_IMAGE_DATA_URI_MARKER` (export)
+- `DATA_URI_PREFIX = 'data:'` (private)
+- `MIN_NON_IMAGE_DATA_URI_BYTES = 500` (private、image 側と対称)
+- `normalizeForDataUriDetection(s)`: `s.trimStart().toLowerCase()` (case insensitive + 先頭空白吸収)
+- `isNonImageDataUri(value)`: normalize 後 `data:` で始まり `data:image/` で始まらない + byte ≥ 500
+- `stripPromptHeavyFields` 内に `nonImageAggregator` 追加
+
+改修:
+- `isImageDataUri`: normalize 後 string ベース判定に変更 (case insensitive 化、`DATA:IMAGE/PNG` 等を捕捉)
+- `stripPromptHeavyFields.recurse` の string 経路: `image → non-image` 順の if 並列に変更
+
+### `server/utils/promptSafety.test.ts` (+150 行、+16 件 PASS)
+
+| describe | 件数 | 内容 |
+|---|---|---|
+| `非画像 dataURI 検出 (Issue #137 #1)` | 13 件 | AC-1〜7, AC-11〜14 (PDF/audio/font 800B / 短文素通し / 境界値 499/500/501 / case variant / 空白 / 空 MIME / no base64) |
+| `画像 dataURI 検出 case insensitive 化` | 1 件 | AC-15 (`DATA:IMAGE/PNG` regression pin) |
+| `非画像 observability + cross-event independence` | 2 件 | AC-8 (image-omitted-batch と non-image-data-uri-omitted-batch 別 event) / AC-9 (path log 区別) |
+
+### `docs/spec/promptSafety/2026-06-03-non-image-data-uri-detection-design.md` (+206 行、commit 済)
+
+12 セクション (概要 / 要件 / アーキテクチャ / データモデル / インターフェース / エラー処理 / テスト戦略 / スコープ外 / Open Questions / リスク / 実装手順 / 参考資料)。
+
+## 検証結果
+
+| 項目 | 結果 |
+|---|---|
+| `npm test -- promptSafety` | 67 件 PASS (52 + 16) |
+| `npm test` (全件) | 587 件 PASS (571 + 16) |
+| `npm run lint` (tsc --noEmit) | 0 errors |
+| `/safe-refactor` (Phase 1) | HIGH/MEDIUM/LOW 0 件 (DRY 改善余地は対称設計優先で意図的に保留) |
+| `/code-review low` | (none) — correctness bug 検出ゼロ |
+
+## codex セカンドオピニオン反映状況
+
+| 指摘 (Medium 以上) | 採用 | 反映先 |
+|---|---|---|
+| case normalize (`DATA:application/pdf`, `\n data:...` 等が現案だと素通し) | ✅ | `normalizeForDataUriDetection` + `isImageDataUri` 改修 |
+| edge case テスト (`DATA:application/pdf`, `\n data:...`, `data:;base64,`, `data:,`, `DATA:IMAGE/PNG`) | ✅ | AC-11〜15 |
+| mimeType observability (個別 warn payload に MIME 種別追加) | ⏸ Low-Medium | **別 Issue 起票候補** (運用ニーズが明確になった時点で) |
+
+## Issue #137 の状態
+
+本 PR は **Issue #137 #1 のみ対応**、Issue は **close せず open 維持**。残課題:
+
+- **#2 残り**: collection-level guard (array 合計 byte 閾値で early summarize)
+- **#5**: batch log の pathPrefixes histogram
+- **#6**: logger.warnSampled altitude (別 milestone 検討案件)
+- **新規候補**: mimeType observability (codex Low-Medium 指摘)
+
+## 次のアクション
+
+### 直近 (本セッション継続中)
+
+1. **T9**: `git push -u origin feature/non-image-data-uri-detection` + `gh pr create` — feature ブランチを push し PR 作成
+2. **T10**: CI Success 確認 (Cloud Run dev デプロイ) → 本田様の番号単位明示認可待ち → `gh pr merge --squash --auto`
+
+### マージ後の手動確認 (本田様判断)
+
+- **Cloud Logging で `safetyEvent: 'non-image-data-uri-omitted'` / `non-image-data-uri-omitted-batch` の発火確認** (本番 dev 環境で実トラフィック発生時)
+- 既存待ち事項 (Cloud Logging で `image-omitted` 系発火確認 / モバイル実機確認 / 法務 / 多ターン E2E) は本 PR と独立で継続
+
+### 中期 (本田様の優先順位判断)
+
+- Issue #137 残課題 (#2 残り / #5 / #6 / mimeType observability) を次回セッションで個別 PR 化検討
+- 緊急性 LOW + size guard backstop 機能中で実害なし状態は維持
+
+## 学び / 規律
+
+- **brainstorm + codex セカンドオピニオン + safe-refactor + code-review** の 4 段検証が小規模設計でも有効
+- 「**設計文書 1 commit + 実装 1 commit + handoff 1 commit**」の規律で feature ブランチを clean に保つ (今 PR は数値補正の追加 1 commit を含めて計 4 commit 想定)
+- AC-1〜15 を**設計文書時点で明示**し、TDD で test 名を `AC-N: ...` で一意化したことで設計-実装-テストの 3 層 traceability が確保された

--- a/docs/spec/promptSafety/2026-06-03-non-image-data-uri-detection-design.md
+++ b/docs/spec/promptSafety/2026-06-03-non-image-data-uri-detection-design.md
@@ -68,15 +68,27 @@ stripPromptHeavyFields(data)
 
 | 名前 | 改修内容 |
 |---|---|
-| `isImageDataUri(value: string): boolean` | normalize 後 string を判定し case-insensitive 化。signature 不変、byte 計測も normalize 後 string に統一 |
+| `isImageDataUri(value: string): boolean` | normalize 後 string を判定し case-insensitive 化。signature 不変、**判定 byte 計測** (下記「byte 計測の規律」(a)) も normalize 後 string に統一 |
 
 ### byte 計測の規律
 
+byte 計測は **「判定 byte」** と **「ログ payload bytes」** で対象が異なる。両者は別の目的のため意図的に分離する (PR #143 review-pr comment-analyzer Critical 指摘の解消)。
+
+#### (a) 判定 byte 計測 (`isImageDataUri` / `isNonImageDataUri` 内)
+
 `Buffer.byteLength(normalized, 'utf8')` で **normalize 後 string** を計測する。理由:
 
-1. trimStart で削った先頭空白を payload byte 数に含めるのは「実 payload 評価」として不適切
+1. trimStart で削った先頭空白を判定 byte 数に含めるのは「実 payload 評価」として不適切
 2. image / non-image 側で計測対象を揃えることで判定の一貫性を保つ
 3. trimStart で減る byte は数文字 (現実的に < 10B) であり、500B 閾値に対する影響は無視可能
+
+#### (b) ログ payload bytes 計測 (`tick(() => ({ ..., bytes }))` 内)
+
+`Buffer.byteLength(value, 'utf8')` で **元 string** を計測する。理由:
+
+1. forensic 価値: Cloud Logging で「ユーザーが実際に送った byte 数」を残す方が攻撃面分析・運用観測で有用 (先頭空白を含む真の入力サイズが分かる)
+2. 既存 image 側 (PR #139 / #140) の payload 規律と同じ measurement target を継承し、`safetyEvent: 'image-omitted'` / `'non-image-data-uri-omitted'` で bytes フィールドの意味を統一する
+3. normalize の trim 差は実用上 < 10B で payload 解釈に影響しない
 
 ## 5. インターフェース
 

--- a/docs/spec/promptSafety/2026-06-03-non-image-data-uri-detection-design.md
+++ b/docs/spec/promptSafety/2026-06-03-non-image-data-uri-detection-design.md
@@ -1,0 +1,204 @@
+# 非画像 dataURI 検出層追加設計 (Issue #137 #1)
+
+- **作成日**: 2026-06-03
+- **関連 Issue**: [#137](https://github.com/Yukina1116/novel-writer/issues/137) #1 (non-image dataURI gap)
+- **関連 PR (祖先)**: #136 (Issue #134 part 1), #138 (Issue #137 #2), #139 (Issue #137 #3), #140 / #141 (Issue #137 #4)
+- **対象モジュール**: `server/utils/promptSafety.ts`
+- **ステータス**: Design (Phase 6, brainstorm Skill)
+- **緊急性**: LOW (size guard backstop が機能中で実害発生中ではない)
+
+---
+
+## 1. 概要 / 動機
+
+`stripPromptHeavyFields` は Issue #134 で content-based 検出に進化したが、画像専用 prefix `data:image/` に narrow したため、非画像 dataURI (`data:application/pdf;base64,...`, `data:audio/mp3;base64,...`, `data:font/woff2;base64,...` 等) が `MIN_IMAGE_DATA_URI_BYTES=500` と `MAX_FIELD_BYTES=100_000` の gap 帯 (500B〜100KB) で**両 guard を素通し**する設計上の gap が新設された。
+
+実用上の到達経路は `longDescription` / `memo` / `world fields[].value` 等の text-area への直接ペースト。80KB の base64 ≈ 20K tokens (Gemini 131K context の 20%) を消費し、他フィールド合算で token budget を圧迫する。
+
+本設計は、Issue #134 が掲げた**「content-based で register-or-forget リスクを構造的に解消」**理念を非画像 dataURI にも拡張し、image 系と対称な検出層を追加することで gap を構造的に閉じる。
+
+## 2. 要件
+
+### 機能要件
+
+- **FR-1**: 非画像 dataURI (`data:` で始まり `data:image/` で始まらない) で UTF-8 byte 長が 500 以上の string を AI プロンプトから omission marker に置換する
+- **FR-2**: 画像 dataURI 判定 (`isImageDataUri`) を case-insensitive 化し、`DATA:IMAGE/PNG;base64,...` も既存と同じ `IMAGE_OMITTED_MARKER` に置換する (codex セカンドオピニオン Medium 指摘の解消)
+- **FR-3**: 短文 MIME 説明 (`data:image/png は base64 形式`, `data:text/plain;base64,SGVsbG8=` 等) は引き続き素通し (false positive ゼロ維持)
+- **FR-4**: 集約 log は per-call 50 件上限 + `non-image-data-uri-omitted-batch` event で amplification 抑制 (image 系と独立した batch event)
+
+### 非機能要件
+
+- **NFR-1**: `stripPromptHeavyFields(data: unknown): unknown` の signature 不変、既存呼出側 (`worldService`, `characterService`, `characterPrompt`) は無変更
+- **NFR-2**: `truncateOversizedStrings` (size guard backstop) には触れず、`MAX_FIELD_BYTES=100_000` の altitude を維持
+- **NFR-3**: 既存テスト 569 件全 PASS (regression なし)
+- **NFR-4**: 入力 mutate なし (pure helpers の規律維持)
+
+## 3. アーキテクチャ
+
+### 追加位置
+
+`server/utils/promptSafety.ts` 内の `stripPromptHeavyFields` の string 判定経路に**並列追加** (`isImageDataUri` の sibling)。新規ファイルなし、新規モジュール作成なし。
+
+```
+stripPromptHeavyFields(data)
+  └─ recurse(value, path, depth)
+       └─ if typeof value === 'string':
+            ├─ isImageDataUri(value)?       → imageAggregator.tick + IMAGE_OMITTED_MARKER
+            ├─ isNonImageDataUri(value)?    → nonImageAggregator.tick + NON_IMAGE_DATA_URI_MARKER  ← 新規
+            └─ else                          → 素通し
+```
+
+### 判定順 (重要)
+
+`isImageDataUri` を**先**に評価し、image でなければ `isNonImageDataUri` を評価する。逆順にすると `data:image/png;base64,...` が `NON_IMAGE` 側で誤判定される。AC-7 / AC-15 で regression pin する。
+
+## 4. データモデル
+
+### 新規定数 / helper
+
+| 名前 | 種別 | 値 | 役割 |
+|---|---|---|---|
+| `DATA_URI_PREFIX` | private const | `'data:'` | normalize 後の prefix 判定 |
+| `MIN_NON_IMAGE_DATA_URI_BYTES` | private const | `500` | false-positive guard (image 側 `MIN_IMAGE_DATA_URI_BYTES` と対称) |
+| `NON_IMAGE_DATA_URI_MARKER` | **export** const | `'[non-image-data-uri: omitted from prompt to fit token budget]'` | AI 向け代替マーカー |
+| `normalizeForDataUriDetection(s: string): string` | private fn | `s.trimStart().toLowerCase()` | case-insensitive + 先頭空白吸収 |
+| `isNonImageDataUri(value: string): boolean` | private fn (新規) | normalize 後 `startsWith('data:') && !startsWith('data:image/')` && byte ≥ `MIN_NON_IMAGE_DATA_URI_BYTES` | 非画像 dataURI 判定 |
+
+### 既存改修
+
+| 名前 | 改修内容 |
+|---|---|
+| `isImageDataUri(value: string): boolean` | normalize 後 string を判定し case-insensitive 化。signature 不変、byte 計測も normalize 後 string に統一 |
+
+### byte 計測の規律
+
+`Buffer.byteLength(normalized, 'utf8')` で **normalize 後 string** を計測する。理由:
+
+1. trimStart で削った先頭空白を payload byte 数に含めるのは「実 payload 評価」として不適切
+2. image / non-image 側で計測対象を揃えることで判定の一貫性を保つ
+3. trimStart で減る byte は数文字 (現実的に < 10B) であり、500B 閾値に対する影響は無視可能
+
+## 5. インターフェース
+
+### 公開 API (export)
+
+- 既存: `IMAGE_OMITTED_MARKER`, `OVERSIZED_STRING_MARKER`, `MAX_FIELD_BYTES`, `RECURSION_DEPTH_EXCEEDED_MARKER`, `WarnAggregatorPayload`, `WarnAggregator`, `createWarnAggregator`, `stripPromptHeavyFields`, `truncateOversizedStrings`, `sanitizeForPrompt`
+- **新規追加**: `NON_IMAGE_DATA_URI_MARKER`
+
+### 関数 signature
+
+| 関数 | signature |
+|---|---|
+| `stripPromptHeavyFields(data: unknown): unknown` | **不変** |
+| `truncateOversizedStrings(data: unknown, maxBytes?: number): unknown` | **不変** |
+| `sanitizeForPrompt(data: unknown, maxBytes?: number): unknown` | **不変** |
+
+### 呼出側影響
+
+`worldService` / `characterService` / `characterPrompt` は全て不変。
+
+## 6. エラー処理 / 観測性
+
+### per-call warn aggregator
+
+既存 `createWarnAggregator(individualEvent, individualMessage)` factory を再利用:
+
+```ts
+const nonImageAggregator = createWarnAggregator(
+  'non-image-data-uri-omitted',
+  'promptSafety: non-image dataURI stripped'
+);
+```
+
+- 個別 warn payload: `{ path: string, bytes: number }`
+- batch event: factory が `'non-image-data-uri-omitted-batch'` を機械派生 (#137 #4 残り b の規律)
+- batch message: `'promptSafety: non-image-data-uri-omitted warn amplification suppressed'`
+- MAX_WARN_PER_CALL=50 上限を自動継承
+- imageAggregator と独立 counter (cross-event independence、PR #140 の方針と整合)
+
+### lazy payload builder
+
+`tick(() => ({ path, bytes: Buffer.byteLength(value, 'utf8') }))` 形式で payload を closure 化し、threshold 超後は Buffer.byteLength 計算を skip (PR #140 で確立した altitude を継承)。
+
+### mimeType observability (本 PR スコープ外)
+
+codex 指摘 Low-Medium。個別 warn payload に MIME 種別 (`,` までの media type、lower-case + 長さ cap) を追加する案は運用ニーズが明確になった時点で**別 Issue として起票**する。本 PR では `{ path, bytes }` のみ。
+
+## 7. テスト戦略 (Acceptance Criteria)
+
+`server/utils/promptSafety.test.ts` に以下 15 件を追加 (既存 569 件は不変):
+
+| # | テスト | 期待 |
+|---|---|---|
+| AC-1 | `{ pdf: 'data:application/pdf;base64,' + 'A'.repeat(800) }` | pdf フィールドが `NON_IMAGE_DATA_URI_MARKER` に置換 |
+| AC-2 | `{ audio: 'data:audio/mp3;base64,' + 'B'.repeat(800) }` | audio フィールドが marker 置換 |
+| AC-3 | `{ font: 'data:font/woff2;base64,' + 'C'.repeat(800) }` | font フィールドが marker 置換 |
+| AC-4 | 既存 fixture 維持: `{ pdf: 'data:application/pdf;base64,' + 'A'.repeat(200) }` (~228B) | 素通し (< 500B 未満) |
+| AC-5 | 既存 fixture 維持: `{ text: 'data:text/plain;base64,SGVsbG8=' }` (~30B) | 素通し |
+| AC-6 | 境界値 499B / 500B / 501B (非画像) | 499→素通し、500→marker、501→marker |
+| AC-7 | `{ image: 'data:image/png;base64,' + 'X'.repeat(800) }` (image 既存 path) | `IMAGE_OMITTED_MARKER` (NON_IMAGE 側でない、判定順 regression pin) |
+| AC-8 | image array 100 件 + non-image array 100 件 | `image-omitted-batch` と `non-image-data-uri-omitted-batch` が**別 event** で集約 emit (cross-event independence) |
+| AC-9 | `{ appearance: { imageUrl: '<image 800B>' }, memo: '<non-image 800B>' }` | path log: 個別 warn (先頭 50 件) に `appearance.imageUrl` と `memo` が含まれる |
+| AC-10 | 既存 569 件全 PASS (regression なし) | `npm test` で確認 |
+| AC-11 | `{ pdf: 'DATA:application/pdf;base64,' + 'A'.repeat(800) }` (大文字 prefix) | `NON_IMAGE_DATA_URI_MARKER` (case insensitive 化の検証) |
+| AC-12 | `{ pdf: '\n data:application/pdf;base64,' + 'A'.repeat(800) }` (先頭空白) | `NON_IMAGE_DATA_URI_MARKER` (空白吸収) |
+| AC-13 | `{ empty: 'data:;base64,' + 'A'.repeat(800) }` (空 MIME) | `NON_IMAGE_DATA_URI_MARKER` (非画像扱い) |
+| AC-14 | `{ no_b64: 'data:,' + 'A'.repeat(800) }` (no base64 / mediatype) | `NON_IMAGE_DATA_URI_MARKER` (非画像扱い、byte ≥ 500) |
+| AC-15 | `{ image: 'DATA:IMAGE/PNG;base64,' + 'X'.repeat(800) }` (image 大文字) | `IMAGE_OMITTED_MARKER` (image 側 case insensitive 化の regression pin) |
+
+### テストの位置付け
+
+- **AC-1〜3**: 主要 MIME 種別での marker 置換 (基本動作)
+- **AC-4〜5**: 既存 fixture 維持 (false positive guard 確認)
+- **AC-6**: 境界値 (image 側の `MIN_IMAGE_DATA_URI_BYTES` テストパターンと対称)
+- **AC-7**: 判定順 pin (image 先評価)
+- **AC-8**: cross-event independence (factory 再利用が破綻していないこと)
+- **AC-9**: path 観測性 (Cloud Logging の forensics 価値担保)
+- **AC-10**: regression suite
+- **AC-11〜14**: codex セカンドオピニオン Medium 指摘の test 化 (case variant / 空白 / 空 MIME / no base64)
+- **AC-15**: image 側 case insensitive 化の regression pin
+
+## 8. スコープ外 / 将来課題
+
+| 項目 | 理由 |
+|---|---|
+| **mimeType observability** (個別 warn payload に MIME 種別追加) | 運用ニーズが明確になった時点で別 Issue 起票。現状の `{ path, bytes }` で基本観測性は十分 |
+| **FE 側 text-area サニタイズ** (元の案 C) | 別 Issue。BE 側 (本 PR) で構造的閉鎖が完了するため、FE は UX フィードバック (ペースト時警告) 目的で別途検討 |
+| **MAX_FIELD_BYTES 引き下げ** (元の案 A) | false positive 観測ベースで別途検討。現状は justification (100KB ≈ 小説 1 章) を覆す根拠なし |
+| **logger.warnSampled altitude** (#137 #6) | 別 milestone での検討案件 (blast radius 大) |
+| **collection-level guard** (#137 #2 残り) | 本 PR スコープ外。array 合計 byte 閾値は別途検討 |
+| **batch log の pathPrefixes histogram** (#137 #5) | observability enhancement、別 PR で対応 |
+
+## 9. Open Questions
+
+なし (codex セカンドオピニオン後の Phase 4 への部分回帰で全論点が解消済み)。
+
+## 10. リスクと緩和
+
+| リスク | 影響 | 緩和策 |
+|---|---|---|
+| `MIN_NON_IMAGE_DATA_URI_BYTES=500` が実プロダクトデータで false positive を引き起こす | 通常テキストが marker 置換される | AC-4/5 で既存 fixture 素通しを pin、Cloud Logging で `safetyEvent: 'non-image-data-uri-omitted'` の発火頻度を本番デプロイ後に観測 |
+| `normalizeForDataUriDetection` の trim 範囲 (先頭のみ) が攻撃面を残す | 末尾空白付き dataURI が素通し | data URI 仕様上、scheme 識別は先頭のみで成立。末尾空白は base64 payload に含めても valid decoding になるため、防御対象外で OK |
+| image 側 case insensitive 化が既存 fixture を変質させる | 既存テストが想定外挙動になる | 既存 fixture は全て小文字 `data:image/` で記述されており影響なし。AC-15 で大文字パターンの新規挙動を pin |
+| `'data:,' + 'A'.repeat(800)` のような degenerate input が `NON_IMAGE` 側に流れる | spec 上 valid だが picture-less dataURI が marker 化される | spec 通りの仕様化 (AC-14 で意図確認)。prompt token を食う以上 marker 化は妥当判断 |
+
+## 11. 実装手順 (Phase 9 で `/impl-plan` に渡す要約)
+
+1. `promptSafety.ts` に `DATA_URI_PREFIX`, `MIN_NON_IMAGE_DATA_URI_BYTES`, `NON_IMAGE_DATA_URI_MARKER`, `normalizeForDataUriDetection`, `isNonImageDataUri` を追加
+2. 既存 `isImageDataUri` を normalize 後 string ベースの判定に改修 (case insensitive 化)
+3. `stripPromptHeavyFields` 内に `nonImageAggregator` を追加し、recurse の string 経路に判定追加 (image 先評価)
+4. `promptSafety.test.ts` に AC-1〜15 を TDD で追加 (AC-7 / AC-15 を先に書き判定順の regression pin)
+5. `npm test` / `npm run lint` 全 PASS 確認
+6. handoff 文書を `docs/handoff/` に追加 (実装完了後)
+
+## 12. 参考資料
+
+- Issue #134 (whitelist → content-based 移行提案、本設計の祖)
+- PR #136 (Issue #134 part 1)
+- Issue #137 #1 (本設計の対象)
+- PR #138 (Issue #137 #2、MIN_IMAGE_DATA_URI_BYTES 100→500)
+- PR #139 (Issue #137 #3、per-call warn aggregation)
+- PR #140 / #141 (Issue #137 #4、createWarnAggregator factory 抽出)
+- RFC 2397 (The "data" URL scheme): media type は case-insensitive
+- RFC 3986 (URI Generic Syntax): scheme 部 (`data:` 等) は case-insensitive
+- codex セカンドオピニオン (2026-06-03、Phase 5 で実施)

--- a/docs/spec/promptSafety/2026-06-03-non-image-data-uri-detection-design.md
+++ b/docs/spec/promptSafety/2026-06-03-non-image-data-uri-detection-design.md
@@ -30,7 +30,7 @@
 
 - **NFR-1**: `stripPromptHeavyFields(data: unknown): unknown` の signature 不変、既存呼出側 (`worldService`, `characterService`, `characterPrompt`) は無変更
 - **NFR-2**: `truncateOversizedStrings` (size guard backstop) には触れず、`MAX_FIELD_BYTES=100_000` の altitude を維持
-- **NFR-3**: 既存テスト 569 件全 PASS (regression なし)
+- **NFR-3**: 既存テスト 571 件全 PASS (regression なし)。なお `store/backupSlice.test.ts > T5: AwaitingPassphrase → Decrypting → Idle (retry == MAX, force close + toast)` は M6 PR-C 領域の **flaky timeout (5000ms 上限、再実行で 500ms で PASS)** で本 Issue と無関係。本 PR で対応しない
 - **NFR-4**: 入力 mutate なし (pure helpers の規律維持)
 
 ## 3. アーキテクチャ
@@ -139,7 +139,7 @@ codex 指摘 Low-Medium。個別 warn payload に MIME 種別 (`,` までの med
 | AC-7 | `{ image: 'data:image/png;base64,' + 'X'.repeat(800) }` (image 既存 path) | `IMAGE_OMITTED_MARKER` (NON_IMAGE 側でない、判定順 regression pin) |
 | AC-8 | image array 100 件 + non-image array 100 件 | `image-omitted-batch` と `non-image-data-uri-omitted-batch` が**別 event** で集約 emit (cross-event independence) |
 | AC-9 | `{ appearance: { imageUrl: '<image 800B>' }, memo: '<non-image 800B>' }` | path log: 個別 warn (先頭 50 件) に `appearance.imageUrl` と `memo` が含まれる |
-| AC-10 | 既存 569 件全 PASS (regression なし) | `npm test` で確認 |
+| AC-10 | 既存 571 件全 PASS (regression なし)。flaky T5 (M6 backupSlice) は本 Issue 範囲外で除外 | `npm test` で確認 |
 | AC-11 | `{ pdf: 'DATA:application/pdf;base64,' + 'A'.repeat(800) }` (大文字 prefix) | `NON_IMAGE_DATA_URI_MARKER` (case insensitive 化の検証) |
 | AC-12 | `{ pdf: '\n data:application/pdf;base64,' + 'A'.repeat(800) }` (先頭空白) | `NON_IMAGE_DATA_URI_MARKER` (空白吸収) |
 | AC-13 | `{ empty: 'data:;base64,' + 'A'.repeat(800) }` (空 MIME) | `NON_IMAGE_DATA_URI_MARKER` (非画像扱い) |

--- a/server/utils/promptSafety.test.ts
+++ b/server/utils/promptSafety.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { logger } from './logger';
 import {
   IMAGE_OMITTED_MARKER,
+  NON_IMAGE_DATA_URI_MARKER,
   OVERSIZED_STRING_MARKER,
   MAX_FIELD_BYTES,
   stripPromptHeavyFields,
@@ -656,5 +657,181 @@ describe('createWarnAggregator factory unit (Issue #137 #4 残り)', () => {
     for (let i = 0; i < 100; i++) agg.tick(buildPayload);
     // 最初の 50 件のみ builder が呼ばれる
     expect(buildCalls).toBe(50);
+  });
+});
+
+// === Issue #137 #1: 非画像 dataURI 検出層 (PDF / audio / font 等の 500B〜100KB 帯 gap 閉鎖) ===
+
+describe('stripPromptHeavyFields - 非画像 dataURI 検出 (Issue #137 #1)', () => {
+  // AC-1〜3: 主要 MIME 種別での marker 置換 (基本動作)
+
+  it('AC-1: replaces non-image dataURI (application/pdf, 800B) with NON_IMAGE_DATA_URI_MARKER', () => {
+    const big = `data:application/pdf;base64,${'A'.repeat(800)}`;
+    const out = stripPromptHeavyFields({ pdf: big }) as { pdf: string };
+    expect(out.pdf).toBe(NON_IMAGE_DATA_URI_MARKER);
+  });
+
+  it('AC-2: replaces non-image dataURI (audio/mp3, 800B) with NON_IMAGE_DATA_URI_MARKER', () => {
+    const big = `data:audio/mp3;base64,${'B'.repeat(800)}`;
+    const out = stripPromptHeavyFields({ audio: big }) as { audio: string };
+    expect(out.audio).toBe(NON_IMAGE_DATA_URI_MARKER);
+  });
+
+  it('AC-3: replaces non-image dataURI (font/woff2, 800B) with NON_IMAGE_DATA_URI_MARKER', () => {
+    const big = `data:font/woff2;base64,${'C'.repeat(800)}`;
+    const out = stripPromptHeavyFields({ font: big }) as { font: string };
+    expect(out.font).toBe(NON_IMAGE_DATA_URI_MARKER);
+  });
+
+  // AC-4, AC-5: false positive guard (既存規律の維持 pin)
+
+  it('AC-4: pdf 200B (~228B, < 500) passes through unchanged (false positive guard)', () => {
+    const data = { pdf: `data:application/pdf;base64,${'A'.repeat(200)}` };
+    const out = stripPromptHeavyFields(data) as typeof data;
+    expect(out.pdf).toBe(data.pdf);
+    expect(out.pdf).not.toBe(NON_IMAGE_DATA_URI_MARKER);
+  });
+
+  it('AC-5: data:text/plain;base64,SGVsbG8= (~30B) passes through unchanged (短文 MIME 説明)', () => {
+    const data = { text: 'data:text/plain;base64,SGVsbG8=' };
+    const out = stripPromptHeavyFields(data) as typeof data;
+    expect(out.text).toBe(data.text);
+    expect(out.text).not.toBe(NON_IMAGE_DATA_URI_MARKER);
+  });
+
+  // AC-6: 境界値 (MIN_NON_IMAGE_DATA_URI_BYTES = 500)
+
+  it('AC-6a: non-image dataURI of exactly 499 bytes passes through unchanged', () => {
+    // prefix `data:application/pdf;base64,` = 28 bytes, payload 471 bytes → total 499 bytes
+    const justBelow = `data:application/pdf;base64,${'A'.repeat(471)}`;
+    expect(Buffer.byteLength(justBelow, 'utf8')).toBe(499);
+    const out = stripPromptHeavyFields({ pdf: justBelow }) as { pdf: string };
+    expect(out.pdf).toBe(justBelow);
+  });
+
+  it('AC-6b: non-image dataURI of exactly 500 bytes IS replaced with marker', () => {
+    const exactlyMin = `data:application/pdf;base64,${'A'.repeat(472)}`;
+    expect(Buffer.byteLength(exactlyMin, 'utf8')).toBe(500);
+    const out = stripPromptHeavyFields({ pdf: exactlyMin }) as { pdf: string };
+    expect(out.pdf).toBe(NON_IMAGE_DATA_URI_MARKER);
+  });
+
+  it('AC-6c: non-image dataURI of exactly 501 bytes IS replaced with marker', () => {
+    const justAbove = `data:application/pdf;base64,${'A'.repeat(473)}`;
+    expect(Buffer.byteLength(justAbove, 'utf8')).toBe(501);
+    const out = stripPromptHeavyFields({ pdf: justAbove }) as { pdf: string };
+    expect(out.pdf).toBe(NON_IMAGE_DATA_URI_MARKER);
+  });
+
+  // AC-7: 判定順 regression pin (image 先評価)
+
+  it('AC-7: image dataURI gets IMAGE_OMITTED_MARKER (not NON_IMAGE_DATA_URI_MARKER, image 先評価 pin)', () => {
+    const big = `data:image/png;base64,${'X'.repeat(800)}`;
+    const out = stripPromptHeavyFields({ image: big }) as { image: string };
+    expect(out.image).toBe(IMAGE_OMITTED_MARKER);
+    expect(out.image).not.toBe(NON_IMAGE_DATA_URI_MARKER);
+  });
+
+  // AC-11〜14: codex セカンドオピニオン Medium 指摘の test 化
+
+  it('AC-11: DATA:application/pdf;base64,... (大文字 prefix, 800B) is replaced with NON_IMAGE_DATA_URI_MARKER (case insensitive)', () => {
+    const big = `DATA:application/pdf;base64,${'A'.repeat(800)}`;
+    const out = stripPromptHeavyFields({ pdf: big }) as { pdf: string };
+    expect(out.pdf).toBe(NON_IMAGE_DATA_URI_MARKER);
+  });
+
+  it('AC-12: leading whitespace + data:... (\\n + space prefix, 800B) is replaced with NON_IMAGE_DATA_URI_MARKER', () => {
+    const big = `\n data:application/pdf;base64,${'A'.repeat(800)}`;
+    const out = stripPromptHeavyFields({ pdf: big }) as { pdf: string };
+    expect(out.pdf).toBe(NON_IMAGE_DATA_URI_MARKER);
+  });
+
+  it('AC-13: data:;base64,... (空 MIME, 800B) is replaced with NON_IMAGE_DATA_URI_MARKER', () => {
+    const big = `data:;base64,${'A'.repeat(800)}`;
+    const out = stripPromptHeavyFields({ empty: big }) as { empty: string };
+    expect(out.empty).toBe(NON_IMAGE_DATA_URI_MARKER);
+  });
+
+  it('AC-14: data:,... (no mediatype/base64, byte ≥ 500) is replaced with NON_IMAGE_DATA_URI_MARKER', () => {
+    const big = `data:,${'A'.repeat(800)}`;
+    const out = stripPromptHeavyFields({ noB64: big }) as { noB64: string };
+    expect(out.noB64).toBe(NON_IMAGE_DATA_URI_MARKER);
+  });
+});
+
+describe('stripPromptHeavyFields - 画像 dataURI 検出 case insensitive 化 (Issue #137 #1 / codex 指摘)', () => {
+  it('AC-15: DATA:IMAGE/PNG;base64,... (image 大文字, 800B) is replaced with IMAGE_OMITTED_MARKER (existing isImageDataUri case insensitive 化の regression pin)', () => {
+    const big = `DATA:IMAGE/PNG;base64,${'X'.repeat(800)}`;
+    const out = stripPromptHeavyFields({ image: big }) as { image: string };
+    expect(out.image).toBe(IMAGE_OMITTED_MARKER);
+  });
+});
+
+describe('non-image dataURI observability + cross-event independence (Issue #137 #1)', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+  });
+
+  it('AC-8: image array 100 + non-image array 100 emits image-omitted-batch と non-image-data-uri-omitted-batch 別 event で集約 (cross-event independence)', () => {
+    const imageBig = `data:image/png;base64,${'A'.repeat(600)}`;
+    const nonImageBig = `data:application/pdf;base64,${'B'.repeat(600)}`;
+    const payload = {
+      images: Array.from({ length: 100 }, () => imageBig),
+      pdfs: Array.from({ length: 100 }, () => nonImageBig),
+    };
+    stripPromptHeavyFields(payload);
+
+    // image-omitted: 50 個別 + 1 batch
+    const imageIndividual = warnSpy.mock.calls.filter(
+      (c) => (c[0] as { safetyEvent?: string }).safetyEvent === 'image-omitted'
+    );
+    expect(imageIndividual).toHaveLength(50);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        safetyEvent: 'image-omitted-batch',
+        totalCount: 100,
+        loggedCount: 50,
+        omittedCount: 50,
+      })
+    );
+
+    // non-image-data-uri-omitted: 50 個別 + 1 batch
+    const nonImageIndividual = warnSpy.mock.calls.filter(
+      (c) => (c[0] as { safetyEvent?: string }).safetyEvent === 'non-image-data-uri-omitted'
+    );
+    expect(nonImageIndividual).toHaveLength(50);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        safetyEvent: 'non-image-data-uri-omitted-batch',
+        totalCount: 100,
+        loggedCount: 50,
+        omittedCount: 50,
+      })
+    );
+  });
+
+  it('AC-9: path log differentiates image (appearance.imageUrl) from non-image (memo) in individual warn', () => {
+    const imageBig = `data:image/png;base64,${'A'.repeat(800)}`;
+    const nonImageBig = `data:application/pdf;base64,${'B'.repeat(800)}`;
+    stripPromptHeavyFields({
+      appearance: { imageUrl: imageBig },
+      memo: nonImageBig,
+    });
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        safetyEvent: 'image-omitted',
+        path: 'appearance.imageUrl',
+        bytes: Buffer.byteLength(imageBig, 'utf8'),
+      })
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        safetyEvent: 'non-image-data-uri-omitted',
+        path: 'memo',
+        bytes: Buffer.byteLength(nonImageBig, 'utf8'),
+      })
+    );
   });
 });

--- a/server/utils/promptSafety.test.ts
+++ b/server/utils/promptSafety.test.ts
@@ -4,6 +4,7 @@ import {
   IMAGE_OMITTED_MARKER,
   NON_IMAGE_DATA_URI_MARKER,
   OVERSIZED_STRING_MARKER,
+  RECURSION_DEPTH_EXCEEDED_MARKER,
   MAX_FIELD_BYTES,
   stripPromptHeavyFields,
   truncateOversizedStrings,
@@ -833,5 +834,73 @@ describe('non-image dataURI observability + cross-event independence (Issue #137
         bytes: Buffer.byteLength(nonImageBig, 'utf8'),
       })
     );
+  });
+});
+
+// === PR #143 review-pr (pr-test-analyzer Medium) hardening 追加 ===
+
+describe('非画像 dataURI 検出 hardening (PR #143 review-pr 指摘反映)', () => {
+  it('mixed array: image + non-image + plain + 空文字 が混在しても各 marker が正しい位置・順序で置換される', () => {
+    // pr-test-analyzer Medium: 混在 array で aggregator state が乱れず、recursion 順序が保たれることを pin。
+    const imageBig = `data:image/png;base64,${'A'.repeat(600)}`;
+    const nonImageBig = `data:application/pdf;base64,${'B'.repeat(600)}`;
+    const data = {
+      mixed: [imageBig, nonImageBig, 'plain text', '', 'https://x', imageBig],
+    };
+    const out = stripPromptHeavyFields(data) as { mixed: string[] };
+    expect(out.mixed[0]).toBe(IMAGE_OMITTED_MARKER);
+    expect(out.mixed[1]).toBe(NON_IMAGE_DATA_URI_MARKER);
+    expect(out.mixed[2]).toBe('plain text');
+    expect(out.mixed[3]).toBe('');
+    expect(out.mixed[4]).toBe('https://x');
+    expect(out.mixed[5]).toBe(IMAGE_OMITTED_MARKER);
+  });
+
+  it('depth boundary × non-image dataURI: depth === MAX_RECURSION_DEPTH (1000) では non-image marker、depth > では depth marker (guard 順序 pin)', () => {
+    // pr-test-analyzer Medium: depth-exceeded vs non-image marker の判定順 (depth guard が先) を pin。
+    // depth guard は recurse 冒頭で評価される (promptSafety.ts:330)。
+    // 1000 段ネスト内に non-image dataURI を置くと、leaf に到達した時点では depth === 1000 で
+    // guard 内 ((depth > MAX_RECURSION_DEPTH) === false)、よって non-image marker になる。
+    // 1001 段以降のネスト構造を組むと depth > 1000 で depth marker。
+    const nonImageBig = `data:application/pdf;base64,${'A'.repeat(800)}`;
+
+    // depth ちょうど 1000 (recurse 内 depth 値が 1000) — non-image marker になるべき
+    let atLimit: Record<string, unknown> = { leaf: nonImageBig };
+    for (let i = 0; i < 999; i++) atLimit = { a: atLimit };
+    // depth 0 (root) → depth 1 (a.) → ... → depth 999 (.a.) → depth 1000 (leaf)
+    // recurse(value=nonImageBig, path=..., depth=1000) で if (depth > 1000) false → string 判定で non-image marker
+    const outAtLimit = stripPromptHeavyFields(atLimit) as Record<string, unknown>;
+    // 最深 leaf を辿るのは煩雑なので JSON.stringify でマーカー出現を確認
+    const serializedAtLimit = JSON.stringify(outAtLimit);
+    expect(serializedAtLimit).toContain(NON_IMAGE_DATA_URI_MARKER);
+    expect(serializedAtLimit).not.toContain(RECURSION_DEPTH_EXCEEDED_MARKER);
+
+    // depth 1001 超 (over limit) — depth marker になるべき
+    let beyondLimit: Record<string, unknown> = { leaf: nonImageBig };
+    for (let i = 0; i < 1500; i++) beyondLimit = { a: beyondLimit };
+    const outBeyond = stripPromptHeavyFields(beyondLimit) as Record<string, unknown>;
+    const serializedBeyond = JSON.stringify(outBeyond);
+    expect(serializedBeyond).toContain(RECURSION_DEPTH_EXCEEDED_MARKER);
+    // beyondLimit は途中で depth marker に置換されるため、深い non-image leaf は到達せず marker 化されない
+    expect(serializedBeyond).not.toContain(NON_IMAGE_DATA_URI_MARKER);
+  });
+
+  it('prototype pollution skip × non-image dataURI: __proto__ key を持つ payload で non-image dataURI も sanitize される (対称性 pin)', () => {
+    // pr-test-analyzer Medium: 既存テスト (L195 付近) は image dataURI + __proto__。
+    // 非画像 dataURI でも同じ規律 (key drop + 残り subtree の sanitize) が適用されることを pin。
+    const malicious: Record<string, unknown> = JSON.parse(
+      '{"__proto__":{"polluted":true},"name":"Bob","memo":"data:application/pdf;base64,' +
+        'A'.repeat(600) +
+        '"}'
+    );
+    const out = stripPromptHeavyFields(malicious) as Record<string, unknown>;
+
+    // prototype 汚染が防御されている
+    expect(Object.getPrototypeOf(out)).toBe(Object.prototype);
+    expect((out as { polluted?: boolean }).polluted).toBeUndefined();
+    // 正当な own properties は保持
+    expect(out.name).toBe('Bob');
+    // 非画像 dataURI は marker 置換される (image 側と対称)
+    expect(out.memo).toBe(NON_IMAGE_DATA_URI_MARKER);
   });
 });

--- a/server/utils/promptSafety.ts
+++ b/server/utils/promptSafety.ts
@@ -24,6 +24,12 @@ import { logger } from './logger';
 /** AI プロンプトから除外された生成画像の代替マーカー。AI に「画像が存在する」事実だけ伝える。 */
 export const IMAGE_OMITTED_MARKER = '[generated-image: omitted from prompt to fit token budget]';
 
+/**
+ * AI プロンプトから除外された非画像 dataURI (PDF / audio / font 等) の代替マーカー (Issue #137 #1)。
+ * 画像系の `IMAGE_OMITTED_MARKER` と対称に「非画像 dataURI が存在する」事実だけ AI に伝える。
+ */
+export const NON_IMAGE_DATA_URI_MARKER = '[non-image-data-uri: omitted from prompt to fit token budget]';
+
 /** size guard で truncate した文字列の代替マーカー。 */
 export const OVERSIZED_STRING_MARKER = '[oversized-string: truncated to fit token budget]';
 
@@ -42,10 +48,25 @@ export const OVERSIZED_STRING_MARKER = '[oversized-string: truncated to fit toke
 export const MAX_FIELD_BYTES = 100_000;
 
 /**
+ * dataURI 共通 prefix。`isImageDataUri` / `isNonImageDataUri` の判定で normalize 後の
+ * 先頭 prefix 識別に使う (Issue #137 #1)。
+ */
+const DATA_URI_PREFIX = 'data:';
+
+/**
  * 画像 dataURI と判定する prefix。`data:image/` は MIME type の image/* を全てカバー
  * (png, jpeg, webp, gif, svg+xml, avif, heic 等)。
  */
 const IMAGE_DATA_URI_PREFIX = 'data:image/';
+
+/**
+ * 非画像 dataURI false positive guard の最小 byte 数 (Issue #137 #1)。
+ *
+ * image 側の `MIN_IMAGE_DATA_URI_BYTES` (500) と対称に設定し、ナレッジ等に「`data:application/pdf`
+ * という形式の文字列」が短文として含まれる可能性に備える。500B 未満の非画像 dataURI は
+ * 実プロダクトデータとして登場しない極限値 (実 PDF/audio は数 KB 以上が前提)。
+ */
+const MIN_NON_IMAGE_DATA_URI_BYTES = 500;
 
 /**
  * false positive 防止: この byte 長未満の `data:image/` 始まり文字列は素通しする。
@@ -122,12 +143,48 @@ const MAX_WARN_PER_CALL = 50;
 const PROTOTYPE_POLLUTION_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
 
 /**
- * 任意 leaf string が「画像 dataURI と判定すべきか」を返す。
- * - `data:image/` で始まる
- * - UTF-8 byte 長が `MIN_IMAGE_DATA_URI_BYTES` 以上 (false positive 防止)
+ * dataURI 判定のための文字列 normalize (Issue #137 #1 / codex セカンドオピニオン Medium 指摘):
+ *
+ * - `trimStart()` で先頭空白吸収 (`\n data:...` 等を素通しさせない)
+ * - `toLowerCase()` で case insensitive 化 (`DATA:application/pdf` / `DATA:IMAGE/PNG` 等を捕捉)
+ *
+ * 根拠: RFC 2397 で data URI の media type は case-insensitive、RFC 3986 で scheme 部 (`data:`) も
+ * case-insensitive と規定されている。byte 計測も normalize 後 string で行うことで image / non-image
+ * 側の判定基準を揃え、先頭空白が payload byte 数に混入することを防ぐ。
+ */
+function normalizeForDataUriDetection(value: string): string {
+  return value.trimStart().toLowerCase();
+}
+
+/**
+ * 任意 leaf string が「画像 dataURI と判定すべきか」を返す (Issue #137 #1 で case insensitive 化)。
+ * - normalize 後 `data:image/` で始まる
+ * - normalize 後 UTF-8 byte 長が `MIN_IMAGE_DATA_URI_BYTES` 以上 (false positive 防止)
  */
 function isImageDataUri(value: string): boolean {
-  return value.startsWith(IMAGE_DATA_URI_PREFIX) && Buffer.byteLength(value, 'utf8') >= MIN_IMAGE_DATA_URI_BYTES;
+  const normalized = normalizeForDataUriDetection(value);
+  return (
+    normalized.startsWith(IMAGE_DATA_URI_PREFIX) &&
+    Buffer.byteLength(normalized, 'utf8') >= MIN_IMAGE_DATA_URI_BYTES
+  );
+}
+
+/**
+ * 任意 leaf string が「非画像 dataURI と判定すべきか」を返す (Issue #137 #1)。
+ * - normalize 後 `data:` で始まり `data:image/` で始まらない
+ * - normalize 後 UTF-8 byte 長が `MIN_NON_IMAGE_DATA_URI_BYTES` 以上
+ *
+ * 判定順は呼出側で image → non-image の順に評価することを前提とする (recurse 経路で先評価)。
+ * 本関数単独では「画像でない dataURI」かどうかしか判定せず、空 MIME (`data:;base64,...`) や
+ * no-mediatype (`data:,...`) も「非画像」として扱う (prompt token を食う以上 marker 化が妥当)。
+ */
+function isNonImageDataUri(value: string): boolean {
+  const normalized = normalizeForDataUriDetection(value);
+  return (
+    normalized.startsWith(DATA_URI_PREFIX) &&
+    !normalized.startsWith(IMAGE_DATA_URI_PREFIX) &&
+    Buffer.byteLength(normalized, 'utf8') >= MIN_NON_IMAGE_DATA_URI_BYTES
+  );
 }
 
 /**
@@ -263,6 +320,10 @@ function createDepthExceededAggregator(): WarnAggregator {
  */
 export function stripPromptHeavyFields(data: unknown): unknown {
   const imageAggregator = createWarnAggregator('image-omitted', 'promptSafety: image dataURI stripped');
+  const nonImageAggregator = createWarnAggregator(
+    'non-image-data-uri-omitted',
+    'promptSafety: non-image dataURI stripped'
+  );
   const depthAggregator = createDepthExceededAggregator();
 
   function recurse(value: unknown, path: string, depth: number): unknown {
@@ -271,10 +332,19 @@ export function stripPromptHeavyFields(data: unknown): unknown {
       return RECURSION_DEPTH_EXCEEDED_MARKER;
     }
     if (typeof value === 'string') {
-      if (!isImageDataUri(value)) return value;
-      // lazy builder: threshold 超後は Buffer.byteLength(50KB級) 再計算が skip される
-      imageAggregator.tick(() => ({ path, bytes: Buffer.byteLength(value, 'utf8') }));
-      return IMAGE_OMITTED_MARKER;
+      // 判定順は image → non-image (image 側を先評価する規律、AC-7 / AC-15 で pin)。
+      if (isImageDataUri(value)) {
+        // lazy builder: threshold 超後は Buffer.byteLength(50KB級) 再計算が skip される
+        imageAggregator.tick(() => ({ path, bytes: Buffer.byteLength(value, 'utf8') }));
+        return IMAGE_OMITTED_MARKER;
+      }
+      if (isNonImageDataUri(value)) {
+        // Issue #137 #1: 非画像 dataURI (PDF / audio / font 等) を marker 化。
+        // bytes は元 string で計測 (既存 image 側の payload 規律と揃える、normalize の trim 差は無視可能)。
+        nonImageAggregator.tick(() => ({ path, bytes: Buffer.byteLength(value, 'utf8') }));
+        return NON_IMAGE_DATA_URI_MARKER;
+      }
+      return value;
     }
     if (Array.isArray(value)) {
       let changed = false;
@@ -304,6 +374,7 @@ export function stripPromptHeavyFields(data: unknown): unknown {
   }
   const result = recurse(data, '', 0);
   imageAggregator.flush();
+  nonImageAggregator.flush();
   depthAggregator.flush();
   return result;
 }


### PR DESCRIPTION
## Summary

- Issue #137 #1 (non-image dataURI gap: PDF/audio/font 等の 500B〜100KB 帯素通し) を構造的に閉鎖
- `isImageDataUri` を case insensitive 化 (codex セカンドオピニオン Medium 指摘解消)
- 設計文書 (12 セクション) + AC-1〜15 のテスト + handoff 文書を同梱

Issue #137 は **close せず open 維持** (残課題 #2 残り / #5 / #6 + 新規候補 mimeType observability)。

## 変更内容

### `server/utils/promptSafety.ts` (+50 行)

- 新規 export: `NON_IMAGE_DATA_URI_MARKER`
- 新規 private: `DATA_URI_PREFIX`, `MIN_NON_IMAGE_DATA_URI_BYTES=500`, `normalizeForDataUriDetection`, `isNonImageDataUri`
- 改修: `isImageDataUri` を normalize 後判定に変更 (case insensitive 化、`DATA:IMAGE/PNG` 等を捕捉)
- 改修: `stripPromptHeavyFields` 内に `nonImageAggregator` 追加、判定順は image → non-image (AC-7 / AC-15 で pin)

### `server/utils/promptSafety.test.ts` (+150 行、+16 件 PASS)

- `非画像 dataURI 検出 (Issue #137 #1)`: 13 件 (AC-1〜7, AC-11〜14)
- `画像 dataURI 検出 case insensitive 化`: 1 件 (AC-15)
- `非画像 observability + cross-event independence`: 2 件 (AC-8, AC-9)

### `docs/spec/promptSafety/2026-06-03-non-image-data-uri-detection-design.md` (+206 行)

12 セクション (概要 / 要件 / アーキテクチャ / データモデル / インターフェース / エラー処理 / テスト戦略 / スコープ外 / Open Questions / リスク / 実装手順 / 参考資料)。

### `docs/handoff/2026-06-03c-non-image-data-uri-detection.md` (新規)

セッション記録 + 残課題ハンドオフ。

## codex セカンドオピニオン反映状況

| 指摘 (Medium 以上) | 採用 | 反映先 |
|---|---|---|
| case normalize (`DATA:application/pdf`, `\n data:...` 等が現案だと素通し) | ✅ | `normalizeForDataUriDetection` + `isImageDataUri` 改修 |
| edge case テスト | ✅ | AC-11〜15 |
| mimeType observability | ⏸ | 別 Issue 候補 (運用ニーズ顕在化時) |

## スコープ外 (別 Issue 候補)

- mimeType observability
- FE 側 text-area サニタイズ
- `MAX_FIELD_BYTES` 引下げ
- collection-level guard (#137 #2 残り)
- pathPrefixes histogram (#137 #5)
- `logger.warnSampled` altitude (#137 #6)

## Test plan

- [x] `npm test -- promptSafety` → 67 件 PASS (52 + 16)
- [x] `npm test` (全件) → 587 件 PASS (571 + 16)
- [x] `npm run lint` (tsc --noEmit) → 0 errors
- [x] `/safe-refactor` Phase 1 → HIGH/MEDIUM/LOW 0 件
- [x] `/code-review low` → (none)
- [ ] Cloud Run dev デプロイ success (CI 確認待ち)
- [ ] マージ後 Cloud Logging で `safetyEvent: 'non-image-data-uri-omitted'` 発火確認 (本田様判断、実トラフィック発生時)

## 設計プロセス

- `/brainstorm` Phase 1-9 (codex セカンドオピニオン 2 回反映)
- `/impl-plan` Phase 1-5 (T1-T10 承認後着手、T1-T9 完了)

緊急性 LOW + size guard backstop 機能中で実害なし。Issue #134 「register-or-forget 構造的閉鎖」理念の非画像 dataURI への拡張。

🤖 Generated with [Claude Code](https://claude.com/claude-code)