### PR TITLE
feat(prompt-safety): batch log に pathPrefixes histogram を追加 (Refs #137 #5)

### DIFF
--- a/docs/handoff/2026-06-03d-path-prefixes-histogram.md
+++ b/docs/handoff/2026-06-03d-path-prefixes-histogram.md
@@ -80,6 +80,24 @@ PR #140 で「`tick(() => payload)` の builder は threshold 超後は呼ばな
 - **#137 #7** Statsig/metric counter — 起票済 (https://github.com/Yukina1116/novel-writer/issues/137#issuecomment-4610248160)
 - **#137 #8 (新規候補)** `truncateOversizedStrings` の path 追跡 — 本 PR で `(no-path)` bucket になる経路。enhancement レベル
 
+## /review-pr 5 エージェント並列レビュー → 指摘反映 (追加 commit)
+
+| 指摘 | 重要度 | 反映 |
+|---|---|---|
+| histogram cardinality 爆発 silent 受容 | High (pr-test-analyzer Critical + silent-failure-hunter High 重複) | `MAX_HISTOGRAM_BUCKETS=256` + `(overflow)` bucket + 1 度だけ `histogram-overflow` warn emit (paired signal) |
+| AC-1 タイトルと実装の不一致 | comment-analyzer Critical | payload を `[{ url: big }, ...]` に拡張、bucket は `gallery[*].url` で AC-4 と end-to-end 整合 |
+| pathPrefixes payload shape tuple → object | code-reviewer Important | `Array<{ path, count }>` 形式に変更。Cloud Logging クエリ容易化 |
+| sort 安定性 (count 同値での top-N 選出) | pr-test-analyzer Critical | AC-11 で Map insertion order × stable sort を pin |
+| truncatedBucketCount 観測 | silent-failure-hunter Medium | flush payload に `truncatedBucketCount: max(0, pathHistogram.size - PATH_PREFIX_TOP_N)` 追加。AC-12 で 0 / 1 をそれぞれ pin |
+| inline comment 重複 / JSDoc 例補完 | comment-analyzer Improvement | recurse 内コメント簡略化 + ARRAY_INDEX_PATTERN JSDoc に dot-path 例追加 |
+| NO_PATH_BUCKET 文言 future-proof 化 | comment-analyzer Rot | 「現状 truncateOversizedStrings の 2 callsite のみ」を「将来 sanitize 関数が増えた際にも」に変更 |
+
+### スコープ外 (本 PR で反映せず、別 Issue / future PR 候補)
+
+- root path `''` (空文字) のテスト追加 — pr-test-analyzer Important
+- prototype pollution × pathHistogram regression test — pr-test-analyzer Important
+- `(no-path)` bucket と他正規 bucket の混在分離 (field 分離) — silent-failure-hunter Medium
+
 ## 次のアクション
 
 1. **U4**: `git push -u origin feature/path-prefixes-histogram` + `gh pr create`

--- a/docs/handoff/2026-06-03d-path-prefixes-histogram.md
+++ b/docs/handoff/2026-06-03d-path-prefixes-histogram.md
@@ -1,0 +1,95 @@
+# Handoff: Issue #137 #5 pathPrefixes histogram 追加
+
+- Session Date: 2026-06-03 (3 セッション目 - 続き)
+- Owner: yasushi-honda
+- Status: 🟡 PR 作成待ち (feature/path-prefixes-histogram、ローカル commit 済)
+- Previous handoff: [2026-06-03c-non-image-data-uri-detection.md](./2026-06-03c-non-image-data-uri-detection.md)
+
+## 今セッションのトリガー
+
+PR #143 マージ完了 (Issue #137 #1 構造的閉鎖) を受け、本田様の判断で Issue #137 残課題のうち **#137 #5 (batch log の pathPrefixes histogram)** を「設計判断軽い enhancement」として次に着手。
+
+## 設計プロセス
+
+| Phase | 内容 |
+|---|---|
+| /impl-plan Phase 1 (OQ 1 回目) | top-N、prefix 切り詰め戦略、aggregator API の 3 件を AskUserQuestion で確定 (N=5 / array index normalize のみ / tick payload 自動検出) |
+| /impl-plan Phase 1 (OQ 2 回目) | **落とし穴判明**: 「tick payload 自動検出」は PR #140 lazy builder と両立しない (threshold 超後の buildPayload() 呼出 = Buffer.byteLength regression)。3 案 (F: tick 第 2 引数 / G: lazy 犠牲 / H: 別 helper) 提示し、**案 F (tick(builder, path?: string))** 確定 |
+| 実装 U1-U3 | TDD + safe-refactor + code-review low 全 PASS |
+
+## 変更内容
+
+### `server/utils/promptSafety.ts` (+50 行)
+
+新規:
+- `PATH_PREFIX_TOP_N = 5` (Cloud Logging payload size と observability の妥協点)
+- `ARRAY_INDEX_PATTERN = /\[\d+\]/g` (array index normalize 用 regex)
+- `NO_PATH_BUCKET = '(no-path)'` (path 未渡しの集約 bucket)
+- `normalizePathForHistogram(path?: string)`: undefined → `(no-path)`、`[N]` → `[*]` 置換
+- `WarnAggregator.tick` signature 拡張: `(buildPayload, path?: string) => void`
+- `createWarnAggregator` 内 `pathHistogram: Map<string, number>` 追加、tick で常時 inc
+- `flush` で histogram の **top-5 を count 降順で抽出**して batch payload に `pathPrefixes` 同梱
+
+`stripPromptHeavyFields` の 3 callsite に path 引数追加:
+- `imageAggregator.tick(builder, path)`
+- `nonImageAggregator.tick(builder, path)`
+- `depthAggregator.tick(builder, path)` (depth-exceeded marker 経路)
+
+`truncateOversizedStrings` の 2 callsite は**変更なし** (path 追跡未実装、`(no-path)` bucket に集約)。
+
+### `server/utils/promptSafety.test.ts` (+~165 行、+9 件 PASS)
+
+`createWarnAggregator path histogram (Issue #137 #5)` describe で AC-1〜9:
+
+| # | テスト |
+|---|---|
+| AC-1 | 単一 path 多発 (gallery[0].url × 100) → pathPrefixes: [['gallery[*]', 100]] |
+| AC-2 | 異種 path 混在 → 各 prefix が count とともに記録 |
+| AC-3 | top-5 超 → 上位 5 prefix のみ、低頻度 path は drop |
+| AC-4 | array index normalize: `gallery[0]` `gallery[1]` `gallery[2]` が `gallery[*]` に集約 |
+| AC-5 | path 未渡し (truncateOversizedStrings 経由) → `(no-path)` bucket |
+| AC-6 | 50 件以下では batch event 自体 emit されない (pathPrefixes も出ない) |
+| AC-7 | cross-aggregator independence: image / non-image batch が別 histogram |
+| AC-8 | non-image-data-uri-omitted-batch でも pathPrefixes 載る (PR #143 経路) |
+| AC-9 | recursion-depth-exceeded-batch でも pathPrefixes 載る |
+
+## 検証結果
+
+| 項目 | 結果 |
+|---|---|
+| `npm test -- promptSafety` | 79 件 PASS (70 + 9) |
+| `npm test` (全件) | 599 件 PASS (590 + 9) |
+| `npm run lint` (tsc --noEmit) | 0 errors |
+| `/safe-refactor` Phase 1 | HIGH/MEDIUM/LOW 0 件 |
+| `/code-review low` | (none) — correctness bug 検出ゼロ |
+
+## Lazy builder altitude の維持 (重要)
+
+PR #140 で「`tick(() => payload)` の builder は threshold 超後は呼ばない (Buffer.byteLength の重い計算 skip)」規律を確立済。本 PR で histogram 集計を入れる際、buildPayload() 経由で path を取り出すと **threshold 超後も builder を呼ぶ必要があり lazy 利点が消失**する落とし穴があった。
+
+案 F (tick signature 拡張) で「path のみ軽量別経路で渡す」ことで、PR #140 altitude を維持しつつ histogram を実装した。trade-off:
+- callsite 変更: 3 箇所で path 引数追加 (+1 トークン/箇所)
+- 自動検出は半分: aggregator は path を histogram に集計するが、callsite から明示的に path を渡す必要あり
+
+## Issue #137 状態
+
+- **#137 #1** ✅ PR #143 で完了
+- **#137 #5** 🟡 本 PR で完了予定 (close せず Issue は open 維持)
+- **#137 #2 残り** collection-level guard — 未着手
+- **#137 #6** logger.warnSampled altitude — 別 milestone
+- **#137 #7** Statsig/metric counter — 起票済 (https://github.com/Yukina1116/novel-writer/issues/137#issuecomment-4610248160)
+- **#137 #8 (新規候補)** `truncateOversizedStrings` の path 追跡 — 本 PR で `(no-path)` bucket になる経路。enhancement レベル
+
+## 次のアクション
+
+1. **U4**: `git push -u origin feature/path-prefixes-histogram` + `gh pr create`
+2. **U5**: CI Success 確認 → 本田様の番号単位明示認可待ち → `gh pr merge --squash`
+
+### マージ後の手動確認
+
+- 本番 dev Cloud Logging で `*-batch` event の `pathPrefixes` フィールド出現確認 (実トラフィック発生時、本田様判断)
+
+## 学び / 規律
+
+- **Phase 4-5 で落とし穴発見**: 設計判断時点 (OQ 1 回目) では見えなかった「lazy builder vs histogram の両立」問題が impl-plan Phase 中の細部詰めで顕在化。OQ 2 回目で軌道修正できた
+- **`/brainstorm` スキップ判断の境界線**: 「設計判断軽い enhancement」を本田様が評価したため /brainstorm スキップで /impl-plan 直行したが、設計の細部に重要な trade-off が潜むケースは impl-plan 内で AskUserQuestion 追加で吸収可能

--- a/server/utils/promptSafety.test.ts
+++ b/server/utils/promptSafety.test.ts
@@ -913,18 +913,22 @@ describe('createWarnAggregator path histogram (Issue #137 #5)', () => {
     warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
   });
 
-  it('AC-1: 単一 path 多発 (gallery[0].url × 100) → pathPrefixes に gallery[*].url が count 100 で記録', () => {
+  it('AC-1: 単一 path 多発 (gallery[N].url × 100) → pathPrefixes に gallery[*].url が count 100 で記録 (末尾 prop 保持の AC-4 と end-to-end 整合)', () => {
+    // PR #144 review-pr comment-analyzer Critical 解消:
+    // 元 test は `gallery: items` (string array) で末尾 prop `.url` が含まれず title と矛盾。
+    // payload を `[{url: big}, ...]` 形式に拡張し、bucket が `gallery[*].url` になることで AC-4
+    // (「末尾 prop は normalize 対象外で残す」) を end-to-end で実証する。
     const big = `data:image/png;base64,${'A'.repeat(600)}`;
-    const items = Array.from({ length: 100 }, () => big);
+    const items = Array.from({ length: 100 }, () => ({ url: big }));
     stripPromptHeavyFields({ gallery: items });
 
     const batchCall = warnSpy.mock.calls.find(
       (c) => (c[0] as { safetyEvent?: string }).safetyEvent === 'image-omitted-batch'
     );
     expect(batchCall).toBeDefined();
-    const payload = batchCall![0] as { pathPrefixes: Array<[string, number]> };
+    const payload = batchCall![0] as { pathPrefixes: Array<{ path: string; count: number }> };
     expect(payload.pathPrefixes).toBeDefined();
-    expect(payload.pathPrefixes).toContainEqual(['gallery[*]', 100]);
+    expect(payload.pathPrefixes).toContainEqual({ path: 'gallery[*].url', count: 100 });
   });
 
   it('AC-2: 異種 path 混在 → 各 prefix が count とともに記録される (top-5 内に収まるケース)', () => {
@@ -941,8 +945,8 @@ describe('createWarnAggregator path histogram (Issue #137 #5)', () => {
       (c) => (c[0] as { safetyEvent?: string }).safetyEvent === 'image-omitted-batch'
     );
     expect(batchCall).toBeDefined();
-    const batchPayload = batchCall![0] as { pathPrefixes: Array<[string, number]> };
-    const map = new Map(batchPayload.pathPrefixes);
+    const batchPayload = batchCall![0] as { pathPrefixes: Array<{ path: string; count: number }> };
+    const map = new Map(batchPayload.pathPrefixes.map(({ path, count }) => [path, count]));
     expect(map.get('gallery[*]')).toBe(60);
     expect(map.get('portraits[*]')).toBe(60);
     expect(map.get('avatars[*]')).toBe(60);
@@ -965,13 +969,13 @@ describe('createWarnAggregator path histogram (Issue #137 #5)', () => {
       (c) => (c[0] as { safetyEvent?: string }).safetyEvent === 'image-omitted-batch'
     );
     expect(batchCall).toBeDefined();
-    const batchPayload = batchCall![0] as { pathPrefixes: Array<[string, number]> };
+    const batchPayload = batchCall![0] as { pathPrefixes: Array<{ path: string; count: number }> };
     expect(batchPayload.pathPrefixes).toHaveLength(5);
-    const map = new Map(batchPayload.pathPrefixes);
-    expect(map.has('a[*]')).toBe(true);
-    expect(map.has('b[*]')).toBe(true);
-    expect(map.has('e[*]')).toBe(true);
-    expect(map.has('f[*]')).toBe(false);
+    const paths = batchPayload.pathPrefixes.map(({ path }) => path);
+    expect(paths).toContain('a[*]');
+    expect(paths).toContain('b[*]');
+    expect(paths).toContain('e[*]');
+    expect(paths).not.toContain('f[*]');
   });
 
   it('AC-4: array index normalize: gallery[0] / gallery[1] / gallery[2] が同 prefix gallery[*] にまとまる', () => {
@@ -983,9 +987,9 @@ describe('createWarnAggregator path histogram (Issue #137 #5)', () => {
       (c) => (c[0] as { safetyEvent?: string }).safetyEvent === 'image-omitted-batch'
     );
     expect(batchCall).toBeDefined();
-    const batchPayload = batchCall![0] as { pathPrefixes: Array<[string, number]> };
+    const batchPayload = batchCall![0] as { pathPrefixes: Array<{ path: string; count: number }> };
     // gallery[*] 1 件のみ (array index が normalize されている)
-    expect(batchPayload.pathPrefixes).toEqual([['gallery[*]', 100]]);
+    expect(batchPayload.pathPrefixes).toEqual([{ path: 'gallery[*]', count: 100 }]);
   });
 
   it('AC-5: path が渡されない aggregator (oversized / truncate 経由) では (no-path) bucket になる', () => {
@@ -998,8 +1002,8 @@ describe('createWarnAggregator path histogram (Issue #137 #5)', () => {
       (c) => (c[0] as { safetyEvent?: string }).safetyEvent === 'oversized-truncated-batch'
     );
     expect(batchCall).toBeDefined();
-    const batchPayload = batchCall![0] as { pathPrefixes: Array<[string, number]> };
-    expect(batchPayload.pathPrefixes).toContainEqual(['(no-path)', 60]);
+    const batchPayload = batchCall![0] as { pathPrefixes: Array<{ path: string; count: number }> };
+    expect(batchPayload.pathPrefixes).toContainEqual({ path: '(no-path)', count: 60 });
   });
 
   it('AC-6: 50 件以下 → batch event 自体 emit されない (pathPrefixes も発火しない)', () => {
@@ -1029,10 +1033,12 @@ describe('createWarnAggregator path histogram (Issue #137 #5)', () => {
     expect(imageBatch).toBeDefined();
     expect(nonImageBatch).toBeDefined();
 
-    const imageMap = new Map((imageBatch![0] as { pathPrefixes: Array<[string, number]> }).pathPrefixes);
-    const nonImageMap = new Map(
-      (nonImageBatch![0] as { pathPrefixes: Array<[string, number]> }).pathPrefixes
-    );
+    const imagePrefixes = (imageBatch![0] as { pathPrefixes: Array<{ path: string; count: number }> }).pathPrefixes;
+    const nonImagePrefixes = (
+      nonImageBatch![0] as { pathPrefixes: Array<{ path: string; count: number }> }
+    ).pathPrefixes;
+    const imageMap = new Map(imagePrefixes.map(({ path, count }) => [path, count]));
+    const nonImageMap = new Map(nonImagePrefixes.map(({ path, count }) => [path, count]));
     // 各 batch は自分の path のみ持ち、互いに混入しない
     expect(imageMap.get('images[*]')).toBe(60);
     expect(imageMap.has('pdfs[*]')).toBe(false);
@@ -1048,8 +1054,8 @@ describe('createWarnAggregator path histogram (Issue #137 #5)', () => {
       (c) => (c[0] as { safetyEvent?: string }).safetyEvent === 'non-image-data-uri-omitted-batch'
     );
     expect(batchCall).toBeDefined();
-    const batchPayload = batchCall![0] as { pathPrefixes: Array<[string, number]> };
-    expect(batchPayload.pathPrefixes).toContainEqual(['docs[*]', 60]);
+    const batchPayload = batchCall![0] as { pathPrefixes: Array<{ path: string; count: number }> };
+    expect(batchPayload.pathPrefixes).toContainEqual({ path: 'docs[*]', count: 60 });
   });
 
   it('AC-9: recursion-depth-exceeded-batch でも pathPrefixes が乗る (stripPromptHeavyFields 経路は path 付き)', () => {
@@ -1068,14 +1074,102 @@ describe('createWarnAggregator path histogram (Issue #137 #5)', () => {
       (c) => (c[0] as { safetyEvent?: string }).safetyEvent === 'recursion-depth-exceeded-batch'
     );
     expect(batchCall).toBeDefined();
-    const batchPayload = batchCall![0] as { pathPrefixes: Array<[string, number]> };
+    const batchPayload = batchCall![0] as { pathPrefixes: Array<{ path: string; count: number }>; truncatedBucketCount: number };
     expect(batchPayload.pathPrefixes).toBeDefined();
-    expect(batchPayload.pathPrefixes.length).toBeGreaterThan(0);
+    // PR #144 review-pr: pathPrefixes は top-N (5) を超えない (cardinality 暴走 sentinel)
+    expect(batchPayload.pathPrefixes.length).toBeLessThanOrEqual(5);
     // sib0.a.a.... の prefix なので 'sib*' 等にはならず 'sib0.a.a.a.a...' のような長い path が並ぶ
     // (sib0 / sib1 ... は dot-path 区切りで array index 表記でないため normalize 対象外)
-    // top-5 に何が並ぶかは実装の hash 順序依存だが、合計 60 を pathPrefixes count 合計が満たすことを pin
-    const totalCount = batchPayload.pathPrefixes.reduce((sum, [, c]) => sum + c, 0);
+    // top-5 内 count 合計を pin
+    const totalCount = batchPayload.pathPrefixes.reduce((sum, { count }) => sum + count, 0);
     expect(totalCount).toBeLessThanOrEqual(60);
     expect(totalCount).toBeGreaterThan(0);
+  });
+
+  // === PR #144 review-pr 指摘反映 hardening (cardinality cap + sort 安定性 + truncatedBucketCount) ===
+
+  it('AC-10: histogram cardinality 上限 (MAX_HISTOGRAM_BUCKETS=256) 到達後の新規 path は (overflow) bucket に集約 + histogram-overflow warn 1 件 emit (paired signal)', () => {
+    // 257 種類の unique path を 1 件ずつ振る (sib0, sib1, ..., sib256) — 256 種類 buckets 充填後の追加は overflow へ。
+    // 'sib0.a.a...' の 1500 段ネスト path は normalize 対象外 (array index なし) で各 sibling 1 bucket 占有。
+    // 個別 warn 上限 50、batch event 発火条件 totalCount > 50 を満たすため batch emit される想定。
+    function buildDeepChain(levels: number): Record<string, unknown> {
+      let node: Record<string, unknown> = { leaf: 'end' };
+      for (let i = 0; i < levels; i++) node = { a: node };
+      return node;
+    }
+    const deep = buildDeepChain(1500);
+    const payload: Record<string, unknown> = {};
+    for (let i = 0; i < 300; i++) payload[`sib${i}`] = deep;
+    stripPromptHeavyFields(payload);
+
+    // 1 件以上の histogram-overflow warn が emit され、parentEvent が recursion-depth-exceeded である
+    const overflowCalls = warnSpy.mock.calls.filter(
+      (c) => (c[0] as { safetyEvent?: string }).safetyEvent === 'histogram-overflow'
+    );
+    expect(overflowCalls.length).toBeGreaterThan(0);
+    // 1 度だけ emit される (per aggregator-instance 規律)。300 件で recursion-depth-exceeded aggregator が overflow を 1 回出す
+    const depthOverflows = overflowCalls.filter(
+      (c) => (c[0] as { parentEvent?: string }).parentEvent === 'recursion-depth-exceeded'
+    );
+    expect(depthOverflows).toHaveLength(1);
+    expect(depthOverflows[0][0]).toMatchObject({
+      safetyEvent: 'histogram-overflow',
+      parentEvent: 'recursion-depth-exceeded',
+      maxBuckets: 256,
+    });
+
+    // batch payload に (overflow) bucket が含まれる (top-5 の中、または truncated 外に集約)
+    const batchCall = warnSpy.mock.calls.find(
+      (c) => (c[0] as { safetyEvent?: string }).safetyEvent === 'recursion-depth-exceeded-batch'
+    );
+    expect(batchCall).toBeDefined();
+    const batchPayload = batchCall![0] as {
+      pathPrefixes: Array<{ path: string; count: number }>;
+      truncatedBucketCount: number;
+    };
+    // truncatedBucketCount は MAX_HISTOGRAM_BUCKETS (256) - top-5 = 251 以下 (overflow が bucket 1 つを占めるため厳密 251)
+    expect(batchPayload.truncatedBucketCount).toBeGreaterThan(0);
+  });
+
+  it('AC-11: sort 安定性 — count 同値の bucket 6 件で top-5 を抽出した時、Map insertion order × stable sort で deterministic に残る 5 件が決まる', () => {
+    // 6 種類の path、全て count 20 → V8 sort は stable で、Map iteration 順 = insertion 順。
+    // 最後に insert された 1 件 (`f[*]`) のみが drop され、`a[*]` 〜 `e[*]` が top-5 に残る。
+    const imageBig = `data:image/png;base64,${'A'.repeat(600)}`;
+    const payload: Record<string, unknown> = {
+      a: Array.from({ length: 20 }, () => imageBig),
+      b: Array.from({ length: 20 }, () => imageBig),
+      c: Array.from({ length: 20 }, () => imageBig),
+      d: Array.from({ length: 20 }, () => imageBig),
+      e: Array.from({ length: 20 }, () => imageBig),
+      f: Array.from({ length: 20 }, () => imageBig),
+    };
+    stripPromptHeavyFields(payload);
+
+    const batchCall = warnSpy.mock.calls.find(
+      (c) => (c[0] as { safetyEvent?: string }).safetyEvent === 'image-omitted-batch'
+    );
+    expect(batchCall).toBeDefined();
+    const batchPayload = batchCall![0] as { pathPrefixes: Array<{ path: string; count: number }>; truncatedBucketCount: number };
+    const paths = batchPayload.pathPrefixes.map(({ path }) => path);
+    // 最初に insert された 5 件 (a, b, c, d, e) が残る (Map insertion order × stable sort)
+    expect(paths).toEqual(['a[*]', 'b[*]', 'c[*]', 'd[*]', 'e[*]']);
+    // 6 番目 (f) は drop されて truncatedBucketCount に計上
+    expect(batchPayload.truncatedBucketCount).toBe(1);
+  });
+
+  it('AC-12: truncatedBucketCount: top-5 内に収まる場合は 0、超過分は distinct bucket 数 - 5 を反映', () => {
+    const imageBig = `data:image/png;base64,${'A'.repeat(600)}`;
+
+    // case 1: 3 distinct path × 各 60 → top-5 内、truncatedBucketCount = 0
+    stripPromptHeavyFields({
+      a: Array.from({ length: 60 }, () => imageBig),
+      b: Array.from({ length: 60 }, () => imageBig),
+      c: Array.from({ length: 60 }, () => imageBig),
+    });
+    const case1 = warnSpy.mock.calls.find(
+      (c) => (c[0] as { safetyEvent?: string }).safetyEvent === 'image-omitted-batch'
+    );
+    expect(case1).toBeDefined();
+    expect((case1![0] as { truncatedBucketCount: number }).truncatedBucketCount).toBe(0);
   });
 });

--- a/server/utils/promptSafety.test.ts
+++ b/server/utils/promptSafety.test.ts
@@ -904,3 +904,178 @@ describe('非画像 dataURI 検出 hardening (PR #143 review-pr 指摘反映)', 
     expect(out.memo).toBe(NON_IMAGE_DATA_URI_MARKER);
   });
 });
+
+// === Issue #137 #5: batch log の pathPrefixes histogram (51 件目以降の path 喪失復旧) ===
+
+describe('createWarnAggregator path histogram (Issue #137 #5)', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+  });
+
+  it('AC-1: 単一 path 多発 (gallery[0].url × 100) → pathPrefixes に gallery[*].url が count 100 で記録', () => {
+    const big = `data:image/png;base64,${'A'.repeat(600)}`;
+    const items = Array.from({ length: 100 }, () => big);
+    stripPromptHeavyFields({ gallery: items });
+
+    const batchCall = warnSpy.mock.calls.find(
+      (c) => (c[0] as { safetyEvent?: string }).safetyEvent === 'image-omitted-batch'
+    );
+    expect(batchCall).toBeDefined();
+    const payload = batchCall![0] as { pathPrefixes: Array<[string, number]> };
+    expect(payload.pathPrefixes).toBeDefined();
+    expect(payload.pathPrefixes).toContainEqual(['gallery[*]', 100]);
+  });
+
+  it('AC-2: 異種 path 混在 → 各 prefix が count とともに記録される (top-5 内に収まるケース)', () => {
+    // 3 種類 × 各 60 件 = 180 件 (>50 で batch 発火)、top-5 内なので全部出る
+    const imageBig = `data:image/png;base64,${'A'.repeat(600)}`;
+    const payload: Record<string, unknown> = {
+      gallery: Array.from({ length: 60 }, () => imageBig),
+      portraits: Array.from({ length: 60 }, () => imageBig),
+      avatars: Array.from({ length: 60 }, () => imageBig),
+    };
+    stripPromptHeavyFields(payload);
+
+    const batchCall = warnSpy.mock.calls.find(
+      (c) => (c[0] as { safetyEvent?: string }).safetyEvent === 'image-omitted-batch'
+    );
+    expect(batchCall).toBeDefined();
+    const batchPayload = batchCall![0] as { pathPrefixes: Array<[string, number]> };
+    const map = new Map(batchPayload.pathPrefixes);
+    expect(map.get('gallery[*]')).toBe(60);
+    expect(map.get('portraits[*]')).toBe(60);
+    expect(map.get('avatars[*]')).toBe(60);
+  });
+
+  it('AC-3: top-5 超 → 上位 5 prefix のみ残り、低頻度 path は drop される', () => {
+    // 6 種類の path、各々 count が違う → top-5 を切り捨て
+    const imageBig = `data:image/png;base64,${'A'.repeat(600)}`;
+    const payload: Record<string, unknown> = {
+      a: Array.from({ length: 20 }, () => imageBig), // count 20
+      b: Array.from({ length: 15 }, () => imageBig), // count 15
+      c: Array.from({ length: 10 }, () => imageBig), // count 10
+      d: Array.from({ length: 5 }, () => imageBig),  // count 5
+      e: Array.from({ length: 3 }, () => imageBig),  // count 3
+      f: Array.from({ length: 2 }, () => imageBig),  // count 2 → drop (top-5 圏外)
+    };
+    stripPromptHeavyFields(payload);
+
+    const batchCall = warnSpy.mock.calls.find(
+      (c) => (c[0] as { safetyEvent?: string }).safetyEvent === 'image-omitted-batch'
+    );
+    expect(batchCall).toBeDefined();
+    const batchPayload = batchCall![0] as { pathPrefixes: Array<[string, number]> };
+    expect(batchPayload.pathPrefixes).toHaveLength(5);
+    const map = new Map(batchPayload.pathPrefixes);
+    expect(map.has('a[*]')).toBe(true);
+    expect(map.has('b[*]')).toBe(true);
+    expect(map.has('e[*]')).toBe(true);
+    expect(map.has('f[*]')).toBe(false);
+  });
+
+  it('AC-4: array index normalize: gallery[0] / gallery[1] / gallery[2] が同 prefix gallery[*] にまとまる', () => {
+    // 100 件の image (各 idx 違い) → 全部 'gallery[*]' bucket
+    const imageBig = `data:image/png;base64,${'A'.repeat(600)}`;
+    stripPromptHeavyFields({ gallery: Array.from({ length: 100 }, () => imageBig) });
+
+    const batchCall = warnSpy.mock.calls.find(
+      (c) => (c[0] as { safetyEvent?: string }).safetyEvent === 'image-omitted-batch'
+    );
+    expect(batchCall).toBeDefined();
+    const batchPayload = batchCall![0] as { pathPrefixes: Array<[string, number]> };
+    // gallery[*] 1 件のみ (array index が normalize されている)
+    expect(batchPayload.pathPrefixes).toEqual([['gallery[*]', 100]]);
+  });
+
+  it('AC-5: path が渡されない aggregator (oversized / truncate 経由) では (no-path) bucket になる', () => {
+    // truncateOversizedStrings は recurse が path を渡さない → (no-path)
+    const big = 'X'.repeat(MAX_FIELD_BYTES + 1);
+    const items = Array.from({ length: 60 }, () => big);
+    truncateOversizedStrings({ list: items });
+
+    const batchCall = warnSpy.mock.calls.find(
+      (c) => (c[0] as { safetyEvent?: string }).safetyEvent === 'oversized-truncated-batch'
+    );
+    expect(batchCall).toBeDefined();
+    const batchPayload = batchCall![0] as { pathPrefixes: Array<[string, number]> };
+    expect(batchPayload.pathPrefixes).toContainEqual(['(no-path)', 60]);
+  });
+
+  it('AC-6: 50 件以下 → batch event 自体 emit されない (pathPrefixes も発火しない)', () => {
+    const imageBig = `data:image/png;base64,${'A'.repeat(600)}`;
+    stripPromptHeavyFields({ gallery: Array.from({ length: 50 }, () => imageBig) });
+
+    expect(warnSpy).not.toHaveBeenCalledWith(
+      expect.objectContaining({ safetyEvent: 'image-omitted-batch' })
+    );
+  });
+
+  it('AC-7: cross-aggregator independence: image-omitted-batch と non-image-data-uri-omitted-batch の pathPrefixes は別 histogram', () => {
+    const imageBig = `data:image/png;base64,${'A'.repeat(600)}`;
+    const nonImageBig = `data:application/pdf;base64,${'B'.repeat(600)}`;
+    const payload = {
+      images: Array.from({ length: 60 }, () => imageBig),
+      pdfs: Array.from({ length: 60 }, () => nonImageBig),
+    };
+    stripPromptHeavyFields(payload);
+
+    const imageBatch = warnSpy.mock.calls.find(
+      (c) => (c[0] as { safetyEvent?: string }).safetyEvent === 'image-omitted-batch'
+    );
+    const nonImageBatch = warnSpy.mock.calls.find(
+      (c) => (c[0] as { safetyEvent?: string }).safetyEvent === 'non-image-data-uri-omitted-batch'
+    );
+    expect(imageBatch).toBeDefined();
+    expect(nonImageBatch).toBeDefined();
+
+    const imageMap = new Map((imageBatch![0] as { pathPrefixes: Array<[string, number]> }).pathPrefixes);
+    const nonImageMap = new Map(
+      (nonImageBatch![0] as { pathPrefixes: Array<[string, number]> }).pathPrefixes
+    );
+    // 各 batch は自分の path のみ持ち、互いに混入しない
+    expect(imageMap.get('images[*]')).toBe(60);
+    expect(imageMap.has('pdfs[*]')).toBe(false);
+    expect(nonImageMap.get('pdfs[*]')).toBe(60);
+    expect(nonImageMap.has('images[*]')).toBe(false);
+  });
+
+  it('AC-8: non-image-data-uri-omitted-batch でも pathPrefixes が乗る (PR #143 経路継承)', () => {
+    const nonImageBig = `data:application/pdf;base64,${'A'.repeat(600)}`;
+    stripPromptHeavyFields({ docs: Array.from({ length: 60 }, () => nonImageBig) });
+
+    const batchCall = warnSpy.mock.calls.find(
+      (c) => (c[0] as { safetyEvent?: string }).safetyEvent === 'non-image-data-uri-omitted-batch'
+    );
+    expect(batchCall).toBeDefined();
+    const batchPayload = batchCall![0] as { pathPrefixes: Array<[string, number]> };
+    expect(batchPayload.pathPrefixes).toContainEqual(['docs[*]', 60]);
+  });
+
+  it('AC-9: recursion-depth-exceeded-batch でも pathPrefixes が乗る (stripPromptHeavyFields 経路は path 付き)', () => {
+    /** 1500 段ネスト object */
+    function buildDeepChain(levels: number): Record<string, unknown> {
+      let node: Record<string, unknown> = { leaf: 'end' };
+      for (let i = 0; i < levels; i++) node = { a: node };
+      return node;
+    }
+    const deep = buildDeepChain(1500);
+    const payload: Record<string, unknown> = {};
+    for (let i = 0; i < 60; i++) payload[`sib${i}`] = deep;
+    stripPromptHeavyFields(payload);
+
+    const batchCall = warnSpy.mock.calls.find(
+      (c) => (c[0] as { safetyEvent?: string }).safetyEvent === 'recursion-depth-exceeded-batch'
+    );
+    expect(batchCall).toBeDefined();
+    const batchPayload = batchCall![0] as { pathPrefixes: Array<[string, number]> };
+    expect(batchPayload.pathPrefixes).toBeDefined();
+    expect(batchPayload.pathPrefixes.length).toBeGreaterThan(0);
+    // sib0.a.a.... の prefix なので 'sib*' 等にはならず 'sib0.a.a.a.a...' のような長い path が並ぶ
+    // (sib0 / sib1 ... は dot-path 区切りで array index 表記でないため normalize 対象外)
+    // top-5 に何が並ぶかは実装の hash 順序依存だが、合計 60 を pathPrefixes count 合計が満たすことを pin
+    const totalCount = batchPayload.pathPrefixes.reduce((sum, [, c]) => sum + c, 0);
+    expect(totalCount).toBeLessThanOrEqual(60);
+    expect(totalCount).toBeGreaterThan(0);
+  });
+});

--- a/server/utils/promptSafety.ts
+++ b/server/utils/promptSafety.ts
@@ -130,6 +130,46 @@ export const RECURSION_DEPTH_EXCEEDED_MARKER = '[recursion-depth-exceeded: neste
 const MAX_WARN_PER_CALL = 50;
 
 /**
+ * batch log の `pathPrefixes` histogram の top-N (Issue #137 #5)。
+ *
+ * 旧設計: `image-omitted-batch` 等の集約 log は `totalCount` / `loggedCount` / `omittedCount` のみ
+ * 持ち、51 件目以降の field path 情報が完全喪失していた。Cloud Logging で path 別ダッシュボードを
+ * 組んだ場合、batch 経由の発火はどのバケットにも入らない構造的弱点があった。
+ *
+ * 本定数で「集約時の path 分布」上位 N を batch payload に残す。5 は Cloud Logging payload size と
+ * observability の妥協点で、top-5 で path 分布の大勢が掴める想定。低頻度 path は drop されるが、
+ * 個別 warn (先頭 50 件) には path が残るため forensic 価値は二重に担保される。
+ */
+const PATH_PREFIX_TOP_N = 5;
+
+/**
+ * path histogram で array index `[0]` / `[1]` / `[2]` ... を `[*]` に正規化する正規表現
+ * (Issue #137 #5)。同 subtree で `gallery[0].url` / `gallery[1].url` / `gallery[2].url` ... が
+ * 並ぶと bucket が cardinality 爆発するため、array index は集約 prefix にまとめる。末尾の
+ * property 名 (`url` / `caption` 等) は意味的に異なるため normalize 対象外で残す。
+ */
+const ARRAY_INDEX_PATTERN = /\[\d+\]/g;
+
+/**
+ * path histogram で path に渡されなかった集約 bucket (Issue #137 #5)。
+ *
+ * `truncateOversizedStrings` 等の path 未追跡 caller では tick の path 引数が渡されないため、
+ * `(no-path)` 専用 bucket に集約する。これにより「path 追跡未実装の経路がどの程度発火しているか」
+ * が Cloud Logging で観測可能になる (将来 path 追跡を入れるべき経路の優先度判定材料)。
+ */
+const NO_PATH_BUCKET = '(no-path)';
+
+/**
+ * path を histogram bucket key に正規化する (Issue #137 #5)。
+ * - undefined は `NO_PATH_BUCKET` ('(no-path)') に集約
+ * - array index `[N]` は `[*]` に置換し cardinality 爆発を防ぐ
+ */
+function normalizePathForHistogram(path: string | undefined): string {
+  if (path === undefined) return NO_PATH_BUCKET;
+  return path.replace(ARRAY_INDEX_PATTERN, '[*]');
+}
+
+/**
  * Object.prototype 汚染になりうる特殊 key (`__proto__` / `constructor` / `prototype`)。
  *
  * 理由 (Issue #134 part 1 code-review PLAUSIBLE): JSON.parse は `__proto__` を own enumerable
@@ -256,8 +296,13 @@ export interface WarnAggregator {
    * (Buffer.byteLength(50KB)) を eager 評価してしまい、threshold 超後も無駄な work が走る
    * regression があった。`tick(() => ({ ... }))` に変えることで threshold 内のみ closure を
    * 呼び出し、上限超後は closure 自体を skip (Buffer.byteLength も走らない)。
+   *
+   * `path` 引数 (Issue #137 #5): 軽量な path 文字列を別経路で受け取り、batch log の `pathPrefixes`
+   * histogram に常時蓄積する。lazy builder の利点 (Buffer.byteLength skip) を保ちつつ、path 集計の
+   * ために重い `buildPayload()` を毎 leaf で呼ばずに済む altitude を維持する。`path` 未渡しは
+   * `(no-path)` bucket に集約。
    */
-  tick: (buildPayload: () => WarnAggregatorPayload) => void;
+  tick: (buildPayload: () => WarnAggregatorPayload, path?: string) => void;
   /** 関数末尾で 1 回呼ぶ。totalCount > MAX_WARN_PER_CALL の時のみ 1 件集約 log を emit。 */
   flush: () => void;
 }
@@ -270,9 +315,14 @@ export function createWarnAggregator(individualEvent: string, individualMessage:
 
   let totalCount = 0;
   let loggedCount = 0;
+  // Issue #137 #5: per-call の path 分布を蓄積し、batch log に top-N histogram を残す。
+  const pathHistogram = new Map<string, number>();
   return {
-    tick(buildPayload: () => WarnAggregatorPayload) {
+    tick(buildPayload: () => WarnAggregatorPayload, path?: string) {
       totalCount++;
+      // Issue #137 #5: lazy builder の altitude を破壊せず軽量 path のみ常時集計。
+      const bucket = normalizePathForHistogram(path);
+      pathHistogram.set(bucket, (pathHistogram.get(bucket) ?? 0) + 1);
       if (loggedCount < MAX_WARN_PER_CALL) {
         // (a) spread 順反転で固定 message / safetyEvent が payload から上書きされない構造を保証。
         logger.warn({
@@ -285,12 +335,17 @@ export function createWarnAggregator(individualEvent: string, individualMessage:
     },
     flush() {
       if (totalCount > MAX_WARN_PER_CALL) {
+        // Issue #137 #5: top-N path prefix を count 降順で抽出して batch payload に同梱。
+        const pathPrefixes = Array.from(pathHistogram.entries())
+          .sort(([, a], [, b]) => b - a)
+          .slice(0, PATH_PREFIX_TOP_N);
         logger.warn({
           message: batchMessage,
           safetyEvent: batchEvent,
           totalCount,
           loggedCount,
           omittedCount: totalCount - loggedCount,
+          pathPrefixes,
         });
       }
     },
@@ -328,20 +383,24 @@ export function stripPromptHeavyFields(data: unknown): unknown {
 
   function recurse(value: unknown, path: string, depth: number): unknown {
     if (depth > MAX_RECURSION_DEPTH) {
-      depthAggregator.tick(() => ({ path, depth }));
+      // Issue #137 #5: path を第 2 引数で渡して batch log の pathPrefixes histogram に集計。
+      depthAggregator.tick(() => ({ path, depth }), path);
       return RECURSION_DEPTH_EXCEEDED_MARKER;
     }
     if (typeof value === 'string') {
       // 判定順は image → non-image (image 側を先評価する規律、AC-7 / AC-15 で pin)。
       if (isImageDataUri(value)) {
         // lazy builder: threshold 超後は Buffer.byteLength(50KB級) 再計算が skip される
-        imageAggregator.tick(() => ({ path, bytes: Buffer.byteLength(value, 'utf8') }));
+        imageAggregator.tick(() => ({ path, bytes: Buffer.byteLength(value, 'utf8') }), path);
         return IMAGE_OMITTED_MARKER;
       }
       if (isNonImageDataUri(value)) {
         // Issue #137 #1: 非画像 dataURI (PDF / audio / font 等) を marker 化。
         // bytes は元 string で計測 (既存 image 側の payload 規律と揃える、normalize の trim 差は無視可能)。
-        nonImageAggregator.tick(() => ({ path, bytes: Buffer.byteLength(value, 'utf8') }));
+        nonImageAggregator.tick(
+          () => ({ path, bytes: Buffer.byteLength(value, 'utf8') }),
+          path,
+        );
         return NON_IMAGE_DATA_URI_MARKER;
       }
       return value;

--- a/server/utils/promptSafety.ts
+++ b/server/utils/promptSafety.ts
@@ -147,17 +147,45 @@ const PATH_PREFIX_TOP_N = 5;
  * (Issue #137 #5)。同 subtree で `gallery[0].url` / `gallery[1].url` / `gallery[2].url` ... が
  * 並ぶと bucket が cardinality 爆発するため、array index は集約 prefix にまとめる。末尾の
  * property 名 (`url` / `caption` 等) は意味的に異なるため normalize 対象外で残す。
+ *
+ * 例: `gallery[0].url` → `gallery[*].url` / `gallery[1].caption` → `gallery[*].caption`
+ * 例: array index を含まない dot-path (`users.profile.avatar`) はそのまま `users.profile.avatar` で残る
+ *     (dot-path 構造は意味情報として保持し、prefix 集約は array index 専用)。
  */
 const ARRAY_INDEX_PATTERN = /\[\d+\]/g;
 
 /**
  * path histogram で path に渡されなかった集約 bucket (Issue #137 #5)。
  *
- * `truncateOversizedStrings` 等の path 未追跡 caller では tick の path 引数が渡されないため、
- * `(no-path)` 専用 bucket に集約する。これにより「path 追跡未実装の経路がどの程度発火しているか」
- * が Cloud Logging で観測可能になる (将来 path 追跡を入れるべき経路の優先度判定材料)。
+ * 現状の path 未追跡 caller は `truncateOversizedStrings` の 2 callsite のみだが、将来 sanitize
+ * 関数が増えた際にも path 引数を渡さない caller があれば本 bucket に集約される。これにより
+ * 「path 追跡未実装の経路がどの程度発火しているか」が Cloud Logging で観測可能になる (将来 path
+ * 追跡を入れるべき経路の優先度判定材料)。
  */
 const NO_PATH_BUCKET = '(no-path)';
+
+/**
+ * path histogram の cardinality 爆発防御の最大 bucket 数 (Issue #137 #5 / PR #144 review-pr High 指摘の解消)。
+ *
+ * 旧設計: `pathHistogram = new Map<string, number>()` に上限なし。攻撃ペイロード (1500 段 ×
+ * 1000 sibling 等で unique path を爆発させる) で aggregator 自身の Map size が暴走し
+ * RSS 上昇するが silent に許容される構造的弱点があった (silent-failure-hunter High)。
+ *
+ * 256 は通常の character / world データの per-call unique path 数 (実用 ~50 未満) に十分余裕、
+ * かつ Cloud Logging 1 row payload size の制約 (top-5 抽出後 + truncatedBucketCount field 等) と
+ * 整合する妥協点。超過時は新規 bucket を `(overflow)` bucket に集約し、本 sanitize call 内で
+ * `histogram-overflow` warn を 1 度だけ emit (paired signal 規律、`feedback_silent_fail_paired_signal`)。
+ */
+const MAX_HISTOGRAM_BUCKETS = 256;
+
+/**
+ * histogram cardinality 上限超過時の集約 bucket (Issue #137 #5 / PR #144 review-pr High)。
+ *
+ * `MAX_HISTOGRAM_BUCKETS` 到達後の新規 path は本 bucket に inc される。Cloud Logging で
+ * `(overflow)` bucket に大量 count が並んでいたら「histogram が飽和した = path 追跡しきれない
+ * トラフィックがあった」を示す early-detection シグナル。
+ */
+const OVERFLOW_BUCKET = '(overflow)';
 
 /**
  * path を histogram bucket key に正規化する (Issue #137 #5)。
@@ -317,12 +345,30 @@ export function createWarnAggregator(individualEvent: string, individualMessage:
   let loggedCount = 0;
   // Issue #137 #5: per-call の path 分布を蓄積し、batch log に top-N histogram を残す。
   const pathHistogram = new Map<string, number>();
+  // PR #144 review-pr High: cardinality 爆発で aggregator が OOM しないよう bucket 数を cap し、
+  // 超過時は (overflow) に集約 + 1 度だけ histogram-overflow warn (paired signal)。
+  let overflowEmitted = false;
   return {
     tick(buildPayload: () => WarnAggregatorPayload, path?: string) {
       totalCount++;
       // Issue #137 #5: lazy builder の altitude を破壊せず軽量 path のみ常時集計。
-      const bucket = normalizePathForHistogram(path);
+      const desired = normalizePathForHistogram(path);
+      // PR #144 review-pr High: 新規 bucket 作成は MAX_HISTOGRAM_BUCKETS で cap、超過は (overflow)。
+      // 既存 bucket への inc は cap 対象外 (同じ bucket は cardinality を増やさない)。
+      const isNewBucket = !pathHistogram.has(desired);
+      const bucket =
+        isNewBucket && pathHistogram.size >= MAX_HISTOGRAM_BUCKETS ? OVERFLOW_BUCKET : desired;
       pathHistogram.set(bucket, (pathHistogram.get(bucket) ?? 0) + 1);
+      if (bucket === OVERFLOW_BUCKET && !overflowEmitted) {
+        // paired early-detection signal (silent_fail_paired_signal): 飽和を 1 度だけ通知。
+        overflowEmitted = true;
+        logger.warn({
+          message: 'promptSafety: path histogram saturation — new buckets aggregated into (overflow)',
+          safetyEvent: 'histogram-overflow',
+          parentEvent: individualEvent,
+          maxBuckets: MAX_HISTOGRAM_BUCKETS,
+        });
+      }
       if (loggedCount < MAX_WARN_PER_CALL) {
         // (a) spread 順反転で固定 message / safetyEvent が payload から上書きされない構造を保証。
         logger.warn({
@@ -335,10 +381,12 @@ export function createWarnAggregator(individualEvent: string, individualMessage:
     },
     flush() {
       if (totalCount > MAX_WARN_PER_CALL) {
-        // Issue #137 #5: top-N path prefix を count 降順で抽出して batch payload に同梱。
-        const pathPrefixes = Array.from(pathHistogram.entries())
-          .sort(([, a], [, b]) => b - a)
-          .slice(0, PATH_PREFIX_TOP_N);
+        // Issue #137 #5: top-N path prefix を count 降順で抽出。
+        // PR #144 review-pr Important: payload は {path, count} object 配列で Cloud Logging クエリ容易化。
+        const sorted = Array.from(pathHistogram.entries()).sort(([, a], [, b]) => b - a);
+        const pathPrefixes = sorted.slice(0, PATH_PREFIX_TOP_N).map(([path, count]) => ({ path, count }));
+        // PR #144 review-pr Medium: top-N に入りきらなかった distinct bucket 数を observability 用に併記。
+        const truncatedBucketCount = Math.max(0, pathHistogram.size - PATH_PREFIX_TOP_N);
         logger.warn({
           message: batchMessage,
           safetyEvent: batchEvent,
@@ -346,6 +394,7 @@ export function createWarnAggregator(individualEvent: string, individualMessage:
           loggedCount,
           omittedCount: totalCount - loggedCount,
           pathPrefixes,
+          truncatedBucketCount,
         });
       }
     },
@@ -383,7 +432,7 @@ export function stripPromptHeavyFields(data: unknown): unknown {
 
   function recurse(value: unknown, path: string, depth: number): unknown {
     if (depth > MAX_RECURSION_DEPTH) {
-      // Issue #137 #5: path を第 2 引数で渡して batch log の pathPrefixes histogram に集計。
+      // path 引数で histogram 集計 (WarnAggregator.tick JSDoc 参照)。
       depthAggregator.tick(() => ({ path, depth }), path);
       return RECURSION_DEPTH_EXCEEDED_MARKER;
     }


### PR DESCRIPTION
## Summary

- Issue #137 #5 (batch log の 51 件目以降 path 喪失復旧) を解消
- WarnAggregator が per-call の path 分布を蓄積し、`*-batch` event payload に **top-5 path prefix histogram** を同梱
- PR #140 lazy builder の altitude を維持 (path のみ軽量別経路、buildPayload は threshold 内のみ)
- Issue #137 は **close せず open 維持** (残課題 #2 残り / #6 / #7 / 新規候補 truncate path 追跡)

## 変更内容

### `server/utils/promptSafety.ts` (+50 行)

新規 (4 要素 + 1 helper):
- `PATH_PREFIX_TOP_N = 5`
- `ARRAY_INDEX_PATTERN = /\[\d+\]/g`
- `NO_PATH_BUCKET = '(no-path)'`
- `normalizePathForHistogram(path?: string)`
- `WarnAggregator.tick` signature 拡張: `(buildPayload, path?: string) => void`
- `createWarnAggregator` 内 `pathHistogram: Map<string, number>` 蓄積 + flush で top-5 抽出

callsite (3 箇所、`stripPromptHeavyFields`):
- `imageAggregator.tick(builder, path)`
- `nonImageAggregator.tick(builder, path)`
- `depthAggregator.tick(builder, path)`

`truncateOversizedStrings` は path 追跡未実装で `(no-path)` bucket に集約 (本 PR スコープ外、別 enhancement 候補)。

### `server/utils/promptSafety.test.ts` (+165 行、+9 件 PASS)

AC-1〜9 (path histogram の挙動 + cross-aggregator independence + 既存 batch event 全件への適用)

## 設計判断 (impl-plan Phase 中 OQ 確定)

| 判断 | 採用案 | 理由 |
|---|---|---|
| top-N | **5** | Cloud Logging payload size と observability の妥協点 |
| prefix 切り詰め | **array index normalize のみ** | `gallery[0..N].url` の cardinality 爆発防止、末尾 prop は意味的に残す |
| aggregator API | **tick 第 2 引数 path 明示** | PR #140 lazy builder 規律を維持。「tick payload 自動検出」案だと threshold 超後 buildPayload を呼ぶ必要があり Buffer.byteLength regression |

## Test plan

- [x] `npm test -- promptSafety` → 79 件 PASS (70 + 9)
- [x] `npm test` (全件) → 599 件 PASS (590 + 9)
- [x] `npm run lint` → 0 errors
- [x] `/safe-refactor` → 検出ゼロ
- [x] `/code-review low` → (none)
- [ ] Cloud Run dev デプロイ success
- [ ] マージ後 Cloud Logging で `pathPrefixes` フィールド出現確認 (本田様判断、実トラフィック発生時)

## スコープ外 (別 Issue / enhancement 候補)

- `truncateOversizedStrings` の path 追跡 (現状 `(no-path)` bucket、enhancement レベル)
- mimeType observability (PR #143 codex Low-Medium 残)
- collection-level guard (#137 #2 残り)
- logger.warnSampled altitude (#137 #6 別 milestone)
- Statsig/metric counter (#137 #7 別 Issue 起票済)

## 設計プロセス

- `/impl-plan` Phase 1 で AskUserQuestion 2 回 (top-N + prefix + API 戦略 → 落とし穴判明 → 2 案目で軌道修正)
- `/brainstorm` スキップ (本田様判断「設計判断軽い enhancement」)
- TDD で AC-1〜9 先行追加 → 実装 → Green

🤖 Generated with [Claude Code](https://claude.com/claude-code)