### PR TITLE
feat(prompt-safety): array 累積 byte threshold guard (Refs #137 #2)

### DIFF
--- a/docs/handoff/2026-06-03e-collection-level-guard-design-handoff.md
+++ b/docs/handoff/2026-06-03e-collection-level-guard-design-handoff.md
@@ -1,0 +1,121 @@
+# Handoff: Issue #137 #2 残り collection-level guard 設計完了 + Phase 9 引継ぎ
+
+- Session Date: 2026-06-03 (3 セッション目)
+- Owner: yasushi-honda
+- Status: 🟢 設計フェーズ完了 + Phase 9 (`/impl-plan`) 待ち、次セッション再開可能
+- Previous handoff: [2026-06-03d-path-prefixes-histogram.md](./2026-06-03d-path-prefixes-histogram.md)
+
+## 本セッション (3 セッション目) 累積成果
+
+| PR | Issue 対応 | 規模 | 状態 |
+|---|---|---|---|
+| **PR #143** | Issue #137 #1 (non-image dataURI gap) | 641 行 / 4 ファイル | ✅ マージ済 |
+| **PR #144** | Issue #137 #5 (pathPrefixes histogram) | 495 行 / 3 ファイル | ✅ マージ済 |
+| **設計文書** | Issue #137 #2 残り (collection-level guard) | 314 行 (commit 2 件) | 🟢 Phase 9 待ち |
+
+両 PR とも brainstorm + impl-plan + TDD + safe-refactor + code-review low + review-pr 5 エージェント並列 + codex セカンドオピニオン (PR #143) の品質ゲートを通過。各 PR の Critical/High 指摘は同 PR 内で反映済。
+
+## 次セッションの最初のアクション (引き継ぎ)
+
+### 1. ブランチ切替
+
+```bash
+cd /Users/yyyhhh/Projects/学校/yamashita/novel-writer
+git fetch origin && git checkout feature/collection-level-guard
+git log --oneline -3  # 設計文書 2 commit (2cb37aa + a414cbf) を確認
+```
+
+### 2. 設計文書を読む
+
+`docs/spec/promptSafety/2026-06-03-collection-level-guard-design.md` (314 行、12 セクション)
+
+設計確定状態:
+- **設計判断 3 件**: array 限定、200KB 閾値、累積到達後 marker 置換
+- **codex セカンドオピニオン 11 件全件反映**: High 3 (defensive coding + 境界 semantics) + Medium 3 (nested 重複 / flush 漏れ防止 / 全体 cap 別 Issue) + Low 5 (観測性 / 命名 / Uint8Array / 代替案 2 件)
+- **AC 14 件**: AC-1〜10 (基本)、AC-11/12 (観測性 + cross-event)、AC-13/14 (defensive: undefined/BigInt)
+- **新規 export**: `COLLECTION_OVERFLOW_MARKER`
+- **新規 private**: `MAX_COLLECTION_BYTES = 200_000`、`estimateElementBytes` helper
+
+### 3. `/impl-plan` で T1-T10 計画作成
+
+PR #143/#144 の流れを継承:
+
+```
+T1: AC-1〜14 テスト先行追加 (TDD Red 状態確認)
+T2: 実装 (MAX_COLLECTION_BYTES + COLLECTION_OVERFLOW_MARKER + estimateElementBytes + collectionAggregator + array recurse 改修)
+T3: npm test + npm run lint
+T4: /safe-refactor
+T5: /code-review low
+T6: handoff 文書追加
+T7: commit + push + PR 作成
+T7.5: post-pr-review hook が large tier 判定したら /review-pr 5 エージェント並列
+T8: 指摘反映 commit + push
+T9: CI Success 確認
+T10: 本田様の番号単位明示認可待ち → merge
+```
+
+### 4. 規律継承事項 (PR #143/#144 経験)
+
+- **TDD Red 状態を commit せず**、テスト追加 + 実装をセットで 1 commit (CI を Red 化しない)
+- **設計文書 §12 の実装手順** を impl-plan に渡す
+- **/review-pr は 5 エージェント並列** (type-design-analyzer は新規 type 追加なしのため除外)
+- **マージ認可** は `PR #番号 — タイトル (N files, +X/-Y)` 形式で要約してから認可を仰ぐ
+- **handoff doc** は `docs/handoff/YYYY-MM-DD<letter>-<topic>.md` 命名規約
+
+## 本セッションで確立した規律 (継承推奨)
+
+### A. brainstorm + codex セカンドオピニオン 2 回パターン (PR #143 経験)
+
+- Phase 1 把握 → Phase 3 OQ で軸確定 → Phase 4 アプローチ提示 → **codex セカンドオピニオン** → Phase 4-5 部分回帰で指摘反映 → Phase 6 設計文書 → セルフレビュー → ユーザーレビュー → /impl-plan
+
+### B. review-pr 5 エージェント並列の context 消費読み (本セッション経験)
+
+PR #143 / #144 ともに **review-pr 5 並列 → Critical/High/Medium 指摘 → 同 PR 内反映 → 再 commit + push** の流れで 30-40K tokens 消費。Phase 9 着手前のセッションは ctx 余裕 (50% 以上) を確保するのが安全。
+
+### C. defensive coding 規律 (PR #143 + 本設計)
+
+- `JSON.stringify(v) ?? 'null'` + try-catch で **non-JSON-safe element を構造的閉鎖**
+- AC で `[undefined, ...]` / `[1n, ...]` / 循環参照 pin → regression test として永続化
+
+### D. Issue triage 規律遵守 (本セッション)
+
+- review-pr Medium 指摘 → 本 PR 同梱 (PR #143 case normalize, PR #144 cardinality cap)
+- 別 PR に分けるべき指摘 → 既存 Issue にコメントで sub-item 追加 (PR #144 Statsig counter → Issue #137 #7)
+- **Net = 0 を許容** したのは umbrella Issue (#137) のサブ進捗のため
+
+## Issue #137 の状態 (Update)
+
+- **#137 #1** ✅ PR #143 完了
+- **#137 #2 残り** 🟢 設計文書完了、Phase 9 待ち (本ハンドオフの主対象)
+- **#137 #5** ✅ PR #144 完了
+- **#137 #6** logger.warnSampled altitude — 別 milestone (未着手)
+- **#137 #7** Statsig/metric counter — 起票済 (Issue #137 コメント `#issuecomment-4610248160`)
+- **#137 #8 候補** `truncateOversizedStrings` の path 追跡 — `(no-path)` bucket 経由で観測可能化済
+
+完了 + 設計済 = 3/7、未着手 = 4/7。Issue #137 の close は #6/#7/#8 候補の処理が決着後。
+
+## 本田様判断待ち事項 (継続、AI 側でできることなし)
+
+- 本番 dev Cloud Logging で発火確認 (実トラフィック発生時):
+  - PR #143 系: `safetyEvent: 'image-omitted'` / `'non-image-data-uri-omitted'` / `*-batch`
+  - PR #144 系: `pathPrefixes` / `truncatedBucketCount` / `histogram-overflow`
+- モバイル実機確認 (PR #128-#130 レスポンシブ修正)
+- 法務確認 (顧問弁護士 → public/legal/*.md 文言確定、M7-β)
+- #125 多ターン E2E (実トラフィック実証)
+
+## 引き継ぎ前の git/CI 状態
+
+```
+main: 7f5e571 (PR #144 マージ済、Cloud Run main デプロイ success)
+feature/collection-level-guard:
+  a414cbf docs(spec): codex セカンドオピニオン High/Medium/Low 指摘反映 (Refs #137)
+  2cb37aa docs(spec): Issue #137 #2 残り collection-level guard の設計文書 (Refs #137)
+  ※ 本ブランチはまだ push していない。本 handoff doc 追加後に push 予定
+```
+
+## 学び / 規律 (本セッション 3 件 PR 連続経験)
+
+- **brainstorm Phase 中の OQ 追加で軌道修正可能** (PR #144 の lazy builder vs histogram の trade-off 落とし穴を OQ 2 回目で吸収)
+- **設計文書 → 実装 → review-pr → 設計文書追補** のループは 1 PR 内で 2-3 巡することも (PR #143/#144 経験)
+- **codex セカンドオピニオン (plan モード)** は brainstorm Phase 6 直前が最適 (設計文書化前の補正余地が大きい)
+- **handoff の境界** は brainstorm Phase 8 完了 = 設計承認直後が綺麗 (Phase 9 以降は ctx 消費読みづらい)

--- a/docs/handoff/2026-06-03f-collection-level-guard-impl.md
+++ b/docs/handoff/2026-06-03f-collection-level-guard-impl.md
@@ -1,0 +1,152 @@
+# Handoff: Issue #137 #2 残り collection-level guard 実装完了 + PR 作成準備
+
+- Session Date: 2026-06-03 (4 セッション目)
+- Owner: yasushi-honda
+- Status: 🟢 T1-T6 完了、T7 (commit + push + PR) 着手中
+- Previous handoff: [2026-06-03e-collection-level-guard-design-handoff.md](./2026-06-03e-collection-level-guard-design-handoff.md)
+- 設計文書: [docs/spec/promptSafety/2026-06-03-collection-level-guard-design.md](../spec/promptSafety/2026-06-03-collection-level-guard-design.md)
+
+## 本セッション成果
+
+| Phase | 内容 | 状態 |
+|---|---|---|
+| T1+T2 | AC-1〜14 テスト + 実装 (TDD Red を commit せず 1 セット) | ✅ |
+| T3 | `npm test` 616/616 PASS + `npm run lint` clean | ✅ |
+| T4 | `/safe-refactor` LOW 1 件のみ (規律継承で保持推奨、修正不要) | ✅ |
+| T5 | `/code-review low` `(none)` | ✅ |
+| T6 | 本 handoff doc 追加 | ✅ |
+| T7 | commit + push + PR 作成 | 🟢 着手中 |
+| T7.5 | post-pr-review hook 判定 → `/review-pr` (large tier 該当時) | ⏸ |
+| T8-T10 | 指摘反映 → CI → 番号単位明示認可 → merge | ⏸ |
+
+## 実装内容
+
+### 変更ファイル
+
+| ファイル | 変更行数 |
+|---|---|
+| `server/utils/promptSafety.ts` | +91 / -10 |
+| `server/utils/promptSafety.test.ts` | +258 / -1 |
+
+### 追加 export / 新規 helper
+
+| 識別子 | 種別 | 値 |
+|---|---|---|
+| `COLLECTION_OVERFLOW_MARKER` | export const | `'[collection-overflow: subsequent items omitted to fit token budget]'` |
+| `MAX_COLLECTION_BYTES` | private const | `200_000` |
+| `estimateElementBytes(value: unknown): number` | private function | JSON.stringify + try-catch + `?? 'null'` の二重 defensive |
+
+### `stripPromptHeavyFields` 改修箇所
+
+- `collectionAggregator` を `createWarnAggregator('collection-overflow', ...)` で 1 instance 生成
+- array recurse loop を `value.map((item, idx) => ...)` から `for (let idx ...) { ... }` に変更
+  - 閾値超え検出時: `cumulativeBytes > MAX_COLLECTION_BYTES` で短絡 → marker push + `tick(lazy builder, path)`
+  - 通常時: recurse → push → `cumulativeBytes += estimateElementBytes(replaced)` + `keptCount++`
+- 関数末尾に `collectionAggregator.flush()` を image/non-image/depth と並列で追加
+
+### AC pin 14 件 (新規 describe block)
+
+| # | テスト | 焦点 |
+|---|---|---|
+| AC-1 | 199KB array → 全 element 保持 | 閾値内全保持の境界 |
+| AC-2 | ~1MB array (500 件 × 2000B) → 閾値超で marker | 攻撃 payload pin |
+| AC-3a/3b | 200 件 × 999B / 250 件 × 1000B | 境界 semantics (`> 200,000` の prose 規律) |
+| AC-4 | nested object in array | per-element JSON.stringify 累積 |
+| AC-5 | image dataURI と co-existence | marker 化済 element は cumulative 圧迫しない |
+| AC-6 | warn payload 6 フィールド | path / arrayLength / cumulativeBytes / droppedIndex / maxCollectionBytes / keptCount |
+| AC-7 | sibling array 独立 (batch.pathPrefixes 経由) | 個別 warn 50 件打ち止め後の観測 |
+| AC-8 | nested array 内側 closure 独立 (外側 1 件構成) | 外側 array に counter が持ち越されない |
+| AC-9 | non-array 影響なし | object/scalar 既存挙動維持 |
+| AC-11 | batch event `collection-overflow-batch` 発火 + pathPrefixes 継承 | PR #144 規律継承 |
+| AC-12 | image-omitted との cross-event independence | 別 histogram / 別 counter |
+| AC-13 | `[undefined, ...]` defensive | throw せず処理完了 |
+| AC-14 | `[1n, ...]` (BigInt) defensive | try-catch fallback で 4 byte 扱い |
+
+AC-10 (regression なし) は `npm test` 616/616 PASS で代替。
+
+## 設計文書との差分 (本セッション発見・記録すべき事項)
+
+### 1. AC-3 table の誤植発見 (prose 優先)
+
+設計文書 §8 AC-3 table:
+> | 201 件 × 1,000B | cumulative 1,000 → 200,000 → 201,000 | 200 件保持、201 件目 marker |
+
+設計文書 §5 prose / pseudo-code:
+> `cumulativeBytes > MAX_COLLECTION_BYTES`、`200,000` ちょうどは保持
+
+prose / pseudo-code が正本 (実装と整合)。201 件 × 1000B の実機挙動は **201 件全保持** (idx=200 入口で cumulative=200,000 → 保持 → 201,000、終了)。「200 件保持 + 1 件 marker」を実現する境界は **202 件 × 1000B** (1002B/件で cumulative 199,398 → 200,400 → idx=200 入口で 200,400>200,000 で fire)。
+
+テストは prose を採用し、AC-3a (200 件 × 999B 全保持) / AC-3b (250 件 × 1000B 部分 marker, droppedIndex=200) で書いた。
+
+### 2. AC-7/AC-8 修正の経緯 (TDD で発見)
+
+- **AC-7 (sibling array 独立)**: 個別 warn は `MAX_WARN_PER_CALL=50` で打ち止まるため、sibling `b[`path が個別 warn に出ない。`collection-overflow-batch.pathPrefixes` で `a[*]` / `b[*]` 両方確認する規律 (PR #144 で確立) に変更
+- **AC-8 (nested array)**: 外側 array に複数 inner を入れると inner recurse 結果 (~200KB) が外側 cumulative を圧迫して外側も overflow する。「外側 1 件構成」(`matrix: [inner]`) に変更し「内側 closure 独立性」のみ pin
+
+### 3. 既存 lazy-builder regression test の期待値更新
+
+`server/utils/promptSafety.test.ts:507-511` の `byteLengthCalls < 200 / >= 150` は、`estimateElementBytes` 追加で +100 増えるため `< 350 / >= 250` に更新。lazy 化の本質 (threshold 超後の tick builder skip) は維持されており、collection-overflow guard 分の独立計算分が baseline に加算される旨をコメントで明記。
+
+## /safe-refactor 結果
+
+HIGH/MEDIUM 0 件、LOW 1 件 (`observedKeptCount` / `observedCumulativeBytes` の local snapshot は overkill だが PR #143/#144 で確立した lazy builder 規律と整合性保持のため保持推奨)。修正不要。
+
+## /code-review low 結果
+
+`(none)` — runtime-correctness bug 検出ゼロ。
+
+## 引き継ぎ事項
+
+### T7 commit message 案
+
+```
+feat(prompt-safety): array 単位の累積 byte threshold guard (Refs #137 #2)
+
+- 追加: COLLECTION_OVERFLOW_MARKER (export), MAX_COLLECTION_BYTES=200_000,
+  estimateElementBytes helper (try-catch + ?? 'null' で BigInt/循環参照 defensive)
+- 改修: stripPromptHeavyFields array recurse に独立 cumulative counter を追加。
+  閾値超 (cumulativeBytes > 200_000) で短絡 marker 置換 + tick で collection-overflow
+  集約。sibling/nested array は closure local で counter 独立。
+- テスト: AC-1〜14 (基本 + 境界値 + 観測性 + cross-event + defensive)。設計文書 §8
+  AC-3 table の誤植 (201 件→200 件保持と書かれているが prose は 201 件全保持) を prose
+  / pseudo-code 採用で修正、handoff doc に記録。
+- 既存 lazy-builder regression test の byteLengthCalls baseline を 150-200 →
+  250-350 に更新 (estimateElementBytes 分の +100)。
+
+設計: docs/spec/promptSafety/2026-06-03-collection-level-guard-design.md
+Refs #137
+```
+
+### post-pr-review hook の large tier 判定
+
+PR #143 (641 行 / 4 ファイル) / PR #144 (495 行 / 3 ファイル) はともに large tier で `/review-pr` 5 並列発火した。本 PR は **+349 / -11 (2 ファイル)** なので large tier 判定 (>=200 行 or >=3 ファイル) に該当 → `/review-pr` 5 並列 (type-design-analyzer は新規 type 追加なしのため除外) を準備しておく。
+
+### マージ認可フォーマット (本田様向け)
+
+```
+PR #<番号> — feat(prompt-safety): array 単位の累積 byte threshold guard (2 files, +349/-11)
+```
+
+## 本田様判断待ち事項 (継続、AI 側でできることなし)
+
+- 本番 dev Cloud Logging で発火確認 (実トラフィック発生時、PR #145 で追加される `safetyEvent: 'collection-overflow'` / `'collection-overflow-batch'` 含む)
+- モバイル実機確認 (PR #128-#130 レスポンシブ修正)
+- 法務確認 (顧問弁護士 → public/legal/*.md 文言確定、M7-β)
+- #125 多ターン E2E
+
+## Issue #137 の状態 (Update 候補)
+
+- **#137 #1** ✅ PR #143 完了
+- **#137 #2 残り** 🟢 本 PR で実装完了、merge 待ち
+- **#137 #5** ✅ PR #144 完了
+- **#137 #6** logger.warnSampled altitude — 別 milestone (未着手)
+- **#137 #7** Statsig/metric counter — 起票済
+- **#137 #8 候補** `truncateOversizedStrings` の path 追跡 — `(no-path)` bucket 経由で観測可能化済
+
+merge 後の状態: 完了 = 3/7 → 4/7 (collection-level guard 完成で Issue #134 の cumulative bypass 軸が構造的に閉鎖)。
+
+## 学び (本セッション)
+
+- **設計文書 prose vs table の不整合**: AC table を機械的に転記すると正しい semantics を取り違える。pseudo-code / prose を正本としてテストを書く規律を徹底
+- **TDD 規律で nested array の overflow chain を発見**: AC-8 設計時の「nested 構造で内側独立」想定は、外側 array でも cumulative guard が走るため複数 inner を入れると外側 overflow する。1 件構成への修正で本質 (closure 独立性) を残しつつ観測可能に
+- **個別 warn vs batch event の使い分け**: sibling/multi-source の独立性は **個別 warn では 50 件打ち止めにより観測不能**。`batch.pathPrefixes` (PR #144 規律) で初めて pin 可能

--- a/docs/spec/promptSafety/2026-06-03-collection-level-guard-design.md
+++ b/docs/spec/promptSafety/2026-06-03-collection-level-guard-design.md
@@ -39,6 +39,7 @@ PR #138 で `MIN_IMAGE_DATA_URI_BYTES` を 100→500 に引き上げ、99B 弱 d
 - **NFR-4**: 入力 mutate なし (pure helpers 規律)
 - **NFR-5**: 攻撃 payload (大型 array) の場合、閾値到達後の short-circuit により perf 悪化なし
 - **NFR-6**: 通常データ (~50KB 以下 array、≤1000 element) の perf 影響は 10ms 級 (per-element JSON.stringify trade-off の許容範囲)
+- **NFR-7**: input は **JSON-safe 前提** だが、`undefined` / `function` / `symbol` / `BigInt` / 循環参照 element でも `Buffer.byteLength` が throw しない defensive coding を入れる (codex セカンドオピニオン High 1-2 解消)
 
 ## 3. アーキテクチャ
 
@@ -79,18 +80,44 @@ stripPromptHeavyFields(data)
 
 ### byte 計測の規律
 
-- 各 element について `Buffer.byteLength(JSON.stringify(processed element), 'utf8')` で計測
+- 各 element について `Buffer.byteLength(JSON.stringify(processed element) ?? 'null', 'utf8')` で計測
 - `processed element` = recurse 通過後の値 (image / non-image marker 化後の短文を含む)
 - これにより「leaf-level marker 化済の element は cumulative 圧迫しない」挙動を保証 (二重防御の補完)
+
+### defensive coding (codex セカンドオピニオン High 1-2 反映)
+
+JSON-safe ではない element を防御的に handle して `Buffer.byteLength` の throw を防ぐ:
+
+| element 型 | 挙動 |
+|---|---|
+| `undefined` / `function` / `symbol` | `JSON.stringify` は `undefined` を返す → `?? 'null'` で `'null'` 文字列 (4 byte) を代入 |
+| `BigInt` (`1n` 等) | `JSON.stringify` は throw → **try-catch** で `'null'` 相当の 4 byte fallback |
+| 循環参照 (`a.self = a`) | `JSON.stringify` は throw → 同じ try-catch fallback で防御 |
+| `Uint8Array` / `Buffer` | `JSON.stringify` は `{"0":..., "length":...}` 形式の object 化 → byte 計測は妥当だが scope 外 (本 PR で追加対応せず) |
+
+これにより `stripPromptHeavyFields([1n])` や循環参照 input が**新たに throw する regression**を防ぐ。「JSON-safe input 前提」を NFR でも明記。
 
 ## 5. アルゴリズム
 
 ### array recurse の改修
 
 ```ts
+/**
+ * processed element の byte 計測 (codex セカンドオピニオン High 1-2 解消)。
+ * JSON-safe ではない element (undefined / function / symbol / BigInt / 循環参照) で
+ * Buffer.byteLength が throw しないよう fallback で 'null' (4 byte) を代入する。
+ */
+function estimateElementBytes(value: unknown): number {
+  try {
+    return Buffer.byteLength(JSON.stringify(value) ?? 'null', 'utf8');
+  } catch {
+    return 4; // 'null' 相当
+  }
+}
+
 if (Array.isArray(value)) {
-  const collectionAggregator = ...; // factory 経由 (Section 6)
   let cumulativeBytes = 0;
+  let keptCount = 0;
   let changed = false;
   const next: unknown[] = [];
   for (let idx = 0; idx < value.length; idx++) {
@@ -102,6 +129,8 @@ if (Array.isArray(value)) {
           arrayLength: value.length,
           cumulativeBytes,
           droppedIndex: idx,
+          maxCollectionBytes: MAX_COLLECTION_BYTES,
+          keptCount,
         }),
         path
       );
@@ -112,11 +141,33 @@ if (Array.isArray(value)) {
     const replaced = recurse(value[idx], joinPath(path, idx), depth + 1);
     next.push(replaced);
     if (replaced !== value[idx]) changed = true;
-    cumulativeBytes += Buffer.byteLength(JSON.stringify(replaced), 'utf8');
+    cumulativeBytes += estimateElementBytes(replaced);
+    keptCount++;
   }
   return changed ? next : value;
 }
 ```
+
+### 閾値 semantics (codex セカンドオピニオン High 3 解消)
+
+判定式 `if (cumulativeBytes > MAX_COLLECTION_BYTES)` の意味:
+
+- **cumulativeBytes ≤ 200,000B のとき**: element を保持して recurse 通過、`estimateElementBytes` 加算
+- **cumulativeBytes > 200,000B のとき**: 当該 index 以降を全 marker 化
+
+具体例: 各 element が 100,000B のとき、
+- idx=0 (cumulativeBytes=0): 保持 → cumulative=100,000
+- idx=1 (cumulativeBytes=100,000): 保持 → cumulative=200,000
+- idx=2 (cumulativeBytes=200,000): まだ閾値以下 → 保持 → cumulative=300,000
+- idx=3 (cumulativeBytes=300,000): **閾値超 → marker**
+
+つまり「閾値ちょうどに到達する element は保持、次から marker」semantics。AC-3 は次の数値で pin:
+
+| 入力 array | 各 element byte | 期待 |
+|---|---|---|
+| 200 件 × 1,000B | cumulative 1,000 → 200,000 | 200 件全保持 (閾値ちょうど) |
+| 201 件 × 1,000B | cumulative 1,000 → 200,000 → 201,000 | 200 件保持、201 件目 marker |
+| 200 件 × 999B | cumulative 999 → 199,800 | 200 件全保持 (閾値内) |
 
 ### perf 設計
 
@@ -158,7 +209,7 @@ const collectionAggregator = createWarnAggregator(
 );
 ```
 
-- 個別 warn payload: `{ path, arrayLength, cumulativeBytes, droppedIndex }`
+- 個別 warn payload: `{ path, arrayLength, cumulativeBytes, droppedIndex, maxCollectionBytes, keptCount }` (codex セカンドオピニオン Low 9 反映)
 - batch event: factory 派生 `'collection-overflow-batch'`
 - `pathPrefixes` histogram (PR #144) を自動継承: 攻撃時 array path 分布が batch payload に top-5 で残る
 - `MAX_HISTOGRAM_BUCKETS=256` + `(overflow)` bucket + `histogram-overflow` warn (PR #144 paired signal) も自動継承
@@ -185,14 +236,16 @@ const collectionAggregator = createWarnAggregator(
 |---|---|---|
 | AC-1 | 199KB array (200,000B 未満) → 全 element 保持 | 閾値内、original 全件 |
 | AC-2 | 大型 array (~1MB、500 件 × 2KB) → 閾値到達後 element が marker | 先頭 N 件保持、残りが `COLLECTION_OVERFLOW_MARKER` |
-| AC-3 境界値 | 199,999B / 200,000B / 200,001B (累積) | 200,000B 以内全保持、200,001B 到達次 element が marker |
+| AC-3 境界値 | 200 件 × 1000B (累積 200,000) / 201 件 × 1000B (累積 201,000) / 200 件 × 999B (累積 199,800) | 1: 200 件全保持 (閾値ちょうど) / 2: 200 件保持 + 1 件 marker / 3: 200 件全保持 (閾値内) |
 | AC-4 | nested object in array (`[{value: '<50KB string>'}, ...]`) | per-element JSON.stringify で累積、object 全体 byte で評価 |
 | AC-5 | image dataURI marker と co-existence | leaf-level で IMAGE_OMITTED_MARKER 化後の短文 (~60B) を cumulative に反映、collection guard が早期発火しない |
-| AC-6 | warn log payload (path / arrayLength / cumulativeBytes / droppedIndex) | `collection-overflow` event が個別 warn で発火 |
+| AC-6 | warn log payload (`path / arrayLength / cumulativeBytes / droppedIndex / maxCollectionBytes / keptCount`) | `collection-overflow` event が個別 warn で発火 (6 フィールド全て確認) |
 | AC-7 | sibling array 独立 (`{a: [200K], b: [200K]}`) | array A/B が別々に閾値超 (2 件の collection-overflow event) |
 | AC-8 | nested array of array (`[[...], [...]]`) | 内側 array が独立した cumulative counter |
 | AC-9 | non-array (object/scalar) は影響なし | 既存挙動維持、collection-overflow event 不発火 |
-| AC-10 | 既存 602 件 + 9 新規 = 611 件全 PASS | regression なし |
+| AC-10 | 既存 602 件 + N 新規 = 全 PASS | regression なし |
+| AC-13 defensive | `[undefined, 'A'.repeat(2000)]` (undefined element) | throw せず処理完了、undefined は 'null' 相当 4 byte で cumulative inc |
+| AC-14 defensive | `[1n, 'A'.repeat(2000)]` (BigInt element) | throw せず処理完了、BigInt は try-catch fallback で 4 byte 扱い |
 
 ### 観測性テスト追加 (PR #144 規律継承)
 
@@ -207,12 +260,14 @@ const collectionAggregator = createWarnAggregator(
 |---|---|
 | **JSON 全長プリチェック (元の案 B)** | sanitize 入口で `sanitizeForPrompt(input)` の全長を 1 回チェック。シンプルだが leaf marker 化の意図を 1 取り返しで上書き、別 enhancement 候補 |
 | **object sibling cumulative (元の案 C)** | 同一 parent の下の全 leaf 合計 byte 追跡。array 専用 vs オブジェクト全体の trade-off は別 Issue で検討 |
+| **sibling array × N 配列の全体 payload cap** (codex セカンドオピニオン Medium 6) | 本 PR は **各 array 200KB が独立**。sibling N 個あれば全体 N × 200KB まで増えうる。全体 cap (JSON 全長プリチェック相当) は別 Issue として保留 |
 | **`truncateOversizedStrings` 側 collection-level guard** | 本 PR は `stripPromptHeavyFields` 側のみ。truncate 側は `(no-path)` bucket 同様、別 enhancement |
 | **`MAX_COLLECTION_BYTES` の動的調整** | Gemini context size 変動 (1M context 等) に応じた閾値調整は別 issue |
+| **Uint8Array / Buffer element の handling** (codex セカンドオピニオン Low 11) | 現状 `JSON.stringify` で object 化されるが byte 計測は妥当に行われる。専用 handling は将来必要時に対応 |
 
 ## 10. Open Questions
 
-なし (3 件全確定 + per-element JSON.stringify trade-off は executor 判断で許容)
+なし (3 件全確定 + codex セカンドオピニオン High 3 + Medium 1 + Low 2 反映済)
 
 ## 11. リスクと緩和
 
@@ -222,13 +277,15 @@ const collectionAggregator = createWarnAggregator(
 | per-element JSON.stringify の perf 劣化 | 1000 element の array で ~10ms 級遅延 | 通常データは ≤1000 element 想定、攻撃時は閾値到達後 short-circuit で stringify 呼出が頭打ち |
 | nested array of nested array of nested... の累積 byte 計算が perf 暴走 | 攻撃 payload で各レベル stringify が指数的増殖 | `MAX_RECURSION_DEPTH=1000` で depth guard、超過時は marker 化で recurse 終端 |
 | `COLLECTION_OVERFLOW_MARKER` 自体の byte size 累積評価への影響 | marker 文字列 (~100B) 自体が次 element の cumulative に inc される | marker は閾値超後にしか出ないため、それ以降はどのみち全部 marker。実害なし |
+| **non-JSON-safe element (BigInt / 循環参照) で `JSON.stringify` が throw** (codex High 1-2) | `stripPromptHeavyFields` が突然 throw する regression | `estimateElementBytes` で try-catch + `JSON.stringify(v) ?? 'null'` の二重 defensive、AC-13/14 で pin |
+| **nested array of array で同 subtree が外側 element stringify で再シリアライズ** (codex Medium 4) | ネスト深さ分のコスト増 (指数的ではない) | 通常データ (深さ ≤5) では perf 影響小、深い wide tree は実用シナリオで稀 (`MAX_RECURSION_DEPTH=1000` の depth guard も二重防御) |
 
 ## 12. 実装手順 (Phase 9 で `/impl-plan` に渡す要約)
 
-1. `promptSafety.ts` に `MAX_COLLECTION_BYTES`, `COLLECTION_OVERFLOW_MARKER` を追加
-2. `stripPromptHeavyFields` 内で `collectionAggregator` を `createWarnAggregator('collection-overflow', ...)` で初期化
-3. array recurse loop を改修: 各 element の `Buffer.byteLength(JSON.stringify(replaced), 'utf8')` を cumulative に累積、閾値超で短絡 marker 置換
-4. `promptSafety.test.ts` に AC-1〜12 を TDD で追加 (AC-3 境界値を先に書き境界 pin)
+1. `promptSafety.ts` に `MAX_COLLECTION_BYTES`, `COLLECTION_OVERFLOW_MARKER`, `estimateElementBytes` helper を追加
+2. `stripPromptHeavyFields` 内で `collectionAggregator` を `createWarnAggregator('collection-overflow', ...)` で初期化、関数末尾に `flush()` 追加忘れ防止 (codex セカンドオピニオン Medium 5)
+3. array recurse loop を改修: 各 element の `estimateElementBytes(replaced)` を cumulative に累積、閾値超で短絡 marker 置換 + `keptCount` 追跡
+4. `promptSafety.test.ts` に AC-1〜12 + AC-13/14 (defensive) を TDD で追加 (AC-3 境界値を先に書き境界 pin)
 5. `npm test` / `npm run lint` 全 PASS 確認
 6. handoff 文書を `docs/handoff/` に追加 (実装完了後)
 7. /safe-refactor + /code-review low + /review-pr (large tier 該当時)

--- a/docs/spec/promptSafety/2026-06-03-collection-level-guard-design.md
+++ b/docs/spec/promptSafety/2026-06-03-collection-level-guard-design.md
@@ -161,13 +161,18 @@ if (Array.isArray(value)) {
 - idx=2 (cumulativeBytes=200,000): まだ閾値以下 → 保持 → cumulative=300,000
 - idx=3 (cumulativeBytes=300,000): **閾値超 → marker**
 
-つまり「閾値ちょうどに到達する element は保持、次から marker」semantics。AC-3 は次の数値で pin:
+つまり「閾値ちょうどに到達する element は保持、次から marker」semantics。AC-3 は次の数値で pin
+(**PR #145 review-pr code-reviewer M-2 訂正**: 初版の table で `201 件 × 1,000B → 200 件保持` と書いていたが pseudo-code と矛盾 (実機では idx=200 入口で cumulative=200,000 → まだ閾値以下で保持 → cumulative=201,000、終了で 201 件全保持)。202 件で初めて 1 件 marker):
 
-| 入力 array | 各 element byte | 期待 |
+| 入力 array | 各 element byte (JSON.stringify 後) | 期待 |
 |---|---|---|
-| 200 件 × 1,000B | cumulative 1,000 → 200,000 | 200 件全保持 (閾値ちょうど) |
-| 201 件 × 1,000B | cumulative 1,000 → 200,000 → 201,000 | 200 件保持、201 件目 marker |
-| 200 件 × 999B | cumulative 999 → 199,800 | 200 件全保持 (閾値内) |
+| 200 件 × 1,000B raw (1,002 byte/件) | cumulative 1,002 → ... → 200,400 (idx=199 後) | 200 件全保持 (idx=199 入口 199,398 で保持、終了) |
+| 202 件 × 1,000B raw (1,002 byte/件) | cumulative 1,002 → ... → 200,400 → 201,402 (idx=201 入口) | 201 件保持、idx=201 で 1 件 marker (droppedIndex=201) |
+| 200 件 × 999B raw (1,001 byte/件) | cumulative 1,001 → ... → 200,200 (idx=199 後) | 200 件全保持 (閾値内) |
+
+実装テストは `AC-3a` (200 件 × 999B 全保持) / `AC-3b` (250 件 × 1000B → idx=200 で marker、droppedIndex=200) で
+pseudo-code と整合した境界値を pin している。
+JSON.stringify("a".repeat(N)) は `"..."` の quote 2 byte 込で N+2 byte になる点に注意。
 
 ### perf 設計
 

--- a/docs/spec/promptSafety/2026-06-03-collection-level-guard-design.md
+++ b/docs/spec/promptSafety/2026-06-03-collection-level-guard-design.md
@@ -1,0 +1,245 @@
+# collection-level guard 設計 (Issue #137 #2 残り)
+
+- **作成日**: 2026-06-03
+- **関連 Issue**: [#137](https://github.com/Yukina1116/novel-writer/issues/137) #2 残り (collection-level guard)
+- **関連 PR (祖先)**: #136 (Issue #134 part 1)、#138 (MIN 100→500)、#139-#141 (aggregator 系)、#143 (non-image dataURI)、#144 (pathPrefixes histogram)
+- **対象モジュール**: `server/utils/promptSafety.ts`
+- **ステータス**: Design (Phase 6, brainstorm Skill)
+- **緊急性**: LOW (size guard backstop が機能中で実害発生中ではない)
+
+---
+
+## 1. 概要 / 動機
+
+PR #138 で `MIN_IMAGE_DATA_URI_BYTES` を 100→500 に引き上げ、99B 弱 dataURI の cumulative bypass 帯域を ~5x 縮小済。残課題は **≤499B dataURI を多数並べた cumulative token-bomb**:
+
+- `[{url: 'data:image/png;base64,' + 'A'.repeat(80)}, ...] × 2000` ≈ **~1MB / ~50K tokens**
+- 各 leaf は `MIN_IMAGE_DATA_URI_BYTES=500` 未満で **content-based detection を素通し**
+- 各 leaf は `MAX_FIELD_BYTES=100KB` 未満で **size guard も素通し**
+- 認証 + `withUsageQuota('character/*', 100 sen)` で call 数は制限されるが、**call 単位 cost amplification は直交軸**
+
+本設計は **array 単位の累積 byte threshold** を追加することで、leaf-level guard を素通しする cumulative bypass を構造的に閉じる。Issue #134 の register-or-forget 解消理念とは **直交軸の防御** (cumulative byte 制限は新フィールド追加で自動カバー、register 不要)。
+
+## 2. 要件
+
+### 機能要件
+
+- **FR-1**: array 内 element の累積 byte (Buffer.byteLength of JSON.stringify(processed element), UTF-8) が `MAX_COLLECTION_BYTES=200KB` を超えた後、残り element を `COLLECTION_OVERFLOW_MARKER` に置換する
+- **FR-2**: 閾値内 element は image / non-image marker 化 (既存) を経由して通常通り保持される
+- **FR-3**: sibling array は独立した cumulative counter を持つ (`{a: [...], b: [...]}` で a/b 個別追跡)
+- **FR-4**: nested array (array of array) も内側 array が独立に追跡される
+- **FR-5**: non-array (object / scalar) のロジックは無変更
+- **FR-6**: 集約 log は per-call 50 件上限 + `collection-overflow-batch` event で amplification 抑制 (既存 aggregator factory 再利用)
+
+### 非機能要件
+
+- **NFR-1**: `stripPromptHeavyFields(data: unknown): unknown` signature **不変**、既存呼出側 (`worldService` / `characterService` / `characterPrompt`) 無変更
+- **NFR-2**: `truncateOversizedStrings` / `sanitizeForPrompt` signature **不変**
+- **NFR-3**: 既存テスト 602 件全 PASS (regression なし)
+- **NFR-4**: 入力 mutate なし (pure helpers 規律)
+- **NFR-5**: 攻撃 payload (大型 array) の場合、閾値到達後の short-circuit により perf 悪化なし
+- **NFR-6**: 通常データ (~50KB 以下 array、≤1000 element) の perf 影響は 10ms 級 (per-element JSON.stringify trade-off の許容範囲)
+
+## 3. アーキテクチャ
+
+### 追加位置
+
+`server/utils/promptSafety.ts` 内の `stripPromptHeavyFields` の **array recurse 経路** に並列追加。既存 image / non-image / depth marker 経路と並列に動作し、互いに干渉しない。
+
+```
+stripPromptHeavyFields(data)
+  └─ recurse(value, path, depth)
+       ├─ if depth > MAX_RECURSION_DEPTH  → depth marker
+       ├─ if string                        → image / non-image / passthrough (既存)
+       ├─ if array                         → collection-level guard + element recurse  ← 新規
+       └─ if object                        → entry recurse (既存)
+```
+
+### Issue #134 理念との位置付け
+
+- whitelist register-or-forget 解消 (PR #136) = content-based detection (leaf レベル) → register-or-forget 軸
+- collection-level guard (本設計) = **構造的 cumulative byte 制限** → register-or-forget と**直交軸の防御**
+- 新フィールド追加で自動カバー (whitelist 不要)、新型 token-bomb (PDF dataURI × N 等) も自動防御
+
+## 4. データモデル
+
+### 新規定数 / marker
+
+| 名前 | 種別 | 値 | 役割 |
+|---|---|---|---|
+| `MAX_COLLECTION_BYTES` | private const | `200_000` | array 1 つあたりの累積 byte 上限 (1 つの leaf 100KB の 2x altitude) |
+| `COLLECTION_OVERFLOW_MARKER` | **export** const | `'[collection-overflow: subsequent items omitted to fit token budget]'` | 閾値到達後の element 代替マーカー |
+
+### 閾値値 (200KB) の根拠
+
+- 通常の character.skills[] / world.lore[] は実用 ~50KB 以下、200KB は十分余裕 (false positive 実質ゼロ)
+- Gemini 131K context の ~1.5x 相当の ~50K tokens 目安にターゲット
+- `MAX_FIELD_BYTES=100KB` (単一 leaf 上限) の 2x で「単一 vs 集合」の altitude を区別
+- ≥200KB の array は通常データで起きえない (~400 件の 499B dataURI に相当する量)
+
+### byte 計測の規律
+
+- 各 element について `Buffer.byteLength(JSON.stringify(processed element), 'utf8')` で計測
+- `processed element` = recurse 通過後の値 (image / non-image marker 化後の短文を含む)
+- これにより「leaf-level marker 化済の element は cumulative 圧迫しない」挙動を保証 (二重防御の補完)
+
+## 5. アルゴリズム
+
+### array recurse の改修
+
+```ts
+if (Array.isArray(value)) {
+  const collectionAggregator = ...; // factory 経由 (Section 6)
+  let cumulativeBytes = 0;
+  let changed = false;
+  const next: unknown[] = [];
+  for (let idx = 0; idx < value.length; idx++) {
+    if (cumulativeBytes > MAX_COLLECTION_BYTES) {
+      // 閾値到達後は短絡 marker 置換 (recurse skip で perf 改善)
+      collectionAggregator.tick(
+        () => ({
+          path: joinPath(path, idx),
+          arrayLength: value.length,
+          cumulativeBytes,
+          droppedIndex: idx,
+        }),
+        path
+      );
+      next.push(COLLECTION_OVERFLOW_MARKER);
+      changed = true;
+      continue;
+    }
+    const replaced = recurse(value[idx], joinPath(path, idx), depth + 1);
+    next.push(replaced);
+    if (replaced !== value[idx]) changed = true;
+    cumulativeBytes += Buffer.byteLength(JSON.stringify(replaced), 'utf8');
+  }
+  return changed ? next : value;
+}
+```
+
+### perf 設計
+
+| シナリオ | per-element 呼出回数 | 実用許容 |
+|---|---|---|
+| 通常データ (~50KB array、≤1000 element) | JSON.stringify ×1000 (~10ms 級) | ✅ |
+| 攻撃 payload (~1MB array、~2000 element) | 閾値到達後 short-circuit、stringify は ~400 件で頭打ち | ✅ (攻撃時こそ perf 良化) |
+| nested array (array of small array) | 内側 array が再帰呼出、内側 cumulative は独立 | ✅ (各 array 200KB 上限) |
+
+## 6. インターフェース
+
+### 公開 API (export)
+
+- 既存: `IMAGE_OMITTED_MARKER`, `NON_IMAGE_DATA_URI_MARKER`, `OVERSIZED_STRING_MARKER`, `RECURSION_DEPTH_EXCEEDED_MARKER`, `MAX_FIELD_BYTES`, `WarnAggregatorPayload`, `WarnAggregator`, `createWarnAggregator`, `stripPromptHeavyFields`, `truncateOversizedStrings`, `sanitizeForPrompt`
+- **新規追加**: `COLLECTION_OVERFLOW_MARKER`
+
+### 関数 signature
+
+| 関数 | signature |
+|---|---|
+| `stripPromptHeavyFields(data: unknown): unknown` | **不変** |
+| `truncateOversizedStrings(data: unknown, maxBytes?: number): unknown` | **不変** |
+| `sanitizeForPrompt(data: unknown, maxBytes?: number): unknown` | **不変** |
+
+### 呼出側影響
+
+`worldService` / `characterService` / `characterPrompt` は全て **不変**。
+
+## 7. エラー処理 / 観測性
+
+### per-call warn aggregator (PR #144 規律継承)
+
+既存 `createWarnAggregator(individualEvent, individualMessage)` factory を再利用:
+
+```ts
+const collectionAggregator = createWarnAggregator(
+  'collection-overflow',
+  'promptSafety: collection-level cumulative byte threshold exceeded'
+);
+```
+
+- 個別 warn payload: `{ path, arrayLength, cumulativeBytes, droppedIndex }`
+- batch event: factory 派生 `'collection-overflow-batch'`
+- `pathPrefixes` histogram (PR #144) を自動継承: 攻撃時 array path 分布が batch payload に top-5 で残る
+- `MAX_HISTOGRAM_BUCKETS=256` + `(overflow)` bucket + `histogram-overflow` warn (PR #144 paired signal) も自動継承
+- `truncatedBucketCount` (PR #144) も自動継承
+
+### aggregator instance のスコープ
+
+各 `stripPromptHeavyFields(data)` 呼出ごとに 1 instance 生成 (sibling array は同 aggregator を共有、内側 array は独立 instance を作るかどうか要検討):
+
+**選択**: aggregator は `stripPromptHeavyFields` 関数全体で 1 instance を共有する (image / non-image aggregator と同じ pattern)。理由:
+- cumulative byte counter は array ごとに別 closure 変数で管理 (recurse 内 local)
+- aggregator は warn 集約 (call 単位の 50 件上限) のみが責務、cumulative byte の累積責任は recurse 側
+- per-array aggregator instance 作ると factory 呼出が array 数だけ増えるが、aggregator 初期化は軽量なので perf 影響なし
+
+### lazy payload builder
+
+`tick(() => ({ path, arrayLength, cumulativeBytes, droppedIndex }))` で payload を closure 化、PR #140 lazy builder altitude を継承。
+
+## 8. テスト戦略 (Acceptance Criteria)
+
+`server/utils/promptSafety.test.ts` に以下 9 件追加 (AC-10 は npm test 全件 PASS で代替):
+
+| # | テスト | 期待 |
+|---|---|---|
+| AC-1 | 199KB array (200,000B 未満) → 全 element 保持 | 閾値内、original 全件 |
+| AC-2 | 大型 array (~1MB、500 件 × 2KB) → 閾値到達後 element が marker | 先頭 N 件保持、残りが `COLLECTION_OVERFLOW_MARKER` |
+| AC-3 境界値 | 199,999B / 200,000B / 200,001B (累積) | 200,000B 以内全保持、200,001B 到達次 element が marker |
+| AC-4 | nested object in array (`[{value: '<50KB string>'}, ...]`) | per-element JSON.stringify で累積、object 全体 byte で評価 |
+| AC-5 | image dataURI marker と co-existence | leaf-level で IMAGE_OMITTED_MARKER 化後の短文 (~60B) を cumulative に反映、collection guard が早期発火しない |
+| AC-6 | warn log payload (path / arrayLength / cumulativeBytes / droppedIndex) | `collection-overflow` event が個別 warn で発火 |
+| AC-7 | sibling array 独立 (`{a: [200K], b: [200K]}`) | array A/B が別々に閾値超 (2 件の collection-overflow event) |
+| AC-8 | nested array of array (`[[...], [...]]`) | 内側 array が独立した cumulative counter |
+| AC-9 | non-array (object/scalar) は影響なし | 既存挙動維持、collection-overflow event 不発火 |
+| AC-10 | 既存 602 件 + 9 新規 = 611 件全 PASS | regression なし |
+
+### 観測性テスト追加 (PR #144 規律継承)
+
+| # | テスト |
+|---|---|
+| AC-11 | 51 件超 collection-overflow → batch event `collection-overflow-batch` 発火 + `pathPrefixes` 自動継承 |
+| AC-12 | collection-overflow と image-omitted の cross-event independence (別 histogram、別 counter) |
+
+## 9. スコープ外 / 将来課題
+
+| 項目 | 理由 |
+|---|---|
+| **JSON 全長プリチェック (元の案 B)** | sanitize 入口で `sanitizeForPrompt(input)` の全長を 1 回チェック。シンプルだが leaf marker 化の意図を 1 取り返しで上書き、別 enhancement 候補 |
+| **object sibling cumulative (元の案 C)** | 同一 parent の下の全 leaf 合計 byte 追跡。array 専用 vs オブジェクト全体の trade-off は別 Issue で検討 |
+| **`truncateOversizedStrings` 側 collection-level guard** | 本 PR は `stripPromptHeavyFields` 側のみ。truncate 側は `(no-path)` bucket 同様、別 enhancement |
+| **`MAX_COLLECTION_BYTES` の動的調整** | Gemini context size 変動 (1M context 等) に応じた閾値調整は別 issue |
+
+## 10. Open Questions
+
+なし (3 件全確定 + per-element JSON.stringify trade-off は executor 判断で許容)
+
+## 11. リスクと緩和
+
+| リスク | 影響 | 緩和策 |
+|---|---|---|
+| 200KB 閾値が実プロダクトデータで false positive を引き起こす | 通常 character/world データの array が marker 置換される | AC-1 で 199KB 全保持を pin、Cloud Logging で `safetyEvent: 'collection-overflow'` 発火頻度を本番デプロイ後に観測 |
+| per-element JSON.stringify の perf 劣化 | 1000 element の array で ~10ms 級遅延 | 通常データは ≤1000 element 想定、攻撃時は閾値到達後 short-circuit で stringify 呼出が頭打ち |
+| nested array of nested array of nested... の累積 byte 計算が perf 暴走 | 攻撃 payload で各レベル stringify が指数的増殖 | `MAX_RECURSION_DEPTH=1000` で depth guard、超過時は marker 化で recurse 終端 |
+| `COLLECTION_OVERFLOW_MARKER` 自体の byte size 累積評価への影響 | marker 文字列 (~100B) 自体が次 element の cumulative に inc される | marker は閾値超後にしか出ないため、それ以降はどのみち全部 marker。実害なし |
+
+## 12. 実装手順 (Phase 9 で `/impl-plan` に渡す要約)
+
+1. `promptSafety.ts` に `MAX_COLLECTION_BYTES`, `COLLECTION_OVERFLOW_MARKER` を追加
+2. `stripPromptHeavyFields` 内で `collectionAggregator` を `createWarnAggregator('collection-overflow', ...)` で初期化
+3. array recurse loop を改修: 各 element の `Buffer.byteLength(JSON.stringify(replaced), 'utf8')` を cumulative に累積、閾値超で短絡 marker 置換
+4. `promptSafety.test.ts` に AC-1〜12 を TDD で追加 (AC-3 境界値を先に書き境界 pin)
+5. `npm test` / `npm run lint` 全 PASS 確認
+6. handoff 文書を `docs/handoff/` に追加 (実装完了後)
+7. /safe-refactor + /code-review low + /review-pr (large tier 該当時)
+
+## 13. 参考資料
+
+- Issue #134 (whitelist → content-based 移行の祖)
+- PR #136 (Issue #134 part 1)
+- Issue #137 (#1 / #2 / #3 / #4 / #5 / #6 / #7)
+- PR #138 (Issue #137 #2 一部、MIN 100→500)
+- PR #143 (non-image dataURI 検出)
+- PR #144 (pathPrefixes histogram + cardinality cap)
+- Gemini 2.5 Flash context limit (131,072 tokens)
+- `withUsageQuota('character/*', 100 sen)` (M3 PR-F、call 単位制限)

--- a/server/utils/promptSafety.test.ts
+++ b/server/utils/promptSafety.test.ts
@@ -5,6 +5,7 @@ import {
   NON_IMAGE_DATA_URI_MARKER,
   OVERSIZED_STRING_MARKER,
   RECURSION_DEPTH_EXCEEDED_MARKER,
+  COLLECTION_OVERFLOW_MARKER,
   MAX_FIELD_BYTES,
   stripPromptHeavyFields,
   truncateOversizedStrings,
@@ -503,11 +504,13 @@ describe('observability (silent fail paired signal)', () => {
       (Buffer as any).byteLength = originalByteLength;
     }
 
-    // 旧 eager 設計: 100 leaf × 2 回 = 200 回
-    // 新 lazy 設計: 100 leaf × 1 回 (isImageDataUri) + 50 leaf × 1 回 (tick builder) = 150 回
-    // 厳密に 150 回でなくても、200 回未満であれば lazy 化は効いている
-    expect(byteLengthCalls).toBeLessThan(200);
-    expect(byteLengthCalls).toBeGreaterThanOrEqual(150);
+    // 旧 eager 設計 (PR #140 以前): 100 leaf × 2 回 = 200 回
+    // 新 lazy 設計 (PR #140): 100 leaf × 1 回 (isImageDataUri) + 50 leaf × 1 回 (tick builder) = 150 回
+    // PR #145 (Issue #137 #2 collection-level guard): + 100 leaf × 1 回 (estimateElementBytes 経由) = 250 回
+    // lazy 化の本質 (threshold 超後の tick builder skip) は維持されているため、350 未満であれば
+    // 退行していない。collection-overflow guard は array recurse 内の独立計算で、別 baseline を持つ。
+    expect(byteLengthCalls).toBeLessThan(350);
+    expect(byteLengthCalls).toBeGreaterThanOrEqual(250);
   });
 
   it('image and depth aggregators are independent (one event burst does not exhaust the other quota)', () => {
@@ -1171,5 +1174,251 @@ describe('createWarnAggregator path histogram (Issue #137 #5)', () => {
     );
     expect(case1).toBeDefined();
     expect((case1![0] as { truncatedBucketCount: number }).truncatedBucketCount).toBe(0);
+  });
+});
+
+describe('stripPromptHeavyFields - collection-level guard (Issue #137 #2 残り)', () => {
+  // 設計文書 §5 prose / pseudo-code が境界 semantics の正本: `cumulativeBytes > MAX_COLLECTION_BYTES`
+  // 演算子なので「閾値ちょうど (=200,000) は保持、次から marker」。各 element X byte のとき
+  // floor(200,000 / X) + 1 件目までは保持 (入口で cumulative ≤ 200,000) され、その次が marker。
+  // 設計文書 AC-3 table の "201 件×1000B → 200 件保持" は pseudo-code と矛盾し誤植扱い (実機では 202 件で
+  // 初めて 1 件 marker)。handoff に記録する。
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+  });
+
+  function buildElementOfBytes(byteLength: number): string {
+    // JSON.stringify(s) で `"..."` の前後の quote 2 byte 込で byte 計測されることを考慮し、
+    // estimateElementBytes(s) = byteLength + 2 になる。ここでは raw byte 長で指定して
+    // テスト側で +2 を含めた cumulative 計算をする規律にする (テスト名で byte 数を明示)。
+    return 'a'.repeat(byteLength);
+  }
+
+  it('AC-1: 199KB array (cumulative < 200,000) → 全 element 保持、collection-overflow 不発火', () => {
+    // 1000B raw 文字列 200 件で JSON.stringify 後は 1002B/件 × 200 = 200,400 byte
+    // → cumulative 200,400 で fire するが、AC-1 は「199KB の領域」の確認なので 800B raw × 200 件
+    // (= 802B/件 × 200 = 160,400 cumulative) を使う。閾値内で全保持を pin する。
+    const arr = Array.from({ length: 200 }, () => buildElementOfBytes(800));
+    const out = stripPromptHeavyFields({ list: arr }) as { list: string[] };
+    expect(out.list).toHaveLength(200);
+    expect(out.list.every((s) => s === 'a'.repeat(800))).toBe(true);
+    const fired = warnSpy.mock.calls.find(
+      (c) => (c[0] as { safetyEvent?: string }).safetyEvent === 'collection-overflow'
+    );
+    expect(fired).toBeUndefined();
+  });
+
+  it('AC-2: ~1MB array (500 件 × 2000B) → 閾値到達後 element が COLLECTION_OVERFLOW_MARKER に置換', () => {
+    const elem = buildElementOfBytes(2000); // estimateElementBytes(elem) = 2002
+    const arr = Array.from({ length: 500 }, () => elem);
+    const out = stripPromptHeavyFields({ list: arr }) as { list: string[] };
+    // 先頭 N 件は保持、残りは marker。N は cumulative ≤ 200,000 を満たす最大件数 + 1。
+    // 2002 * 100 = 200,200 > 200,000、2002 * 99 = 198,198 ≤ 200,000。
+    // idx=99 入口 cumulative=198,198 → 保持 → 200,200。idx=100 入口 200,200 > 200,000 → marker。
+    expect(out.list).toHaveLength(500);
+    expect(out.list[0]).toBe(elem); // 保持
+    expect(out.list[99]).toBe(elem); // 最後の保持 (cumulative ちょうど超え)
+    expect(out.list[100]).toBe(COLLECTION_OVERFLOW_MARKER); // 1 件目 marker
+    expect(out.list[499]).toBe(COLLECTION_OVERFLOW_MARKER); // 末尾も marker
+  });
+
+  it('AC-3a: 200 件 × 999B raw (estimateElementBytes 1001 × 200 = 200,200) → idx=199 までは入口で <=200,000 で保持、idx=200 はないので全 200 件保持', () => {
+    // 1001 × 199 = 199,199 ≤ 200,000、idx=199 入口 199,199 → 保持 → 200,200。終了。
+    const arr = Array.from({ length: 200 }, () => buildElementOfBytes(999));
+    const out = stripPromptHeavyFields({ list: arr }) as { list: string[] };
+    expect(out.list).toHaveLength(200);
+    expect(out.list.every((s) => s === 'a'.repeat(999))).toBe(true);
+  });
+
+  it('AC-3b: 閾値超で部分 marker — 250 件 × 1000B → 先頭 N 件保持後 marker', () => {
+    // 1002 × 199 = 199,398 ≤ 200,000、idx=199 入口 199,398 → 保持 → 200,400。
+    // idx=200 入口 200,400 > 200,000 → marker。droppedIndex=200。
+    const arr = Array.from({ length: 250 }, () => buildElementOfBytes(1000));
+    const out = stripPromptHeavyFields({ list: arr }) as { list: string[] };
+    expect(out.list).toHaveLength(250);
+    expect(out.list[199]).toBe('a'.repeat(1000));
+    expect(out.list[200]).toBe(COLLECTION_OVERFLOW_MARKER);
+    expect(out.list[249]).toBe(COLLECTION_OVERFLOW_MARKER);
+  });
+
+  it('AC-4: nested object in array → per-element JSON.stringify 累積で評価', () => {
+    // 各 element = { value: 'a'.repeat(1000) } → JSON.stringify は {"value":"a..a"} ≈ 1012 byte
+    // 1012 × 197 = 199,364 ≤ 200,000、idx=197 入口 199,364 → 保持 → 200,376。
+    // idx=198 入口 200,376 > 200,000 → marker。droppedIndex=198。
+    const arr = Array.from({ length: 250 }, () => ({ value: 'a'.repeat(1000) }));
+    const out = stripPromptHeavyFields({ list: arr }) as { list: Array<unknown> };
+    expect(out.list[197]).toEqual({ value: 'a'.repeat(1000) });
+    expect(out.list[198]).toBe(COLLECTION_OVERFLOW_MARKER);
+  });
+
+  it('AC-5: image dataURI marker と co-existence — leaf 化された marker (~60B) で cumulative を圧迫しない', () => {
+    // 各 element が大型 dataURI (5000B raw) → IMAGE_OMITTED_MARKER (~58B) に marker 化
+    // marker 化後の processed element 1 件は約 60B、JSON.stringify で 62B 程度
+    // → 62 × N で N=3000 でも cumulative ≈ 186,000 で閾値以下、collection-overflow 不発火
+    const bigImage = `data:image/png;base64,${'A'.repeat(5000)}`;
+    const arr = Array.from({ length: 1000 }, () => bigImage);
+    const out = stripPromptHeavyFields({ list: arr }) as { list: string[] };
+    expect(out.list).toHaveLength(1000);
+    expect(out.list.every((s) => s === IMAGE_OMITTED_MARKER)).toBe(true);
+    // collection-overflow は発火していない (image-omitted marker 化で cumulative が圧迫されない)
+    const collectionFired = warnSpy.mock.calls.find(
+      (c) => (c[0] as { safetyEvent?: string }).safetyEvent === 'collection-overflow'
+    );
+    expect(collectionFired).toBeUndefined();
+  });
+
+  it('AC-6: warn log payload に 6 フィールド (path / arrayLength / cumulativeBytes / droppedIndex / maxCollectionBytes / keptCount) が含まれる', () => {
+    const arr = Array.from({ length: 250 }, () => buildElementOfBytes(1000));
+    stripPromptHeavyFields({ items: arr });
+    const overflowCall = warnSpy.mock.calls.find(
+      (c) => (c[0] as { safetyEvent?: string }).safetyEvent === 'collection-overflow'
+    );
+    expect(overflowCall).toBeDefined();
+    const payload = overflowCall![0] as {
+      path: string;
+      arrayLength: number;
+      cumulativeBytes: number;
+      droppedIndex: number;
+      maxCollectionBytes: number;
+      keptCount: number;
+      safetyEvent: string;
+      message: string;
+    };
+    expect(payload.safetyEvent).toBe('collection-overflow');
+    expect(payload.message).toContain('cumulative byte threshold');
+    expect(payload.path).toBe('items[200]');
+    expect(payload.arrayLength).toBe(250);
+    expect(payload.droppedIndex).toBe(200);
+    expect(payload.maxCollectionBytes).toBe(200_000);
+    expect(payload.keptCount).toBe(200);
+    expect(payload.cumulativeBytes).toBeGreaterThan(200_000);
+  });
+
+  it('AC-7: sibling array 独立 — {a: [overflow], b: [overflow]} は batch.pathPrefixes で各々観測', () => {
+    // 個別 warn は MAX_WARN_PER_CALL=50 で打ち止まるため (a[] 50 件で枯渇)、sibling 独立性は
+    // batch event の pathPrefixes histogram で観測する規律 (PR #144 で確立)。
+    const elem = buildElementOfBytes(1000); // 1002 byte/件
+    const data = {
+      a: Array.from({ length: 250 }, () => elem),
+      b: Array.from({ length: 250 }, () => elem),
+    };
+    stripPromptHeavyFields(data);
+    const batchCall = warnSpy.mock.calls.find(
+      (c) => (c[0] as { safetyEvent?: string }).safetyEvent === 'collection-overflow-batch'
+    );
+    expect(batchCall).toBeDefined();
+    const pathPrefixes = (batchCall![0] as { pathPrefixes: Array<{ path: string; count: number }> }).pathPrefixes;
+    const paths = pathPrefixes.map((p) => p.path);
+    // a[*] と b[*] が両方とも histogram bucket に存在 (sibling array で独立に counter が回る)
+    expect(paths).toContain('a[*]');
+    expect(paths).toContain('b[*]');
+  });
+
+  it('AC-8: nested array — 内側 array の collection guard は外側 cumulative counter とは独立 closure', () => {
+    // 「内側 array で 200,000 を超えて counter が回っても、外側 array に counter が持ち越されない」を
+    // pin する。外側 array を **1 件構成** にすることで「外側自身は overflow せず、内側だけが overflow」を
+    // 観測する。外側に複数 inner を入れると inner recurse 結果 (~200KB) が外側 cumulative を圧迫して
+    // 外側も overflow するため、AC-8 の本質 (内側 closure 独立性) が観測できない。
+    const inner = Array.from({ length: 250 }, () => buildElementOfBytes(1000));
+    const data = { matrix: [inner] };
+    const out = stripPromptHeavyFields(data) as { matrix: string[][] };
+    expect(out.matrix).toHaveLength(1);
+    expect(out.matrix[0]).toHaveLength(250);
+    // 内側 array で閾値到達後 marker
+    expect(out.matrix[0][199]).toBe('a'.repeat(1000));
+    expect(out.matrix[0][200]).toBe(COLLECTION_OVERFLOW_MARKER);
+    expect(out.matrix[0][249]).toBe(COLLECTION_OVERFLOW_MARKER);
+  });
+
+  it('AC-9: non-array (object/scalar) には影響なし、collection-overflow 不発火', () => {
+    const data = {
+      name: 'Alice',
+      age: 42,
+      profile: { bio: 'a'.repeat(50_000) },
+      nullField: null,
+      undefinedField: undefined,
+    };
+    const out = stripPromptHeavyFields(data) as typeof data;
+    expect(out.name).toBe('Alice');
+    expect(out.age).toBe(42);
+    expect(out.profile.bio).toBe('a'.repeat(50_000));
+    const collectionFired = warnSpy.mock.calls.find(
+      (c) => (c[0] as { safetyEvent?: string }).safetyEvent === 'collection-overflow'
+    );
+    expect(collectionFired).toBeUndefined();
+  });
+
+  it('AC-11: 51 件超 collection-overflow → batch event "collection-overflow-batch" 発火 + pathPrefixes 自動継承', () => {
+    // 1 つの array 内で 51 件超の overflow を発生させる必要がある。
+    // 1002B × 200 件で cumulative ちょうど超え → idx=200 以降 marker、合計 100 件 marker
+    // 個別 warn 50 件まで + batch 1 件 (= total >50 で batch fire)。
+    const arr = Array.from({ length: 300 }, () => buildElementOfBytes(1000));
+    stripPromptHeavyFields({ bulk: arr });
+    const batchCall = warnSpy.mock.calls.find(
+      (c) => (c[0] as { safetyEvent?: string }).safetyEvent === 'collection-overflow-batch'
+    );
+    expect(batchCall).toBeDefined();
+    const payload = batchCall![0] as {
+      totalCount: number;
+      loggedCount: number;
+      omittedCount: number;
+      pathPrefixes: Array<{ path: string; count: number }>;
+    };
+    expect(payload.totalCount).toBeGreaterThan(50);
+    expect(payload.loggedCount).toBe(50);
+    expect(payload.pathPrefixes.length).toBeGreaterThan(0);
+    // pathPrefixes は array index を `[*]` に正規化済 (PR #144 規律継承)
+    expect(payload.pathPrefixes[0].path).toBe('bulk[*]');
+  });
+
+  it('AC-12: collection-overflow と image-omitted の cross-event independence (別 histogram / 別 counter)', () => {
+    // image-omitted (large dataURI × 多数) と collection-overflow (大量 raw string array) を同時発火
+    const bigImage = `data:image/png;base64,${'A'.repeat(600)}`;
+    const data = {
+      images: Array.from({ length: 60 }, () => bigImage), // image-omitted のみ発火 (marker 後 cumulative 小)
+      bulk: Array.from({ length: 300 }, () => buildElementOfBytes(1000)), // collection-overflow も発火
+    };
+    stripPromptHeavyFields(data);
+    const imageBatch = warnSpy.mock.calls.find(
+      (c) => (c[0] as { safetyEvent?: string }).safetyEvent === 'image-omitted-batch'
+    );
+    const collectionBatch = warnSpy.mock.calls.find(
+      (c) => (c[0] as { safetyEvent?: string }).safetyEvent === 'collection-overflow-batch'
+    );
+    expect(imageBatch).toBeDefined();
+    expect(collectionBatch).toBeDefined();
+    // 別 histogram: image-omitted-batch.pathPrefixes は `images[*]`、collection-overflow-batch.pathPrefixes は `bulk[*]`
+    const imagePaths = (imageBatch![0] as { pathPrefixes: Array<{ path: string }> }).pathPrefixes.map((p) => p.path);
+    const collectionPaths = (collectionBatch![0] as { pathPrefixes: Array<{ path: string }> }).pathPrefixes.map(
+      (p) => p.path
+    );
+    expect(imagePaths).toContain('images[*]');
+    expect(collectionPaths).toContain('bulk[*]');
+    expect(imagePaths).not.toContain('bulk[*]');
+    expect(collectionPaths).not.toContain('images[*]');
+  });
+
+  it('AC-13 defensive: [undefined, ...] 含む array でも throw せず処理完了 (undefined は estimateElementBytes で "null" 相当 4 byte)', () => {
+    const data = {
+      mixed: [undefined, 'a'.repeat(2000), undefined, undefined],
+    };
+    expect(() => stripPromptHeavyFields(data)).not.toThrow();
+    const out = stripPromptHeavyFields(data) as { mixed: Array<string | undefined | null> };
+    expect(out.mixed).toHaveLength(4);
+    // undefined は保持される (JSON.stringify は undefined を返すが配列で書くと null になる規律は今回は適用外、
+    // recurse が undefined を素通す)
+    expect(out.mixed[1]).toBe('a'.repeat(2000));
+  });
+
+  it('AC-14 defensive: [BigInt, ...] 含む array でも throw せず処理完了 (BigInt は try-catch fallback で 4 byte 扱い)', () => {
+    const data = {
+      mixed: [1n, 'a'.repeat(2000), 2n],
+    };
+    expect(() => stripPromptHeavyFields(data)).not.toThrow();
+    const out = stripPromptHeavyFields(data) as { mixed: unknown[] };
+    expect(out.mixed).toHaveLength(3);
+    expect(out.mixed[1]).toBe('a'.repeat(2000));
   });
 });

--- a/server/utils/promptSafety.test.ts
+++ b/server/utils/promptSafety.test.ts
@@ -504,13 +504,13 @@ describe('observability (silent fail paired signal)', () => {
       (Buffer as any).byteLength = originalByteLength;
     }
 
-    // 旧 eager 設計 (PR #140 以前): 100 leaf × 2 回 = 200 回
-    // 新 lazy 設計 (PR #140): 100 leaf × 1 回 (isImageDataUri) + 50 leaf × 1 回 (tick builder) = 150 回
-    // PR #145 (Issue #137 #2 collection-level guard): + 100 leaf × 1 回 (estimateElementBytes 経由) = 250 回
-    // lazy 化の本質 (threshold 超後の tick builder skip) は維持されているため、350 未満であれば
-    // 退行していない。collection-overflow guard は array recurse 内の独立計算で、別 baseline を持つ。
-    expect(byteLengthCalls).toBeLessThan(350);
-    expect(byteLengthCalls).toBeGreaterThanOrEqual(250);
+    // 意図ベースの pin (review I-3): 「lazy 化の本質 = threshold 超後の tick builder skip」と
+    // 「2 桁の amplification 退行を block」のみを assert する。具体値は推移するため幅広めに取る。
+    // - 下限 100: 各 leaf の isImageDataUri 必須計算が 100 件確定走る
+    // - 上限 500: 旧 eager amplification (~200) を 2.5x 超える退行を block
+    // - 推移履歴 (参考): PR #140 lazy 化 ~150 → PR #145 collection-overflow ~250 → 将来 sanitize 関数追加で再増加可能性
+    expect(byteLengthCalls).toBeGreaterThanOrEqual(100);
+    expect(byteLengthCalls).toBeLessThan(500);
   });
 
   it('image and depth aggregators are independent (one event burst does not exhaust the other quota)', () => {
@@ -1293,7 +1293,10 @@ describe('stripPromptHeavyFields - collection-level guard (Issue #137 #2 残り)
     expect(payload.droppedIndex).toBe(200);
     expect(payload.maxCollectionBytes).toBe(200_000);
     expect(payload.keptCount).toBe(200);
-    expect(payload.cumulativeBytes).toBeGreaterThan(200_000);
+    // cumulativeBytes 具体値 pin (review I-2): 1002 byte/件 × 200 件 = 200,400 byte
+    // idx=199 を保持して cumulative=200,400 → idx=200 入口で 200,400 > 200,000 で fire。
+    // Cloud Logging 運用 dashboard の信頼性担保のため厳密値で固定。
+    expect(payload.cumulativeBytes).toBe(200_400);
   });
 
   it('AC-7: sibling array 独立 — {a: [overflow], b: [overflow]} は batch.pathPrefixes で各々観測', () => {
@@ -1344,6 +1347,18 @@ describe('stripPromptHeavyFields - collection-level guard (Issue #137 #2 残り)
     expect(out.name).toBe('Alice');
     expect(out.age).toBe(42);
     expect(out.profile.bio).toBe('a'.repeat(50_000));
+    const collectionFired = warnSpy.mock.calls.find(
+      (c) => (c[0] as { safetyEvent?: string }).safetyEvent === 'collection-overflow'
+    );
+    expect(collectionFired).toBeUndefined();
+  });
+
+  it('AC-9b: empty array [] は collection-overflow 不発火、changed=false で same reference (review I-1)', () => {
+    // for-loop が iteration 0 回で抜けるパスを pin。将来「length===0 で marker 返却」等の bug を block。
+    const inner: unknown[] = [];
+    const data = { list: inner };
+    const out = stripPromptHeavyFields(data) as typeof data;
+    expect(out.list).toBe(inner); // changed=false で same reference
     const collectionFired = warnSpy.mock.calls.find(
       (c) => (c[0] as { safetyEvent?: string }).safetyEvent === 'collection-overflow'
     );
@@ -1420,5 +1435,43 @@ describe('stripPromptHeavyFields - collection-level guard (Issue #137 #2 残り)
     const out = stripPromptHeavyFields(data) as { mixed: unknown[] };
     expect(out.mixed).toHaveLength(3);
     expect(out.mixed[1]).toBe('a'.repeat(2000));
+  });
+
+  it('AC-14b defensive: 循環参照を含む array element でも throw せず処理完了 (review C-1)', () => {
+    // 設計文書 §11 Risk row 7 で明示宣言済の defensive 要件。BigInt と並ぶ JSON.stringify throw
+    // パターンを test で hard-pin する。将来 estimateElementBytes の try-catch が「perf 改善」を
+    // 名目に shallow stringify 化されると、循環参照 input で 500 INTERNAL 量産になる regression を CI で block。
+    type CyclicNode = { name: string; self?: CyclicNode };
+    const cyclic: CyclicNode = { name: 'self-ref' };
+    cyclic.self = cyclic;
+    const data = { mixed: [cyclic, 'a'.repeat(2000)] };
+    expect(() => stripPromptHeavyFields(data)).not.toThrow();
+    const out = stripPromptHeavyFields(data) as { mixed: unknown[] };
+    expect(out.mixed).toHaveLength(2);
+  });
+
+  it('AC-15: collection-overflow aggregator も histogram-overflow paired signal を継承する (review I-4)', () => {
+    // MAX_HISTOGRAM_BUCKETS=256 超過時の (overflow) bucket + histogram-overflow paired warn は
+    // PR #144 で確立済の規律。aggregator factory 共通実装で本 PR の collection-overflow 経路も
+    // 対称適用されるはず。257 種類の sibling array を全部 overflow させて pin する。
+    const elem = buildElementOfBytes(1000);
+    const payload: Record<string, unknown> = {};
+    for (let i = 0; i < 257; i++) {
+      payload[`sib${i}`] = Array.from({ length: 250 }, () => elem);
+    }
+    stripPromptHeavyFields(payload);
+    const histogramOverflowCalls = warnSpy.mock.calls.filter(
+      (c) =>
+        (c[0] as { safetyEvent?: string }).safetyEvent === 'histogram-overflow' &&
+        (c[0] as { parentEvent?: string }).parentEvent === 'collection-overflow'
+    );
+    // 飽和は 1 度だけ発火 (paired signal 規律: overflowEmitted で gate される)
+    expect(histogramOverflowCalls).toHaveLength(1);
+    const overflowPayload = histogramOverflowCalls[0]![0] as {
+      maxBuckets: number;
+      parentEvent: string;
+    };
+    expect(overflowPayload.maxBuckets).toBe(256);
+    expect(overflowPayload.parentEvent).toBe('collection-overflow');
   });
 });

--- a/server/utils/promptSafety.ts
+++ b/server/utils/promptSafety.ts
@@ -100,6 +100,55 @@ const MAX_RECURSION_DEPTH = 1000;
 export const RECURSION_DEPTH_EXCEEDED_MARKER = '[recursion-depth-exceeded: nested data truncated to fit safety limit]';
 
 /**
+ * array 1 つあたりの累積 byte 上限 (Issue #137 #2 残り collection-level guard)。
+ *
+ * 背景: PR #138 で `MIN_IMAGE_DATA_URI_BYTES` を 100→500 に引き上げ、99B 弱 dataURI cumulative
+ * bypass 帯域を ~5x 縮小したが、≤499B dataURI を多数並べた累積 token-bomb (例 2000 件 × 80B
+ * dataURI で ~1MB / ~50K tokens) は leaf-level guard を素通しできる残課題があった。
+ *
+ * 200KB の根拠:
+ * - 通常 character.skills[] / world.lore[] の array は実用 ~50KB 以下、200KB は十分余裕
+ *   (false positive 実質ゼロ)
+ * - `MAX_FIELD_BYTES=100KB` (単一 leaf 上限) の 2x altitude で「単一 vs 集合」を区別
+ * - Gemini 131K context の ~1.5x 相当の ~50K tokens 目安をターゲット
+ * - ≥200KB の array は通常データで起きえない (~400 件の 499B dataURI 相当)
+ *
+ * Issue #134 register-or-forget 解消理念とは直交軸: leaf-level whitelist→content-based は
+ * 「leaf 検出の自動カバー」軸、本定数は「累積 byte の構造的制限」軸で、新フィールド追加でも
+ * 自動的にカバーされる (whitelist 不要)。
+ */
+const MAX_COLLECTION_BYTES = 200_000;
+
+/**
+ * 累積 byte 閾値到達後の array element 代替マーカー (Issue #137 #2 残り)。
+ *
+ * 閾値以下の element は image / non-image marker 化 (既存) を経由して保持される。閾値を超えた
+ * index 以降を本 marker で置換し「同じ array にまだ要素があった」事実だけ AI に伝える。
+ */
+export const COLLECTION_OVERFLOW_MARKER =
+  '[collection-overflow: subsequent items omitted to fit token budget]';
+
+/**
+ * processed element の byte 計測 (Issue #137 #2 残り、codex セカンドオピニオン High 1-2 解消)。
+ *
+ * JSON-safe ではない element (`undefined` / `function` / `symbol` / `BigInt` / 循環参照) で
+ * `Buffer.byteLength` が throw しないよう二重 defensive:
+ * - `JSON.stringify(value) ?? 'null'`: undefined / function / symbol で stringify が undefined を
+ *   返したら `'null'` 文字列 (4 byte) で代替
+ * - try-catch: BigInt や循環参照で stringify が throw する場合は 4 byte fallback で防御
+ *
+ * `processed element` = recurse 通過後の値 (image / non-image marker 化後の短文を含む) を想定。
+ * 「leaf-level marker 化済の element は cumulative 圧迫しない」を保証する。
+ */
+function estimateElementBytes(value: unknown): number {
+  try {
+    return Buffer.byteLength(JSON.stringify(value) ?? 'null', 'utf8');
+  } catch {
+    return 4; // 'null' 相当
+  }
+}
+
+/**
  * 単一 sanitize 関数呼出あたりの個別 warn ログ発火上限。これを超えると個別 warn を抑制し、
  * 関数末尾で集約 log 1 件 (`*-batch`) に切替える。
  *
@@ -429,6 +478,13 @@ export function stripPromptHeavyFields(data: unknown): unknown {
     'promptSafety: non-image dataURI stripped'
   );
   const depthAggregator = createDepthExceededAggregator();
+  // Issue #137 #2 残り: array 単位の累積 byte threshold 超過を集約。aggregator instance は
+  // stripPromptHeavyFields 呼出全体で 1 つ共有 (cumulative byte counter は array ごとに別
+  // closure 変数で管理するので干渉しない)。image / non-image / depth と並列 flush。
+  const collectionAggregator = createWarnAggregator(
+    'collection-overflow',
+    'promptSafety: collection-level cumulative byte threshold exceeded'
+  );
 
   function recurse(value: unknown, path: string, depth: number): unknown {
     if (depth > MAX_RECURSION_DEPTH) {
@@ -455,12 +511,45 @@ export function stripPromptHeavyFields(data: unknown): unknown {
       return value;
     }
     if (Array.isArray(value)) {
+      // Issue #137 #2 残り collection-level guard: 各 array で independent な cumulative byte
+      // counter を回し、`MAX_COLLECTION_BYTES` 超過後の index は recurse skip + marker 置換。
+      // sibling array は parent ループ側で別 closure 経由で独立に評価され、nested array (array
+      // of array) も内側 array が recurse 内でこのブロックに入り直すので cumulative は独立。
+      let cumulativeBytes = 0;
+      let keptCount = 0;
       let changed = false;
-      const next = value.map((item, idx) => {
-        const replaced = recurse(item, joinPath(path, idx), depth + 1);
-        if (replaced !== item) changed = true;
-        return replaced;
-      });
+      const next: unknown[] = [];
+      for (let idx = 0; idx < value.length; idx++) {
+        if (cumulativeBytes > MAX_COLLECTION_BYTES) {
+          // 閾値超: 当該 index 以降を marker 置換。recurse skip で perf も改善 (攻撃 payload 時こそ
+          // stringify 呼出が頭打ちになる)。lazy builder で payload 計算を threshold 内のみ実行。
+          const overflowIdx = idx;
+          const overflowPath = joinPath(path, overflowIdx);
+          const arrayLength = value.length;
+          const observedKeptCount = keptCount;
+          const observedCumulativeBytes = cumulativeBytes;
+          collectionAggregator.tick(
+            () => ({
+              path: overflowPath,
+              arrayLength,
+              cumulativeBytes: observedCumulativeBytes,
+              droppedIndex: overflowIdx,
+              maxCollectionBytes: MAX_COLLECTION_BYTES,
+              keptCount: observedKeptCount,
+            }),
+            overflowPath
+          );
+          next.push(COLLECTION_OVERFLOW_MARKER);
+          changed = true;
+          continue;
+        }
+        const replaced = recurse(value[idx], joinPath(path, idx), depth + 1);
+        next.push(replaced);
+        if (replaced !== value[idx]) changed = true;
+        // processed element の byte を加算 (marker 化された短文も計上、二重防御の補完)。
+        cumulativeBytes += estimateElementBytes(replaced);
+        keptCount++;
+      }
       return changed ? next : value;
     }
     if (value && typeof value === 'object') {
@@ -484,6 +573,7 @@ export function stripPromptHeavyFields(data: unknown): unknown {
   imageAggregator.flush();
   nonImageAggregator.flush();
   depthAggregator.flush();
+  collectionAggregator.flush();
   return result;
 }
 

--- a/server/utils/promptSafety.ts
+++ b/server/utils/promptSafety.ts
@@ -198,6 +198,7 @@ const PATH_PREFIX_TOP_N = 5;
  * property 名 (`url` / `caption` 等) は意味的に異なるため normalize 対象外で残す。
  *
  * 例: `gallery[0].url` → `gallery[*].url` / `gallery[1].caption` → `gallery[*].caption`
+ * 例: `items[200]` → `items[*]` (末尾 index で終わる path、collection-overflow 経路で発生)
  * 例: array index を含まない dot-path (`users.profile.avatar`) はそのまま `users.profile.avatar` で残る
  *     (dot-path 構造は意味情報として保持し、prefix 集約は array index 専用)。
  */
@@ -520,30 +521,33 @@ export function stripPromptHeavyFields(data: unknown): unknown {
       let changed = false;
       const next: unknown[] = [];
       for (let idx = 0; idx < value.length; idx++) {
+        // loop 先頭で path を 1 度算出し overflow / retention 両分岐で共有 (object recurse 経路と
+        // altitude 整合、joinPath の per-iter 重複呼出を排除)。
+        const itemPath = joinPath(path, idx);
         if (cumulativeBytes > MAX_COLLECTION_BYTES) {
           // 閾値超: 当該 index 以降を marker 置換。recurse skip で perf も改善 (攻撃 payload 時こそ
           // stringify 呼出が頭打ちになる)。lazy builder で payload 計算を threshold 内のみ実行。
-          const overflowIdx = idx;
-          const overflowPath = joinPath(path, overflowIdx);
-          const arrayLength = value.length;
+          // observedKeptCount / observedCumulativeBytes は規律継承の local snapshot (PR #143/#144、
+          // 将来 lazy builder が deferred 化された場合の stale value 防止)。idx / value.length は
+          // for-loop の per-iteration `let` binding で closure-safe のため snapshot 不要。
           const observedKeptCount = keptCount;
           const observedCumulativeBytes = cumulativeBytes;
           collectionAggregator.tick(
             () => ({
-              path: overflowPath,
-              arrayLength,
+              path: itemPath,
+              arrayLength: value.length,
               cumulativeBytes: observedCumulativeBytes,
-              droppedIndex: overflowIdx,
+              droppedIndex: idx,
               maxCollectionBytes: MAX_COLLECTION_BYTES,
               keptCount: observedKeptCount,
             }),
-            overflowPath
+            itemPath
           );
           next.push(COLLECTION_OVERFLOW_MARKER);
           changed = true;
           continue;
         }
-        const replaced = recurse(value[idx], joinPath(path, idx), depth + 1);
+        const replaced = recurse(value[idx], itemPath, depth + 1);
         next.push(replaced);
         if (replaced !== value[idx]) changed = true;
         // processed element の byte を加算 (marker 化された短文も計上、二重防御の補完)。


### PR DESCRIPTION
## Summary

- Issue #137 #2 残りの **collection-level guard** を実装。`stripPromptHeavyFields` の array recurse に array 1 つあたりの累積 byte 上限 (`MAX_COLLECTION_BYTES = 200_000`) を追加し、閾値超え index 以降を `COLLECTION_OVERFLOW_MARKER` で短絡置換
- `≤499B dataURI を多数並べた cumulative token-bomb` (例: 2000 件 × 80B dataURI ≈ 1MB/50K tokens) を **leaf-level guard 素通しのまま構造的に閉鎖**
- `estimateElementBytes` helper で BigInt / 循環参照 / undefined element の defensive coding (codex セカンドオピニオン High 1-2 解消)

設計文書: `docs/spec/promptSafety/2026-06-03-collection-level-guard-design.md`

## 設計判断 (codex セカンドオピニオン 11 件全件反映済)

| 軸 | 決定 | 根拠 |
|---|---|---|
| 閾値 | 200KB (`MAX_FIELD_BYTES=100KB` × 2x altitude) | 通常データの ~50KB array に十分余裕、~400 件の 499B dataURI 相当 |
| semantics | `cumulativeBytes > MAX_COLLECTION_BYTES` (閾値ちょうどは保持) | 設計文書 §5 prose / pseudo-code を正本採用 |
| defensive | `JSON.stringify(v) ?? 'null'` + try-catch | BigInt / 循環参照 / undefined element で throw しない |
| 適用範囲 | array 専用 (object は影響なし、AC-9 で pin) | register-or-forget と直交軸の防御 |
| aggregator スコープ | stripPromptHeavyFields 全体で 1 instance、cumulative counter は closure local | image/non-image/depth と並列 flush |

## 観測性 (PR #143/#144 規律継承)

- 新規 safetyEvent: `collection-overflow` (個別) / `collection-overflow-batch` (集約)
- batch payload: `totalCount` / `loggedCount` / `omittedCount` / `pathPrefixes` (top-5 histogram) / `truncatedBucketCount`
- 個別 warn payload: `path` / `arrayLength` / `cumulativeBytes` / `droppedIndex` / `maxCollectionBytes` / `keptCount`
- PR #144 の `MAX_HISTOGRAM_BUCKETS=256` / `(overflow)` bucket / `histogram-overflow` paired signal を自動継承

## AC 14 件 (`server/utils/promptSafety.test.ts` に追加)

| # | テスト | 焦点 |
|---|---|---|
| AC-1 | 199KB array → 全 element 保持 | 閾値内全保持の境界 |
| AC-2 | ~1MB array → 閾値超で marker | 攻撃 payload pin |
| AC-3a/3b | 200 件×999B / 250 件×1000B | 境界 semantics |
| AC-4 | nested object in array | per-element JSON.stringify 累積 |
| AC-5 | image dataURI と co-existence | marker 化済 element は cumulative 圧迫しない |
| AC-6 | warn payload 6 フィールド | path / arrayLength / cumulativeBytes / droppedIndex / maxCollectionBytes / keptCount |
| AC-7 | sibling array 独立 (batch.pathPrefixes 経由) | 個別 warn 50 件打ち止め後の観測規律 |
| AC-8 | nested array 内側 closure 独立 (外側 1 件構成) | 外側 array に counter が持ち越されない |
| AC-9 | non-array 影響なし | object/scalar 既存挙動維持 |
| AC-11 | batch event `collection-overflow-batch` + pathPrefixes | PR #144 継承 |
| AC-12 | image-omitted との cross-event independence | 別 histogram / 別 counter |
| AC-13 | `[undefined, ...]` defensive | throw せず処理完了 |
| AC-14 | `[1n, ...]` (BigInt) defensive | try-catch fallback で 4 byte 扱い |

## Test plan

- [x] `npm test` 616/616 PASS (前回 602 + 新規 14 件)
- [x] `npm run lint` clean (tsc --noEmit)
- [x] `/safe-refactor` HIGH/MEDIUM 0 件、LOW 1 件 (保持推奨で修正不要)
- [x] `/code-review low` `(none)` — runtime-correctness bug 検出ゼロ
- [ ] `/review-pr` 5 並列 (large tier 該当、type-design-analyzer 除外) — マージ前
- [ ] CI Success 確認
- [ ] dev デプロイ後 Cloud Logging で `safetyEvent: 'collection-overflow'` / `'collection-overflow-batch'` の発火確認 (実トラフィック発生時、本田様判断待ち)

## 設計文書の誤植訂正

設計文書 §8 AC-3 table の `201 件 × 1000B → 200 件保持` は §5 prose / pseudo-code と矛盾 (実装上は 201 件全保持、202 件目以降が marker)。本 PR の AC-3a/3b では prose を正本としてテストを書いた。handoff doc (`docs/handoff/2026-06-03f-...`) に記録済。

🤖 Generated with [Claude Code](https://claude.com/claude-code)