### PR TITLE
fix(prompt-safety): histogram-overflow warn に firstOverflowPath 追加 (Refs #149 残-C)

### DIFF
--- a/docs/runbook/cloud-logging-safety-event-metrics.md
+++ b/docs/runbook/cloud-logging-safety-event-metrics.md
@@ -235,8 +235,18 @@ alert 発火時に何を確認するか。
 |---|---|
 | **症状** | aggregator が cardinality cap (256 bucket) を超過 |
 | **原因候補** | (a) path が大量に異種混在 (unique 1000+ leaf) / (b) `(no-path)` bucket への大量集約 / (c) bug で path が generate されている |
-| **確認手順** | §4 query で `parentEvent` field を確認 → どの個別 event 由来かを特定 → batch log の `pathPrefixes` を見る |
+| **確認手順** | §4 query で `parentEvent` field を確認 → どの個別 event 由来かを特定 → batch log の `pathPrefixes` を見る → **`firstOverflowPath` field で飽和を引き起こした path family を特定** (Issue #149 残-C で追加) |
 | **対処** | path 多様性が正当なら `MAX_HISTOGRAM_BUCKETS` 引き上げ検討、bug なら通常修正 |
+
+#### firstOverflowPath grep query 例
+
+```
+resource.type="cloud_run_revision"
+jsonPayload.safetyEvent="histogram-overflow"
+jsonPayload.firstOverflowPath:*
+```
+
+`firstOverflowPath` は 257 個目以降の unique path のうち最初に到達したもの (例: `appearance.gallery[*].metadata.attacker-key-xxx.url`)。これにより 51 件目以降が `(overflow)` bucket に集約されても、攻撃 payload の path 構造を再現可能。
 
 ### 6.2 image-omitted surge (1 分 > 100 件)
 

--- a/docs/runbook/cloud-logging-safety-event-metrics.md
+++ b/docs/runbook/cloud-logging-safety-event-metrics.md
@@ -235,7 +235,7 @@ alert 発火時に何を確認するか。
 |---|---|
 | **症状** | aggregator が cardinality cap (256 bucket) を超過 |
 | **原因候補** | (a) path が大量に異種混在 (unique 1000+ leaf) / (b) `(no-path)` bucket への大量集約 / (c) bug で path が generate されている |
-| **確認手順** | §4 query で `parentEvent` field を確認 → どの個別 event 由来かを特定 → batch log の `pathPrefixes` を見る → **`firstOverflowPath` field で飽和を引き起こした path family を特定** (Issue #149 残-C で追加) |
+| **確認手順** | §4 query で `parentEvent` field を確認 → どの個別 event 由来かを特定 → batch log の `pathPrefixes` を見る → **`firstOverflowPath` field で飽和を引き起こした path family を特定** |
 | **対処** | path 多様性が正当なら `MAX_HISTOGRAM_BUCKETS` 引き上げ検討、bug なら通常修正 |
 
 #### firstOverflowPath grep query 例
@@ -246,7 +246,15 @@ jsonPayload.safetyEvent="histogram-overflow"
 jsonPayload.firstOverflowPath:*
 ```
 
-`firstOverflowPath` は 257 個目以降の unique path のうち最初に到達したもの (例: `appearance.gallery[*].metadata.attacker-key-xxx.url`)。これにより 51 件目以降が `(overflow)` bucket に集約されても、攻撃 payload の path 構造を再現可能。
+`firstOverflowPath` は 257 個目 (`MAX_HISTOGRAM_BUCKETS=256` 超過分) の unique path のうち最初に到達したもの (例: `appearance.gallery[*].metadata.<dynamic-key>.url` — 攻撃 payload の場合も、ユーザーが大量の動的 metadata key を含めた正当ケースも同じ形)。
+
+**完全な path family 特定には組み合わせ運用**:
+- `firstOverflowPath` (本 field): saturate 起点の 1 path
+- `*-batch` log の `pathPrefixes` (top-5 path 分布、PR #144 追加)
+- `*-batch` log の `truncatedBucketCount` (overflow 集約された総 path 数)
+- 個別 warn の先頭 50 件 (`MAX_WARN_PER_CALL=50` 上限)
+
+の 4 種類を組み合わせることで、257 個目以降が `(overflow)` bucket に集約されても、攻撃 payload / 大量入力の path 構造を再現可能。
 
 ### 6.2 image-omitted surge (1 分 > 100 件)
 

--- a/server/utils/promptSafety.test.ts
+++ b/server/utils/promptSafety.test.ts
@@ -1132,8 +1132,14 @@ describe('createWarnAggregator path histogram (Issue #137 #5)', () => {
     // payload に含まれることを pin。MAX_HISTOGRAM_BUCKETS=256 を超えた最初の path が
     // 含まれていれば、attack payload の path family を Cloud Logging から特定可能。
     expect(depthOverflows[0][0]).toHaveProperty('firstOverflowPath');
-    expect(typeof (depthOverflows[0][0] as { firstOverflowPath?: unknown }).firstOverflowPath).toBe('string');
-    expect((depthOverflows[0][0] as { firstOverflowPath: string }).firstOverflowPath.length).toBeGreaterThan(0);
+    const firstOverflowPath = (depthOverflows[0][0] as { firstOverflowPath: string }).firstOverflowPath;
+    expect(typeof firstOverflowPath).toBe('string');
+    expect(firstOverflowPath.length).toBeGreaterThan(0);
+    // review-pr pr-test-analyzer Rating 7: length > 0 だけだと `(no-path)` / `(overflow)`
+    // sentinel が偶然 emit された場合に silent regression を素通す。実 path が露出して
+    // いることを pin する (forensic 価値の本質: attack payload の path 構造復元可能性)。
+    expect(firstOverflowPath).not.toBe('(no-path)');
+    expect(firstOverflowPath).not.toBe('(overflow)');
 
     // batch payload に (overflow) bucket が含まれる (top-5 の中、または truncated 外に集約)
     const batchCall = warnSpy.mock.calls.find(

--- a/server/utils/promptSafety.test.ts
+++ b/server/utils/promptSafety.test.ts
@@ -1128,6 +1128,12 @@ describe('createWarnAggregator path histogram (Issue #137 #5)', () => {
       parentEvent: 'recursion-depth-exceeded',
       maxBuckets: 256,
     });
+    // Issue #149 残-C: 飽和を引き起こした path (firstOverflowPath) が forensic 情報として
+    // payload に含まれることを pin。MAX_HISTOGRAM_BUCKETS=256 を超えた最初の path が
+    // 含まれていれば、attack payload の path family を Cloud Logging から特定可能。
+    expect(depthOverflows[0][0]).toHaveProperty('firstOverflowPath');
+    expect(typeof (depthOverflows[0][0] as { firstOverflowPath?: unknown }).firstOverflowPath).toBe('string');
+    expect((depthOverflows[0][0] as { firstOverflowPath: string }).firstOverflowPath.length).toBeGreaterThan(0);
 
     // batch payload に (overflow) bucket が含まれる (top-5 の中、または truncated 外に集約)
     const batchCall = warnSpy.mock.calls.find(

--- a/server/utils/promptSafety.ts
+++ b/server/utils/promptSafety.ts
@@ -414,12 +414,17 @@ export function createWarnAggregator(individualEvent: SafetyEventName, individua
       pathHistogram.set(bucket, (pathHistogram.get(bucket) ?? 0) + 1);
       if (bucket === OVERFLOW_BUCKET && !overflowEmitted) {
         // paired early-detection signal (silent_fail_paired_signal): 飽和を 1 度だけ通知。
+        // firstOverflowPath は飽和を引き起こした最初の path を含む (review-pr
+        // silent-failure-hunter Medium #4 / Issue #149 残-C 反映)。
+        // 51 件目以降は (overflow) bucket に集約されるため、attack payload が
+        // どの path family を狙ったかを forensic に追跡可能にする。
         overflowEmitted = true;
         logger.warn({
           message: 'promptSafety: path histogram saturation — new buckets aggregated into (overflow)',
           safetyEvent: SAFETY_EVENTS.HISTOGRAM_OVERFLOW,
           parentEvent: individualEvent,
           maxBuckets: MAX_HISTOGRAM_BUCKETS,
+          firstOverflowPath: desired,
         });
       }
       if (loggedCount < MAX_WARN_PER_CALL) {

--- a/server/utils/promptSafety.ts
+++ b/server/utils/promptSafety.ts
@@ -414,10 +414,11 @@ export function createWarnAggregator(individualEvent: SafetyEventName, individua
       pathHistogram.set(bucket, (pathHistogram.get(bucket) ?? 0) + 1);
       if (bucket === OVERFLOW_BUCKET && !overflowEmitted) {
         // paired early-detection signal (silent_fail_paired_signal): 飽和を 1 度だけ通知。
-        // firstOverflowPath は飽和を引き起こした最初の path を含む (review-pr
-        // silent-failure-hunter Medium #4 / Issue #149 残-C 反映)。
-        // 51 件目以降は (overflow) bucket に集約されるため、attack payload が
-        // どの path family を狙ったかを forensic に追跡可能にする。
+        // firstOverflowPath は飽和を引き起こした最初の path を含む (Issue #149 残-C)。
+        // 257 個目以降 (MAX_HISTOGRAM_BUCKETS=256 超過分) は (overflow) bucket に集約
+        // されるため、attack payload がどの path family を狙ったかを forensic に追跡
+        // 可能にする。完全な path family 特定には *-batch の pathPrefixes (top-5) +
+        // truncatedBucketCount との combination が必要。
         overflowEmitted = true;
         logger.warn({
           message: 'promptSafety: path histogram saturation — new buckets aggregated into (overflow)',


### PR DESCRIPTION
## Summary

- PR #148 review-pr silent-failure-hunter agent Medium #4 / Issue #149 残-C 解消
- `histogram-overflow` warn payload に飽和を引き起こした path (`firstOverflowPath`) を追加し、PR #144 で塞いだ forensic 経路の残 gap (51 件目以降の path 情報消失) を構造的に閉じる
- 1 行 fix + test 3 assertion + runbook 1 段落、最小リスク

## 変更ファイル (3 files, +22/-1)

| ファイル | 規模 | 内容 |
|---|---|---|
| `server/utils/promptSafety.ts` | +6/-1 | warn payload に `firstOverflowPath: desired` + JSDoc 補強 |
| `server/utils/promptSafety.test.ts` | +6/-0 | 既存 AC-10 test に `firstOverflowPath` 存在 + 文字列型 + 非空 の 3 assertion 追加 |
| `docs/runbook/cloud-logging-safety-event-metrics.md` | +10/-0 | §6.1 トリアージ「確認手順」に firstOverflowPath 経路追加 + 独立 grep query 例 |

## Test plan

- [x] 635 tests PASS (`npm run test`、件数不変、既存 AC-10 test 内に assertion 追加)
- [x] tsc --noEmit エラーゼロ (`npm run lint`)
- [x] 既存 histogram-overflow paired signal 規律 (per-aggregator 1 回 emit) を維持
- [x] runbook §6.1 grep query 例の syntax 確認 (Cloud Logging filter 仕様準拠)
- [ ] **本田様運用**: Cloud Logging 実トラフィックで `firstOverflowPath` field が観測される (Issue #149 残課題完了後)

## Issue #149 進捗

| 残課題 | 状態 | 備考 |
|---|---|---|
| 残-A: dry-run gcloud paired signal | ⏸ 別 PR | 中規模 (~50 行)、設計判断含む |
| 残-B: estimateElementBytes silent fallback | ⏸ 別 PR | 新規 safetyEvent 追加必要、4 ファイル同時更新 |
| 残-C: histogram-overflow path | ✅ 本 PR | 1 行 fix で完結 |

残-A/B は本田様の優先順位判断後に着手予定。本 PR merge 後の Issue #149 は残 2/3 件。

🤖 Generated with [Claude Code](https://claude.com/claude-code)