### PR TITLE
docs(handoff): LATEST.md を Issue #137 サブタスク 3 件完了に更新

### DIFF
--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -1,107 +1,87 @@
-# Handoff: promptSafety 構造化 — Issue #134/#137 part 1+α 5 PR 連続着地
+# Handoff: promptSafety 構造化 — Issue #137 サブタスク #1/#2残り/#5 完了 (PR #143/#144/#145)
 
-- Session Date: 2026-06-03 (2 セッション目)
+- Session Date: 2026-06-03 (3-4 セッション目通算)
 - Owner: yasushi-honda
-- Status: ✅ 再開可能 (main clean `ab45acd`、Cloud Run デプロイ全 PR success、Issue #137 のみ open で残課題明確化)
-- Previous handoff: [2026-06-03-prompt-safety-token-bomb-fix.md](./2026-06-03-prompt-safety-token-bomb-fix.md)
+- Status: ✅ 再開可能 (main clean `58f3c35`、PR #145 Cloud Run main デプロイ in_progress、Issue #137 のみ open でサブ残課題明確化)
+- Previous handoff: [2026-06-03b-prompt-safety-hardening.md](./2026-06-03b-prompt-safety-hardening.md) (2 セッション目までの 5 PR まとめ)
 
-## 今セッションのトリガー
+## 本セッション (3-4 セッション目) のトリガー
 
-前セッションで `Issue #134` (whitelist register-or-forget 解消、content-based dataURI 検出移行) を起票したまま終了。本田様から `次のアクション:優先順にすすめて` の指示で、緊急性 LOW の enhancement を順次解消する流れに着手。各 PR で `/code-review medium` を回し、見つかった correctness 残点を **同 PR 内で fix** + **PLAUSIBLE は Issue に追記** する反復で進めた。
+前セッション (2 セッション目) で `Issue #137` を起票し 4 サブ項目を残してハンドオフ。本田様から `次のアクション:優先順にすすめて` の指示で、緊急性 LOW の enhancement を順次解消。各 PR で `/code-review low` + 大規模時は `/review-pr` 5 並列 (type-design-analyzer 除外) を回し、見つかった correctness 残点・brittle test を **同 PR 内で fix** する反復で進めた。
 
-## 完了 PR (5 件、全 main マージ + Cloud Run デプロイ success)
+## 完了 PR (3 件、全 main マージ + Cloud Run デプロイ success)
 
 | PR | 内容 | 規模 | merge |
 |---|---|---|---|
-| #136 | fix: whitelist 廃止し content-based dataURI 検出に切替 (Closes #134) + code-review 同梱 (depth guard / prototype pollution skip / doc drift / test name drift) | 2 files, +268/-92 | `a5e649b` |
-| #138 | fix: MIN_IMAGE_DATA_URI_BYTES を 100 → 500 へ引き上げ + 境界値テスト 3 件 (Refs #137 #2) | 2 files, +46/-9 | `e09b897` |
-| #139 | fix: per-call warn aggregation で log amplification を抑制 + code-review 同梱 (depth-exceeded counter 化 + JSDoc 量的明示) (Refs #137 #3) | 2 files, +272/-25 | `25a87cb` |
-| #140 | refactor: createWarnAggregator factory 抽出 + code-review 同梱 (lazy builder eager regression 閉鎖) (Refs #137 #4) | 2 files, +177/-101 | `1b39351` |
-| #141 | refactor: factory altitude 補強 (a-d) + code-review 同梱 (eslint-disable / type export / JSDoc warning) (Refs #137 #4 残り) | 2 files, +149/-44 | `ab45acd` |
+| #143 | feat: 非画像 dataURI 検出層追加 + isImageDataUri を case insensitive 化 (Refs #137 #1) | 4 files, +641/-? | `9bca971` |
+| #144 | feat: batch log に pathPrefixes histogram を追加 + cardinality cap + paired signal (Refs #137 #5) | 3 files, +495/-? | `7f5e571` |
+| #145 | feat: array 単位の累積 byte threshold guard + defensive coding (Refs #137 #2) | 5 files, +986/-10 | `58f3c35` |
 
-合計: 11 files / +912/-271 行、テスト数 +26 件 (543 → 569)。
+合計: 12 files / +2122 行、テスト数 +50 件 (569 → 619)。
 
-## アーキテクチャ進化 (3 段階)
+## アーキテクチャ進化 (3 段階、Issue #134 register-or-forget 解消の継続)
 
-### PR #136 (whitelist → content-based)
+### PR #143 (非画像 dataURI 検出層)
 
-```ts
-// 旧 (PR #132/#133)
-const IMAGE_FIELD_PATHS = ['appearance.imageUrl', 'mapImageUrl'];  // register-or-forget リスク
-// 新 (PR #136)
-function isImageDataUri(value): boolean {
-  return value.startsWith('data:image/') && Buffer.byteLength(value, 'utf8') >= MIN_IMAGE_DATA_URI_BYTES;
-}
-```
+- `NON_IMAGE_DATA_URI_MARKER` 追加、`isNonImageDataUri(value)` で `data:` 始まり / `data:image/` 不始まり / `MIN_NON_IMAGE_DATA_URI_BYTES=500` 以上を検出
+- `isImageDataUri` を `normalizeForDataUriDetection(s) = s.trimStart().toLowerCase()` 経由で case insensitive 化 (RFC 2397 整合)
+- 判定順 image → non-image を `recurse` 内で固定
 
-任意 path の `data:image/` 始まり文字列 (100B 以上、後に PR #138 で 500B に引き上げ) を再帰スキャンで marker 化。新フィールド追加で自動カバー。同 PR で:
-- depth guard (V8 stack overflow DoS 防御)
-- prototype pollution skip (`__proto__` / `constructor` / `prototype` を再帰中に drop)
+### PR #144 (path histogram + cardinality cap + paired signal)
 
-### PR #138 + #139 (bypass 縮小 + log amplification 抑制)
+- batch log payload に `pathPrefixes` (top-5 path 分布) / `truncatedBucketCount` 追加
+- `MAX_HISTOGRAM_BUCKETS=256` で aggregator OOM 防御 (silent fail を paired signal 規律で構造的に閉鎖)
+- `(overflow)` bucket + `histogram-overflow` warn (per aggregator 1 度だけ、`parentEvent` 付き) で saturation を early-detection 通知
+- `ARRAY_INDEX_PATTERN` で `gallery[0].url` → `gallery[*].url` に normalize、`(no-path)` bucket で path 未渡し caller を観測可能化
 
-- MIN を 500B に引き上げ: 99B 弱 dataURI × N 個 array の cumulative token-bomb の bypass 帯域を 5x 押し上げ
-- per-call warn 集約 (`MAX_WARN_PER_CALL = 50`): attacker が 10k 件 dataURI を array に詰めても warn 発火を 50 件 + 集約 batch 1 件で打ち止め
-- 3 種類の safetyEvent 各々独立 counter: `image-omitted` / `oversized-truncated` / `recursion-depth-exceeded`
+### PR #145 (collection-level cumulative byte guard)
 
-### PR #140 + #141 (factory 抽出 + altitude 補強)
+- `MAX_COLLECTION_BYTES = 200_000` (private) + `COLLECTION_OVERFLOW_MARKER` (export) を追加
+- `stripPromptHeavyFields` array recurse に independent な cumulative byte counter (`> MAX_COLLECTION_BYTES` で閾値超、ちょうどは保持)
+- `estimateElementBytes(value)` helper で `JSON.stringify(v) ?? 'null'` + try-catch 二重 defensive (BigInt / 循環参照 / undefined / function / symbol で throw しない)
+- `collectionAggregator` を image/non-image/depth と並列に flush (codex セカンドオピニオン Medium 5 「flush 忘れ防止」)
+- sibling/nested array は closure local 変数で counter 独立 (AC-7/AC-8 で pin)
 
-```ts
-// callsite (各 sanitize 関数内):
-const imageAggregator = createWarnAggregator('image-omitted', 'promptSafety: image dataURI stripped');
-const depthAggregator = createDepthExceededAggregator();
-// ...
-imageAggregator.tick(() => ({ path, bytes: Buffer.byteLength(value, 'utf8') }));  // lazy builder
-// ...
-imageAggregator.flush();
-depthAggregator.flush();
-```
+## レビュー方式 (本セッションで強化)
 
-- factory 化で counter scaffolding ~16 行/aggregator → 2 行に圧縮
-- lazy builder (`tick(() => ({...}))`) で threshold 超後の `Buffer.byteLength` を skip (PR #140 で regression 検出 → 同 PR fix)
-- spread 順反転 + 型 narrow (`WarnAggregatorPayload = Record<string, unknown> & { message?: never; safetyEvent?: never }`) で payload shadowing 構造的閉鎖
-- batchEvent / batchMessage は `${event}-batch` / `promptSafety: ${event} warn amplification suppressed` で派生 (4-arg → 2-arg)
-- `createDepthExceededAggregator()` helper で literal 重複を集約
+- **PR #143**: brainstorm 2 回 (OQ → codex セカンドオピニオン) → impl-plan T1-T10 → /safe-refactor + /code-review low + /review-pr 6 並列
+- **PR #144**: 同パターン + lazy builder vs histogram trade-off の OQ 2 回目で軌道修正
+- **PR #145**: brainstorm + 設計文書 314 行 + codex セカンドオピニオン 11 件 (High 3 / Medium 3 / Low 5) 反映 → /review-pr 5 並列 (type-design-analyzer 除外) → Critical 1 + Important 7 を同 PR 反映
 
-## レビュー方式 (4 段階反復)
+5 review エージェント並列の指摘集約 → 同 PR fix の流れが安定。
 
-各 PR で:
-1. **実装** (TDD: RED → GREEN → REFACTOR)
-2. **`/code-review medium`** (7 angles × 6 candidates → 1-vote verify)
-3. **CONFIRMED は同 PR 同梱 fix** / **PLAUSIBLE は Issue 追記**
-4. **番号単位明示認可後マージ** (`PR #XXX マージ` / `gh pr merge XXX --squash --delete-branch を実行`)
+## Issue Net 変化 (本セッション通算)
 
-5 PR 全体で:
-- CONFIRMED 8 件 + PLAUSIBLE 7 件 + REFUTED 8 件 = 23 件 verify
-- 8 件 (CONFIRMED) を同 PR fix、7 件 (PLAUSIBLE) を Issue 追記、REFUTED 8 件は logger.ts safeWrite + body-parser cycle 防御 + test pin 等で排除
+- Close 数: 0 件 (Issue #137 は umbrella で残)
+- 起票数: 0 件
+- Net: **0 件**
 
-## Issue Net 変化
+**Net = 0 だが umbrella Issue サブ進捗で許容**:
+- Issue #137 のサブタスク #1 / #2 残り / #5 を **3 件完了** (コード上)
+- 残サブタスク: #6 (logger.warnSampled altitude、別 milestone) / #7 (Statsig counter、起票済) / #8 候補 (truncateOversizedStrings path 追跡)
+- Issue #137 全体 close は #6/#7/#8 決着後 (規律 D 継承: [`docs/handoff/2026-06-03e-...`](./2026-06-03e-collection-level-guard-design-handoff.md))
 
-- Close 数: 1 件 (#134)
-- 起票数: 1 件 (#137)
-- Net: 0 件
-
-**Net = 0 だが進捗ゼロではない**:
-- #137 は元々 3 サブ項目 (non-image gap / 99B bypass / log amplification) で起票
-- セッション中に **#3 完全完了** + **#2 部分完了** (MIN 500 引き上げ実施、collection-level guard は残) + **#4 完全完了 (a-d 4 サブ項目)** + サブ項目 2 件追記 (#5 path histogram / #6 logger 持ち上げ)
-- 実質的には 5 件 close 相当 + 2 件追記 = net -3 件分の進捗
+CLAUDE.md GitHub Issues 規律「Net ≤ 0 は進捗ゼロ扱い」だが、umbrella Issue 内のサブ進捗としては前回 handoff と同じ判断 (PR #143/#144 と整合)。
 
 ## Issue #137 残課題 (active、open 維持)
 
-| サブ項目 | 内容 | 緊急性 |
+| サブ項目 | 内容 | 状態 |
 |---|---|---|
-| #137 #1 | non-image dataURI gap (PDF/audio 100B-100KB 帯素通し) | LOW、設計議論含む |
-| #137 #2 残り | collection-level guard (array 合計 byte 閾値超で early summarize) | LOW |
-| #137 #5 | batch log path 喪失、pathPrefixes histogram | LOW、enhancement |
-| #137 #6 | logger.ts altitude (logger.warnSampled future work) | LOW、別 milestone |
+| #137 #1 | non-image dataURI gap | ✅ PR #143 完了 |
+| #137 #2 残り | collection-level guard | ✅ PR #145 完了 |
+| #137 #5 | pathPrefixes histogram | ✅ PR #144 完了 |
+| #137 #6 | logger.warnSampled altitude | ⏸ 別 milestone (未着手) |
+| #137 #7 | Statsig/metric counter | ⏸ 起票済、未着手 |
+| #137 #8 候補 | `truncateOversizedStrings` の path 追跡 | ⏸ `(no-path)` bucket 経由で観測可能化済、本格 path 追跡は別 enhancement |
 
-すべて緊急性 LOW、size guard backstop が効いている現状で実害なし。
+完了 = 4/7 (#3 含む前セッション完了分)、未着手 = 3/7。緊急性 LOW、size guard / collection guard / paired signal 全て backstop が機能。
 
-## 本田様判断待ち / 外部依存
+## 本田様判断待ち / 外部依存 (継続、AI 側でできることなし)
 
 | 項目 | 状態 |
 |---|---|
-| Cloud Logging で `safetyEvent: image-omitted` / `*-batch` / `recursion-depth-exceeded` 発火確認 | 5 PR Test plan の残項目、dev デプロイ後の手動 grep |
+| Cloud Logging で `safetyEvent: 'image-omitted'` / `'non-image-data-uri-omitted'` / `'collection-overflow'` / `*-batch` / `'recursion-depth-exceeded'` / `'histogram-overflow'` の実トラフィック発火確認 | dev デプロイ後の手動 grep |
+| `pathPrefixes` / `truncatedBucketCount` histogram の payload 観察 (PR #144) | 同上 |
 | モバイル実機確認 (PR #128-#130 のレスポンシブ修正) | 前 handoff からの継続課題 |
 | 法務確認 (顧問弁護士 → public/legal/*.md 文言確定、M7-β) | 外部依存 |
 | #125 多ターン E2E (「それで」継続 + intent 引き継ぎの実トラフィック実証) | 外部依存 |
@@ -110,35 +90,36 @@ depthAggregator.flush();
 
 | PR | 件数 |
 |---|---|
-| セッション開始時 | 543 |
-| PR #136 後 | 552 (+9: content-based / depth guard / proto pollution) |
-| PR #138 後 | 555 (+3: 境界値 499/500/501) |
-| PR #139 後 | 560 (+5: per-call 集約 + boundary) |
-| PR #140 後 | 564 (+4: lazy builder regression pin + cross-event independence) |
-| PR #141 後 | 569 (+5: factory unit test) |
+| セッション開始時 (前 handoff b- 終了時) | 569 |
+| PR #143 後 | 583 (+14: 非画像 dataURI / case insensitive / cross-event) |
+| PR #144 後 | 602 (+19: pathPrefixes / cardinality cap / overflow bucket / paired signal) |
+| PR #145 後 | 619 (+17: AC-1〜15 + AC-9b/14b 含む、循環参照 / empty array / histogram-overflow × collection 等) |
 
-`backupSlice.test.ts T5` は flaky で本セッションの変更とは無関係 (単独実行で常時 PASS)。
+## 学び (本セッション 3 PR + 設計文書 1 件)
 
-## 学び (本セッション)
-
-1. **`/code-review medium` を 5 PR 連続適用したパターン**: 各 PR で「実装 + code-review + 同梱 fix」を 1 ループにすると、findings の同 PR 内 fix で diff が小さい状態を維持できる
-2. **Issue 1 件に複数サブ項目をまとめる運用**: code-review の PLAUSIBLE 提案を Issue サブ項目として追記し、Net 0 を維持しつつ実質的な進捗を確保
-3. **CONFIRMED と PLAUSIBLE の処理分離**: CONFIRMED (機械的検証可能) は同 PR で fix、PLAUSIBLE (将来 risk / latent) は Issue で扱う、という分離が 5 PR を通じて一貫して機能
-4. **factory altitude 補強の段階**: PR #140 で factory 抽出 → PR #141 で API stability 補強 (export, JSDoc, runtime/compile-time 二重防御) という 2 段階で altitude を上げる進化パターン
-5. **lazy builder pattern**: `tick(() => ({...}))` で hot path の threshold 超後評価を skip する設計。code-review で eager evaluation regression を pin する spy ベース test で固定
+1. **brainstorm Phase 中の OQ 追加で軌道修正可能**: PR #144 の lazy builder vs histogram の trade-off 落とし穴を OQ 2 回目で吸収
+2. **codex セカンドオピニオン (plan モード)** は brainstorm Phase 6 直前が最適。PR #145 は 11 件指摘を全件反映してから設計文書化
+3. **/review-pr 5 並列 → 同 PR fix の context 消費**: PR #143/#144/#145 ともに 30-40K tokens 消費。Phase 9 着手前のセッションは ctx 余裕 (50% 以上) を確保
+4. **設計文書の prose vs AC table 誤植**: PR #145 で AC-3 table (`201 件 × 1000B → 200 件保持`) が pseudo-code (`>` 演算子) と矛盾を発見。TDD で実機検証 → prose を正本として table を訂正、handoff doc に記録
+5. **paired signal 規律の橫展開**: PR #144 の histogram-overflow paired signal が aggregator factory 共通実装で PR #145 の collection-overflow にも自動継承 (AC-15 で pin)
+6. **defensive coding の 2 層化**: `JSON.stringify(v) ?? 'null'` + try-catch で undefined/function/symbol vs BigInt/循環参照/throwing toJSON の 5 失敗パターンを構造的に潰す。AC-13/14/14b で pin
 
 ## 規範遵守確認
 
-- ✅ main 直 push なし (5 PR すべて feature ブランチ + PR 経由)
-- ✅ PR マージはすべて番号単位明示認可後 (`PR #XXX マージ` / `gh pr merge XXX --squash --delete-branch を実行`)
-- ✅ 同セッションで 5 PR 連続マージしたが、code-review medium の効果検証として正当性あり
-- ✅ Issue Net 0 だが内容実質進捗 +3 件分を明示
-- ✅ ドキュメント整合性: CLAUDE.md / docs/handoff / Issue で promptSafety 関連の記述ズレなし
+- ✅ main 直 push なし (3 PR すべて feature ブランチ + PR 経由)
+- ✅ PR マージは番号単位明示認可後 (`PR #145 をマージしてよい` 受領 → squash merge)
+- ✅ review-pr 5 並列の Critical/Important 指摘を同 PR 内で全件反映
+- ✅ Issue Net 0 だが umbrella サブタスク 3 件完了で実質進捗あり (前 handoff 規律 D 継承)
+- ✅ ドキュメント整合性: CLAUDE.md / docs/handoff / 設計文書 / Issue で promptSafety 関連の記述ズレなし
+- ✅ 残留 Node プロセスなし
 
 ## 次セッション再開ガイド
 
-最優先で考慮すべき残課題は **Issue #137 #1 (non-image dataURI gap)**。設計議論を含む (MAX_FIELD_BYTES 引き下げ vs 非画像 marker 追加層 vs FE 側サニタイズ) ため `/brainstorm` 先行が妥当。
+`/catchup` で `Issue #137` のみ active、本田様判断待ち 5 件 (Cloud Logging 6 種類 / モバイル / 法務 / E2E / pathPrefixes 観察) で再開可能。
 
-他 3 件 (#2 残り / #5 / #6) は緊急性 LOW で size guard backstop あり、本田様の優先順位判断に委ねる状態。
+優先度の高い未着手サブタスクは:
+- **Issue #137 #6** logger.warnSampled altitude — 別 milestone (未着手、ROI 評価で延期判断)
+- **Issue #137 #7** Statsig/metric counter — 起票済 (Issue #137 コメント参照)
+- **Issue #137 #8 候補** `truncateOversizedStrings` の path 追跡 — `(no-path)` bucket 経由で観測可能化済、本格対応は緊急性 LOW
 
-`/catchup` で `Issue #137` のみ active、本田様判断待ち 4 件 (Cloud Logging / モバイル / 法務 / E2E) で再開可能。
+すべて緊急性 LOW で本田様の優先順位判断に委ねる状態。`/catchup` 後に「優先順にすすめて」指示があれば #6/#7/#8 のいずれかから brainstorm or codex セカンドオピニオン先行が妥当。


### PR DESCRIPTION
## Summary

- 本セッション (3-4 セッション目) で PR #143/#144/#145 を merge 完了 (Issue #137 のサブタスク #1/#2残り/#5)
- LATEST.md を前セッション (2 セッション目、b- 5 PR 連続着地) の内容から本セッション最新状態に書き換え
- テスト推移 569 → 619 (+50)、サブタスク完了 4/7
- ドキュメント変更のみ (`docs/handoff/LATEST.md` 1 ファイル、+90/-109)

## Test plan

- [x] handoff doc は構文検証 (markdown render) のみ、コード影響なし
- [ ] 次セッション開始時に `/catchup` でロード正常確認