### PR TITLE
feat(prompt-safety): bytes-estimation-failed paired signal (7 件目 safetyEvent、Closes #149)

### DIFF
--- a/docs/runbook/cloud-logging-safety-event-metrics.md
+++ b/docs/runbook/cloud-logging-safety-event-metrics.md
@@ -5,13 +5,13 @@
 - **関連 script**: [`scripts/setup-safety-event-metrics.sh`](../../scripts/setup-safety-event-metrics.sh)
 - **関連 enum**: [`server/utils/promptSafetyEvents.ts`](../../server/utils/promptSafetyEvents.ts)
 
-`server/utils/promptSafety.ts` が emit する 6 種類の `safetyEvent` を Cloud Logging log-based metric と Cloud Monitoring alert policy で観測可能化する手順書。
+`server/utils/promptSafety.ts` が emit する 7 種類の `safetyEvent` を Cloud Logging log-based metric と Cloud Monitoring alert policy で観測可能化する手順書。
 
 ---
 
 ## 1. 概要 + 前提条件
 
-### 観測対象 6 metric
+### 観測対象 7 metric
 
 | safetyEvent | metric 名 | 意味 |
 |---|---|---|
@@ -21,6 +21,7 @@
 | `recursion-depth-exceeded` | `prompt_safety_recursion_depth_exceeded_count` | 再帰深度 (1000) を超過した件数 |
 | `collection-overflow` | `prompt_safety_collection_overflow_count` | array 累積 byte (200KB) を超過した件数 |
 | `histogram-overflow` | `prompt_safety_histogram_overflow_count` | path histogram の cardinality (256 bucket) を超過した件数 (paired signal) |
+| `bytes-estimation-failed` | `prompt_safety_bytes_estimation_failed_count` | JSON.stringify failure (BigInt / 循環参照 / Proxy throw) で 4 bytes fallback した件数 (paired signal) |
 
 各 metric は **個別 warn** (`safetyEvent: 'image-omitted'`) と **batch warn** (`safetyEvent: 'image-omitted-batch'`) を **1 metric に合算**する。filter regex: `jsonPayload.safetyEvent=~"^<event>(-batch)?$"`
 
@@ -70,7 +71,7 @@ jsonPayload.totalCount>1000
 # 1. dry-run で適用予定を確認 (副作用ゼロ)
 ./scripts/setup-safety-event-metrics.sh --project novel-writer-dev --dry-run
 
-# 2. 出力で 6 metric scaffold + 6 alert scaffold を確認
+# 2. 出力で 7 metric scaffold + 7 alert scaffold を確認
 
 # 3. 本適用
 ./scripts/setup-safety-event-metrics.sh --project novel-writer-dev
@@ -91,11 +92,11 @@ jsonPayload.totalCount>1000
 
 ### 2.3 confirm: 作成した metric を Console で確認
 
-[https://console.cloud.google.com/logs/metrics](https://console.cloud.google.com/logs/metrics) → project 切替 → 6 件の `prompt_safety_*_count` を確認。
+[https://console.cloud.google.com/logs/metrics](https://console.cloud.google.com/logs/metrics) → project 切替 → 7 件の `prompt_safety_*_count` を確認。
 
 ---
 
-## 3. 6 metric の意味 (個別解説)
+## 3. 7 metric の意味 (個別解説)
 
 各 metric の「正常時に出る/出ない」「異常境界」を一覧化。
 
@@ -135,6 +136,12 @@ jsonPayload.totalCount>1000
 - **正常時**: 0 件のはず (`MAX_HISTOGRAM_BUCKETS=256` は通常運用では到達しない)
 - **異常境界**: **発火即異常**。aggregator OOM 防御の早期検知シグナル
 
+### 3.7 `prompt_safety_bytes_estimation_failed_count` (paired signal)
+
+- **何を捕まえる**: `estimateElementBytes` 内 `JSON.stringify` failure (BigInt / 循環参照 / Proxy throwing `get` / throwing `toJSON`) で 4 bytes fallback した件数
+- **正常時**: 0 件のはず (通常データは JSON-safe)
+- **異常境界**: 1 分間に 1 件超 → 攻撃的 payload (token-bomb 試行) or データ破損 (循環参照) or 外部 API 経由 BigInt 流入の疑い
+
 ---
 
 ## 4. 通常運用での Cloud Logging grep query 集
@@ -145,7 +152,7 @@ Cloud Logging Console ([https://console.cloud.google.com/logs](https://console.c
 
 ```
 resource.type="cloud_run_revision"
-jsonPayload.safetyEvent=~"^(image-omitted|non-image-data-uri-omitted|oversized-truncated|recursion-depth-exceeded|collection-overflow|histogram-overflow)(-batch)?$"
+jsonPayload.safetyEvent=~"^(image-omitted|non-image-data-uri-omitted|oversized-truncated|recursion-depth-exceeded|collection-overflow|histogram-overflow|bytes-estimation-failed)(-batch)?$"
 ```
 
 ### 4.2 特定 event だけを見る (例: histogram-overflow)
@@ -184,7 +191,7 @@ jsonPayload.path=~"^appearance\."
 
 ### ⚠ script の振る舞い (重要)
 
-`setup-safety-event-metrics.sh` は **log-based metric (6 件) を実際に gcloud で create/update する**が、**alert policy は scaffold (stdout 出力のみ) であり、実際に作成しない**。これは notification channel ID が環境依存 (本田様 email / Slack 等) で script に hardcoded できないため。
+`setup-safety-event-metrics.sh` は **log-based metric (7 件) を実際に gcloud で create/update する**が、**alert policy は scaffold (stdout 出力のみ) であり、実際に作成しない**。これは notification channel ID が環境依存 (本田様 email / Slack 等) で script に hardcoded できないため。
 
 したがって、`./scripts/setup-safety-event-metrics.sh --project xxx` 実行後の Cloud Monitoring policy 一覧 ([https://console.cloud.google.com/monitoring/alerting/policies](https://console.cloud.google.com/monitoring/alerting/policies)) には **何も増えていない**ことに注意。alert policy 作成は §5.2 以降の手順で Console から手動で実施する (channel 作成 §5.3 → 各 policy 作成時に attach する流れ)。
 
@@ -211,6 +218,7 @@ jsonPayload.path=~"^appearance\."
 | `recursion-depth-exceeded` | 例: > 1 / 1 min |
 | `collection-overflow` | 例: > 5 / 1 min |
 | `histogram-overflow` | **>= 1** (初期 enabled) |
+| `bytes-estimation-failed` | 例: > 1 / 1 min (disabled 初期、baseline 観察後 enable 推奨) |
 
 ⚠ **metric の上限値に注意**: §1 ⚠ で説明した「per-call 51 件上限」のため、上記閾値は metric count = matching log entry 数。「1 call で 1000 件」のような大規模 surge は §1 「実 event 数を知る方法」の batch totalCount 経路で観察する。
 
@@ -294,6 +302,15 @@ jsonPayload.firstOverflowPath:*
 | **確認手順** | §4.5 で path 絞り込み + `bytes` field 分布確認 |
 | **対処** | 正当用途なら閾値 (`MAX_COLLECTION_BYTES` / `MAX_FIELD_BYTES`) 見直し、攻撃なら quota |
 
+### 6.6 bytes-estimation-failed 発火 (paired signal)
+
+| 確認項目 | 内容 |
+|---|---|
+| **症状** | `JSON.stringify` failure (BigInt / 循環参照 / Proxy throw / toJSON throw) で 4 bytes fallback |
+| **原因候補** | (a) 攻撃的 payload (token-bomb 試行で `collection-overflow` guard を bypass) / (b) データ破損 (循環参照を含む user data) / (c) 外部 API 経由で BigInt 流入 |
+| **確認手順** | §4.5 query で `path` field 確認 → batch log の `pathPrefixes` で path family 特定 → user / 入力経路特定 |
+| **対処** | 攻撃なら quota / WAF 強化、データ破損なら upstream 修正、BigInt 流入なら API client 側で sanitize 追加 |
+
 ---
 
 ## 7. enum / script 同期規律
@@ -312,7 +329,7 @@ jsonPayload.firstOverflowPath:*
 
 - `tests/static/safety-events-lockstep.test.ts` (T3): TS enum と sh script の SAFETY_EVENTS 集合が一致しないと CI 失敗
 - `tests/static/safety-events-bash-syntax.test.ts` (T4): sh script の bash 構文エラー / dry-run 出力件数 / --project 必須を CI 失敗で検知
-- `server/utils/promptSafetyEvents.test.ts` (T1): enum literal 6 値の byte-for-byte pin
+- `server/utils/promptSafetyEvents.test.ts` (T1): enum literal の byte-for-byte pin (count は ALL_SAFETY_EVENT_NAMES.length 動的)
 
 ### 7.3 新規 safetyEvent 追加手順
 
@@ -322,7 +339,7 @@ jsonPayload.firstOverflowPath:*
 2. `scripts/setup-safety-event-metrics.sh` の `SAFETY_EVENTS=( ... )` array に 1 行追加 (順序を合わせる)
 3. 本 runbook §1 metric 表 / §3 解説 / §6 トリアージに対応する row 追加
 4. design-doc (`docs/spec/promptSafety/2026-06-04-observability-metric-counter-design.md`) を更新 (or 後継 spec を新規作成)
-5. `server/utils/promptSafetyEvents.test.ts` の期待 6 値を 7 値に更新
+5. `server/utils/promptSafetyEvents.test.ts` の期待 set に新 event 値を追加 (例: 6→7→8 と更新)
 6. `tests/static/safety-events-lockstep.test.ts` の `expected` set を更新
 7. `./scripts/setup-safety-event-metrics.sh --project novel-writer-dev --dry-run` で出力確認 → 本適用
 

--- a/docs/spec/promptSafety/2026-06-04-bytes-estimation-paired-signal-design.md
+++ b/docs/spec/promptSafety/2026-06-04-bytes-estimation-paired-signal-design.md
@@ -1,17 +1,17 @@
 # bytes-estimation-failed paired signal 設計 (Issue #149 残-B)
 
 - **作成日**: 2026-06-04
-- **関連 Issue**: [#149](https://github.com/Yukina1116/users/Yukina1116/novel-writer/issues/149) 残-B
+- **関連 Issue**: [#149](https://github.com/Yukina1116/novel-writer/issues/149) 残-B
 - **関連 PR (祖先)**: PR #148 (Issue #137 #7)、PR #150 (Issue #149 残-C)、PR #151 (Issue #149 残-A)
 - **対象モジュール**: `server/utils/promptSafety.ts` + `server/utils/promptSafetyEvents.ts` + 既存 lockstep / runbook / setup script (6 ファイル)
-- **ステータス**: Design (Phase 6, brainstorm Skill)
+- **ステータス**: Implemented (PR #153)
 - **緊急性**: LOW (collection-overflow / size guard で実害発生中ではない、規模拡大時の保守性整備)
 
 ---
 
 ## 1. 概要 / 動機
 
-PR #148 review-pr silent-failure-hunter agent Medium #5 として指摘された HIGH severity 残課題。
+PR #148 review-pr silent-failure-hunter agent #5 (HIGH severity) として指摘された残課題。
 
 `server/utils/promptSafety.ts:144-150` の `estimateElementBytes()`:
 
@@ -53,14 +53,14 @@ bare `catch {}` で JSON.stringify failure (BigInt / 循環参照 / Proxy throwi
 - **FR-1**: `SAFETY_EVENTS` に `BYTES_ESTIMATION_FAILED = 'bytes-estimation-failed'` を追加 (7 件目)
 - **FR-2**: `estimateElementBytes` signature を `(value: unknown, onStringifyFailure?: () => void) => number` に変更 (optional callback)、未指定時は既存挙動 (silent 4 bytes fallback) を維持 (backward compat)
 - **FR-3**: `stripPromptHeavyFields` 内に `bytesEstimationAggregator` を追加 (image / non-image / depth / collection と並列、5 件目の aggregator)
-- **FR-4**: callsite (`promptSafety.ts:563`) で `estimateElementBytes(replaced, () => bytesEstimationAggregator.tick(...))` の callback 経由 tick
+- **FR-4**: callsite (`stripPromptHeavyFields` 内 array recurse ループ末尾、cumulative byte 加算箇所) で `estimateElementBytes(replaced, () => bytesEstimationAggregator.tick(...))` の callback 経由 tick
 - **FR-5**: 関数末尾の flush 呼出に `bytesEstimationAggregator.flush()` を追加 (既存 4 aggregator 並列)
 - **FR-6**: warn payload に `path` (string、`itemPath`) + `fallbackBytes: 4` を含む
 - **FR-7**: 全 4 ファイル (lockstep test / setup script / runbook / promptSafetyEvents.test.ts) を新 safetyEvent 7 件目に同期更新
 
 ### 非機能要件
 
-- **NFR-1**: 既存 636 + 新規 3 = 639 tests PASS (regression なし)
+- **NFR-1**: 既存 636 + 新規 4 = 640 tests PASS (regression なし)
 - **NFR-2**: 既存 4 aggregator (image / non-image / depth / collection) の挙動を変更しない
 - **NFR-3**: `estimateElementBytes` の fallback 値 (4 bytes) を変更しない (silent → paired signal 化のみ)
 - **NFR-4**: `estimateElementBytes` の callback 未指定経路で既存呼出が全て backward compat (truncateOversizedStrings 等で間接的に使用される可能性、ただし現状は 1 callsite のみ)
@@ -312,11 +312,14 @@ AC-3: server/utils/promptSafety.ts の estimateElementBytes signature が
       callback 未指定でも既存挙動 (silent 4 bytes fallback) を維持
 
 AC-4: stripPromptHeavyFields 内に bytesEstimationAggregator が追加され、
-      callsite (line 563) で callback 経由 tick + 関数末尾で flush
+      callsite (array recurse ループ末尾、cumulative byte 加算箇所) で
+      callback 経由 tick + 関数末尾で flush
 
 AC-5: server/utils/promptSafety.test.ts に新規 paired signal 発火 test (3 件):
       - AC-5a: BigInt を含む array element で aggregator.tick が 1 回 emit
-      - AC-5b: 循環参照を含む array element で aggregator.tick が 1 回 emit
+      - AC-5b: toJSON throw element で aggregator.tick が 1 回 emit
+              (循環参照は depth guard 上位で先処理されるため、JSON.stringify throw の
+               代替経路として toJSON throw を使用)
       - AC-5c: 通常 JSON-safe data では aggregator.tick が 0 回 (false positive ゼロ)
 
 AC-6: tests/static/safety-events-lockstep.test.ts の expected set 6 → 7 件、
@@ -332,13 +335,14 @@ AC-9: docs/runbook/cloud-logging-safety-event-metrics.md §1 metric 表に 7 件
       §3 解説 §3.7 追加、§5 alert 閾値表に 7 件目 (disabled 初期)、
       §6 異常時トリアージ §6.6 追加
 
-AC-10: 既存 636 + 新規 3 = 639 tests PASS + tsc --noEmit エラーゼロ
+AC-10: 既存 636 + 新規 4 = 640 tests PASS + tsc --noEmit エラーゼロ
 
 AC-11: 既存 promptSafety.test.ts の全 regression PASS
        (collection-overflow / image-omitted 等の 4 aggregator 既存挙動不変)
 
-AC-12: AC-9 manual failing path 手動確認 (TS enum から BYTES_ESTIMATION_FAILED を
-       一時削除 → lockstep test fail → 復元で全 PASS)
+AC-12: lockstep manual failing path 手動確認 (TS enum から BYTES_ESTIMATION_FAILED を
+       一時削除 → safety-events-lockstep.test.ts の 3 件 (TS↔sh 件数 / 集合一致 /
+       canonical entries) が fail → 復元で全 PASS)
 ```
 
 ### テスト構成
@@ -348,7 +352,7 @@ AC-12: AC-9 manual failing path 手動確認 (TS enum から BYTES_ESTIMATION_FA
 | 既存 | `promptSafetyEvents.test.ts` | unit | enum literal pin 更新 (AC-2) |
 | 既存 | `promptSafety.test.ts` 全件 | regression | 既存 aggregator 挙動不変 (AC-11) |
 | 新 T2 | `promptSafety.test.ts` 新 describe | unit | BigInt array で aggregator.tick × 1 件 (AC-5a) |
-| 新 T3 | 同上 | unit | 循環参照 array で aggregator.tick × 1 件 (AC-5b) |
+| 新 T3 | 同上 | unit | toJSON throw array で aggregator.tick × 1 件 (AC-5b、循環参照は depth guard 上位) |
 | 新 T4 | 同上 | unit | 通常 array で aggregator.tick × 0 件 (AC-5c、false positive 検証) |
 | 既存 | `safety-events-lockstep.test.ts` | static | 集合 6 → 7 件 (AC-6) |
 | 既存 | `safety-events-bash-syntax.test.ts` | static | 動的追従 (AC-7、変更不要) |

--- a/docs/spec/promptSafety/2026-06-04-bytes-estimation-paired-signal-design.md
+++ b/docs/spec/promptSafety/2026-06-04-bytes-estimation-paired-signal-design.md
@@ -1,0 +1,391 @@
+# bytes-estimation-failed paired signal 設計 (Issue #149 残-B)
+
+- **作成日**: 2026-06-04
+- **関連 Issue**: [#149](https://github.com/Yukina1116/users/Yukina1116/novel-writer/issues/149) 残-B
+- **関連 PR (祖先)**: PR #148 (Issue #137 #7)、PR #150 (Issue #149 残-C)、PR #151 (Issue #149 残-A)
+- **対象モジュール**: `server/utils/promptSafety.ts` + `server/utils/promptSafetyEvents.ts` + 既存 lockstep / runbook / setup script (6 ファイル)
+- **ステータス**: Design (Phase 6, brainstorm Skill)
+- **緊急性**: LOW (collection-overflow / size guard で実害発生中ではない、規模拡大時の保守性整備)
+
+---
+
+## 1. 概要 / 動機
+
+PR #148 review-pr silent-failure-hunter agent Medium #5 として指摘された HIGH severity 残課題。
+
+`server/utils/promptSafety.ts:144-150` の `estimateElementBytes()`:
+
+```typescript
+function estimateElementBytes(value: unknown): number {
+  try {
+    return Buffer.byteLength(JSON.stringify(value) ?? 'null', 'utf8');
+  } catch {
+    return 4; // 'null' 相当
+  }
+}
+```
+
+bare `catch {}` で JSON.stringify failure (BigInt / 循環参照 / Proxy throwing `get` / throwing `toJSON`) を全て swallow し 4 bytes fallback。`collection-overflow` aggregator (`MAX_COLLECTION_BYTES=200KB`) が `200KB / 4 = 50,000 element` まで bypass される token-bomb 経路。
+
+**paired signal 規律違反** (`feedback_silent_fail_paired_signal.md`): silent fail を許容する設計には別系統の早期検知シグナルを一対で用意する規律。現状 `estimateElementBytes` の bare catch には paired signal なし、JSDoc で「BigInt や循環参照で stringify が throw する場合は 4 byte fallback で防御」と意図は明示されているが、検知シグナルが欠落。
+
+### 本タスクの位置付け
+
+- **観測性 / 保守性向上 (安定性向上ではない)**: 既存 backstop (size guard / collection guard) で token-bomb 攻撃自体は防御済、本 PR は「攻撃 / データ破損が起きた時に Cloud Logging で早期検知できる」観測層整備
+- 「多くのユーザー」想定 (2026-06-04 本田様判断) への規模拡大時に、BigInt / Proxy / 循環参照を含む payload (攻撃 or データ破損) の早期検知価値が高まる前段で構造的に閉鎖
+- PR #148 で確立した SAFETY_EVENTS enum + lockstep test pattern の **実証** (新 safetyEvent 追加 = 6 ファイル同時更新の drift 検知能力テスト)
+
+### Issue #149 close 条件
+
+本 PR merge 後の Issue #149 残課題:
+- 残-A (create path) ✅ PR #151 マージ済
+- 残-B (estimate-byte-fallback paired signal) ✅ **本 PR**
+- 残-C (histogram-overflow path) ✅ PR #150 マージ済
+
+→ Issue #149 全 3 件完了で **umbrella close 可能**。
+
+---
+
+## 2. 要件
+
+### 機能要件
+
+- **FR-1**: `SAFETY_EVENTS` に `BYTES_ESTIMATION_FAILED = 'bytes-estimation-failed'` を追加 (7 件目)
+- **FR-2**: `estimateElementBytes` signature を `(value: unknown, onStringifyFailure?: () => void) => number` に変更 (optional callback)、未指定時は既存挙動 (silent 4 bytes fallback) を維持 (backward compat)
+- **FR-3**: `stripPromptHeavyFields` 内に `bytesEstimationAggregator` を追加 (image / non-image / depth / collection と並列、5 件目の aggregator)
+- **FR-4**: callsite (`promptSafety.ts:563`) で `estimateElementBytes(replaced, () => bytesEstimationAggregator.tick(...))` の callback 経由 tick
+- **FR-5**: 関数末尾の flush 呼出に `bytesEstimationAggregator.flush()` を追加 (既存 4 aggregator 並列)
+- **FR-6**: warn payload に `path` (string、`itemPath`) + `fallbackBytes: 4` を含む
+- **FR-7**: 全 4 ファイル (lockstep test / setup script / runbook / promptSafetyEvents.test.ts) を新 safetyEvent 7 件目に同期更新
+
+### 非機能要件
+
+- **NFR-1**: 既存 636 + 新規 3 = 639 tests PASS (regression なし)
+- **NFR-2**: 既存 4 aggregator (image / non-image / depth / collection) の挙動を変更しない
+- **NFR-3**: `estimateElementBytes` の fallback 値 (4 bytes) を変更しない (silent → paired signal 化のみ)
+- **NFR-4**: `estimateElementBytes` の callback 未指定経路で既存呼出が全て backward compat (truncateOversizedStrings 等で間接的に使用される可能性、ただし現状は 1 callsite のみ)
+- **NFR-5**: tsc --noEmit エラーゼロ
+- **NFR-6**: bash -n syntax OK
+- **NFR-7**: 新規依存ライブラリゼロ
+- **NFR-8**: 通常 JSON-safe data で false positive ゼロ (T4 で pin)
+
+---
+
+## 3. アーキテクチャ
+
+### ファイル配置
+
+```
+server/utils/
+  promptSafetyEvents.ts             [変更] SAFETY_EVENTS に BYTES_ESTIMATION_FAILED 追加 (7 件目)
+  promptSafetyEvents.test.ts        [変更] expected set 6 → 7 件 (AC-2 pin 更新)
+  promptSafety.ts                   [変更] estimateElementBytes signature + bytesEstimationAggregator
+  promptSafety.test.ts              [変更] regression test + paired signal test 3 件追加
+
+scripts/
+  setup-safety-event-metrics.sh     [変更] SAFETY_EVENTS bash array に "bytes-estimation-failed" 追加
+
+tests/static/
+  safety-events-lockstep.test.ts    [変更] expected 6 → 7 件 (AC-4c pin 更新)
+  safety-events-bash-syntax.test.ts [自動追従] ALL_SAFETY_EVENT_NAMES.length 動的化済 (PR #148 M-3)
+
+docs/runbook/
+  cloud-logging-safety-event-metrics.md [変更] §1 metric 表 + §3.7 解説 + §5 alert 閾値 + §6.6 トリアージ
+```
+
+### aggregator scope
+
+- `bytesEstimationAggregator` を `stripPromptHeavyFields` 関数の closure 内に 1 instance (既存 image / non-image / depth / collection と並列)
+- per-recurse-call scope (= 1 sanitize 呼出で 1 instance、call 終了で破棄)
+- 既存 `createWarnAggregator` factory を再利用 (PR #137 #4 で確立)
+- 新 helper 関数なし
+
+### 依存関係 (1 方向)
+
+```
+SAFETY_EVENTS.BYTES_ESTIMATION_FAILED (定数定義)
+       ↓ import
+promptSafety.ts: bytesEstimationAggregator (per-call instance)
+       ↓ callback DI
+estimateElementBytes(value, () => aggregator.tick(...))
+       ↓ runtime emit
+logger.warn ({ safetyEvent: 'bytes-estimation-failed', path, fallbackBytes })
+       ↓ Cloud Logging
+prompt_safety_bytes_estimation_failed_count metric (setup script で create)
+```
+
+### 変更しないもの
+
+- `truncateOversizedStrings` 関数 (estimateElementBytes 使用なし)
+- 既存 4 aggregator (image / non-image / depth / collection) の挙動
+- estimateElementBytes 内の fallback 値 (4 bytes 維持)
+- estimateElementBytes の JSDoc 内容 (callback 引数追加分のみ補足)
+- 本番 Cloud Run runtime の挙動全体 (新 warn が増えるのみ、既存挙動不変)
+
+---
+
+## 4. データモデル
+
+### SAFETY_EVENTS 7 件目 (新規)
+
+```typescript
+export const SAFETY_EVENTS = {
+  IMAGE_OMITTED: 'image-omitted',
+  NON_IMAGE_DATA_URI_OMITTED: 'non-image-data-uri-omitted',
+  OVERSIZED_TRUNCATED: 'oversized-truncated',
+  RECURSION_DEPTH_EXCEEDED: 'recursion-depth-exceeded',
+  COLLECTION_OVERFLOW: 'collection-overflow',
+  HISTOGRAM_OVERFLOW: 'histogram-overflow',
+  BYTES_ESTIMATION_FAILED: 'bytes-estimation-failed',  // 新規
+} as const;
+```
+
+`SafetyEventName` / `SafetyEventBatchName` 型は `typeof + keyof` で自動派生、型レベル更新不要。
+
+### metric 命名規約 (PR #148 規約踏襲)
+
+| event 名 | metric 名 | filter |
+|---|---|---|
+| `bytes-estimation-failed` | `prompt_safety_bytes_estimation_failed_count` | `jsonPayload.safetyEvent=~"^bytes-estimation-failed(-batch)?$"` |
+
+### warn payload structure
+
+**個別 warn** (per-call 50 件まで、`createWarnAggregator` factory 経由):
+
+```typescript
+{
+  message: 'promptSafety: byte estimation failed (JSON.stringify threw)',
+  safetyEvent: 'bytes-estimation-failed',
+  path: 'gallery[*].metadata.attacker-key',  // estimateElementBytes 呼出時の array element path
+  fallbackBytes: 4,                          // 使用された fallback 値
+}
+```
+
+**batch warn** (51 件目以降、aggregator factory が自動生成、PR #144 pathPrefixes 含む):
+
+```typescript
+{
+  message: 'promptSafety: bytes-estimation-failed warn amplification suppressed',
+  safetyEvent: 'bytes-estimation-failed-batch',
+  totalCount: 1500,
+  loggedCount: 50,
+  omittedCount: 1450,
+  pathPrefixes: [
+    { path: 'gallery[*].metadata.*', count: 900 },
+    { path: 'lore[*].*', count: 400 },
+    ...
+  ],
+  truncatedBucketCount: 0,
+}
+```
+
+### alert policy scaffold (setup script)
+
+| event | 初期状態 | 提案閾値 | 検知意図 |
+|---|---|---|---|
+| `bytes-estimation-failed` | **disabled** | 例 > 1 / 1 min (baseline 観察後決定) | BigInt / Proxy / 循環参照を含む payload の急増検知 |
+
+理由: 通常データ (JSON-safe input) では発火しないはず、発火頻度 baseline 観察後に enable。
+
+---
+
+## 5. インターフェース
+
+### estimateElementBytes signature 変更
+
+```typescript
+// after (Issue #149 残-B)
+function estimateElementBytes(value: unknown, onStringifyFailure?: () => void): number {
+  try {
+    return Buffer.byteLength(JSON.stringify(value) ?? 'null', 'utf8');
+  } catch {
+    onStringifyFailure?.();
+    return 4; // 'null' 相当 (paired signal は onStringifyFailure callback で別系統 emit)
+  }
+}
+```
+
+- 第 2 引数 optional callback (DI)
+- callback 未指定で既存挙動 (silent 4 bytes fallback) を維持 (backward compat、NFR-4)
+
+### stripPromptHeavyFields 内 callsite
+
+```typescript
+export function stripPromptHeavyFields(data: unknown): unknown {
+  const imageAggregator = createWarnAggregator(...);
+  const nonImageAggregator = createWarnAggregator(...);
+  const depthAggregator = createDepthExceededAggregator();
+  const collectionAggregator = createWarnAggregator(...);
+
+  // 新規 (FR-3): 5 件目 aggregator
+  const bytesEstimationAggregator = createWarnAggregator(
+    SAFETY_EVENTS.BYTES_ESTIMATION_FAILED,
+    'promptSafety: byte estimation failed (JSON.stringify threw)'
+  );
+
+  function recurse(value, path, depth) {
+    // ... 既存ロジック ...
+    if (Array.isArray(value)) {
+      // ... 既存ループ ...
+      for (let idx = 0; idx < value.length; idx++) {
+        // ... existing recurse ...
+        const itemPath = path === '' ? `[${idx}]` : `${path}[${idx}]`;
+        const replaced = recurse(value[idx], itemPath, depth + 1);
+        next.push(replaced);
+        if (replaced !== value[idx]) changed = true;
+        // FR-4: callback 経由 tick (per-element)
+        cumulativeBytes += estimateElementBytes(replaced, () =>
+          bytesEstimationAggregator.tick(
+            () => ({ path: itemPath, fallbackBytes: 4 }),
+            itemPath
+          )
+        );
+        keptCount++;
+      }
+    }
+    // ...
+  }
+
+  const result = recurse(data, '', 0);
+
+  imageAggregator.flush();
+  nonImageAggregator.flush();
+  depthAggregator.flush();
+  collectionAggregator.flush();
+  bytesEstimationAggregator.flush();  // FR-5: 新規 flush
+
+  return result;
+}
+```
+
+### runbook §6.6 トリアージ (新規追加)
+
+```markdown
+### 6.6 bytes-estimation-failed 発火
+
+| 確認項目 | 内容 |
+|---|---|
+| **症状** | JSON.stringify failure (BigInt / 循環参照 / Proxy throw / toJSON throw) で 4 bytes fallback |
+| **原因候補** | (a) 攻撃的 payload (token-bomb 試行) / (b) データ破損 (循環参照を含む user data) / (c) 外部 API 経由で BigInt 流入 |
+| **確認手順** | §4 query で path field を確認 → 攻撃か正当かを path 構造で判定 → batch log の pathPrefixes で path family 特定 |
+| **対処** | 攻撃なら quota / WAF 強化、データ破損なら upstream 修正、BigInt 流入なら API client 側で sanitize |
+```
+
+---
+
+## 6. エラー処理
+
+### estimateElementBytes 側
+
+- `JSON.stringify` throw → `onStringifyFailure?.()` 呼出 → 4 bytes fallback
+- callback 未指定 (`undefined`) → silent fallback (既存挙動、backward compat)
+- callback 内部で throw (例: aggregator.tick が誤って throw) → outer catch で再 swallow されない (caller 側で適切に handle される想定)
+
+### bytesEstimationAggregator 側
+
+- `createWarnAggregator` factory の既存規律を継承 (PR #137 #4 / PR #144 / PR #150)
+- 50 件目までは個別 warn、51 件目以降は batch 集約
+- per-aggregator-instance で `overflowEmitted` flag (histogram-overflow paired signal、PR #150 firstOverflowPath 拡張済)
+
+### テスト側
+
+- T2 (BigInt) で aggregator.tick が 1 回呼ばれることを spy で pin
+- T3 (循環参照) で同様
+- T4 (通常 data) で aggregator.tick が呼ばれないことを pin (false positive ゼロ)
+
+---
+
+## 7. テスト戦略
+
+### Acceptance Criteria
+
+```
+AC-1: server/utils/promptSafetyEvents.ts に SAFETY_EVENTS.BYTES_ESTIMATION_FAILED
+      ('bytes-estimation-failed') が追加され、ALL_SAFETY_EVENT_NAMES.length が
+      6 → 7 になる
+
+AC-2: server/utils/promptSafetyEvents.test.ts の expected set が 6 → 7 件、
+      'bytes-estimation-failed' を含む
+
+AC-3: server/utils/promptSafety.ts の estimateElementBytes signature が
+      `(value: unknown, onStringifyFailure?: () => void) => number` に変更され、
+      callback 未指定でも既存挙動 (silent 4 bytes fallback) を維持
+
+AC-4: stripPromptHeavyFields 内に bytesEstimationAggregator が追加され、
+      callsite (line 563) で callback 経由 tick + 関数末尾で flush
+
+AC-5: server/utils/promptSafety.test.ts に新規 paired signal 発火 test (3 件):
+      - AC-5a: BigInt を含む array element で aggregator.tick が 1 回 emit
+      - AC-5b: 循環参照を含む array element で aggregator.tick が 1 回 emit
+      - AC-5c: 通常 JSON-safe data では aggregator.tick が 0 回 (false positive ゼロ)
+
+AC-6: tests/static/safety-events-lockstep.test.ts の expected set 6 → 7 件、
+      'bytes-estimation-failed' を含む (TS↔sh 集合一致)
+
+AC-7: tests/static/safety-events-bash-syntax.test.ts は ALL_SAFETY_EVENT_NAMES.length
+      で動的化済、追加修正なしで自動追従 (PR #148 M-3 の検証)
+
+AC-8: scripts/setup-safety-event-metrics.sh の SAFETY_EVENTS bash array に
+      "bytes-estimation-failed" 追加、--dry-run で 7 件目の "command:" 行が出力される
+
+AC-9: docs/runbook/cloud-logging-safety-event-metrics.md §1 metric 表に 7 件目、
+      §3 解説 §3.7 追加、§5 alert 閾値表に 7 件目 (disabled 初期)、
+      §6 異常時トリアージ §6.6 追加
+
+AC-10: 既存 636 + 新規 3 = 639 tests PASS + tsc --noEmit エラーゼロ
+
+AC-11: 既存 promptSafety.test.ts の全 regression PASS
+       (collection-overflow / image-omitted 等の 4 aggregator 既存挙動不変)
+
+AC-12: AC-9 manual failing path 手動確認 (TS enum から BYTES_ESTIMATION_FAILED を
+       一時削除 → lockstep test fail → 復元で全 PASS)
+```
+
+### テスト構成
+
+| # | ファイル | 種別 | 目的 |
+|---|---|---|---|
+| 既存 | `promptSafetyEvents.test.ts` | unit | enum literal pin 更新 (AC-2) |
+| 既存 | `promptSafety.test.ts` 全件 | regression | 既存 aggregator 挙動不変 (AC-11) |
+| 新 T2 | `promptSafety.test.ts` 新 describe | unit | BigInt array で aggregator.tick × 1 件 (AC-5a) |
+| 新 T3 | 同上 | unit | 循環参照 array で aggregator.tick × 1 件 (AC-5b) |
+| 新 T4 | 同上 | unit | 通常 array で aggregator.tick × 0 件 (AC-5c、false positive 検証) |
+| 既存 | `safety-events-lockstep.test.ts` | static | 集合 6 → 7 件 (AC-6) |
+| 既存 | `safety-events-bash-syntax.test.ts` | static | 動的追従 (AC-7、変更不要) |
+
+---
+
+## 8. スコープ外 / 将来課題
+
+本 PR で扱わない:
+
+- estimateElementBytes の fallback 値の変更 (4 bytes 維持)
+- truncateOversizedStrings 内で estimateElementBytes を使う設計変更 (現状未使用、将来別 Issue)
+- error.message / error.name の payload 含有 (OQ-1、追加実装は別 Issue)
+- alert policy の実 enable (本田様 baseline 観察後の運用判断)
+- 本番 Cloud Logging で `safetyEvent: 'bytes-estimation-failed'` 発火確認 (本田様運用作業)
+- Issue #152 (update path paired signal、別 PR で追跡)
+- Issue #147 (PII path leak)
+- Issue #137 #6 (logger.warnSampled altitude)
+
+---
+
+## 9. Open Questions
+
+本 PR 後の運用判断項目:
+
+- **OQ-1**: warn payload に `error.name` / `error.message` を含めるか? (現状 BigInt vs 循環参照 vs Proxy throw の区別が path だけからは不明、運用上のトリアージで必要性が出てきたら追加)
+- **OQ-2**: BigInt は実 production で起きうるか? (現状 ts 型システムで `unknown` 受け入れ、ユーザー入力には来ないが API 経由で混入の可能性は要観察。baseline 観察 1 週間後に評価)
+- **OQ-3**: 将来 estimateElementBytes を string / object 全体の byte estimation にも汎用化する場合、aggregator 名規約は維持か rename か (汎用化が必要になった時点で議論)
+
+---
+
+## 10. 参照
+
+- Issue #149 ([https://github.com/Yukina1116/novel-writer/issues/149](https://github.com/Yukina1116/novel-writer/issues/149)) 残-B (本設計の対象)
+- PR #148 (Issue #137 #7、SAFETY_EVENTS enum + lockstep test pattern 確立)
+- PR #150 (Issue #149 残-C、histogram-overflow firstOverflowPath、本 PR の paired signal pattern 模範)
+- PR #151 (Issue #149 残-A、dry-run gcloud paired signal、本 PR の AC-7 動的追従検証根拠)
+- `feedback_silent_fail_paired_signal.md` (paired signal 規律、本設計の根拠)
+- 既存 spec [`2026-06-04-observability-metric-counter-design.md`](./2026-06-04-observability-metric-counter-design.md) (上位設計、SAFETY_EVENTS 規約)
+- 既存 spec [`2026-06-03-collection-level-guard-design.md`](./2026-06-03-collection-level-guard-design.md) (estimateElementBytes 導入元)

--- a/scripts/setup-safety-event-metrics.sh
+++ b/scripts/setup-safety-event-metrics.sh
@@ -92,6 +92,7 @@ SAFETY_EVENTS=(
     "recursion-depth-exceeded"
     "collection-overflow"
     "histogram-overflow"
+    "bytes-estimation-failed"
 )
 
 # --- alert policy 初期 enabled / disabled の規約 ---

--- a/scripts/setup-safety-event-metrics.sh
+++ b/scripts/setup-safety-event-metrics.sh
@@ -185,7 +185,7 @@ for event in "${SAFETY_EVENTS[@]}"; do
     fi
 done
 
-# --- 2. alert policy scaffold (6 件、histogram-overflow のみ enabled) ---
+# --- 2. alert policy scaffold (7 件、histogram-overflow のみ enabled) ---
 # 注: alert policy 作成は notification channel ID が環境依存のため、
 # 本 script では policy JSON を一時ファイルに書き出すまでで止め、実 create は
 # 本田様が runbook §5 の手順で channel ID を埋めて gcloud alpha monitoring policies

--- a/server/utils/promptSafety.test.ts
+++ b/server/utils/promptSafety.test.ts
@@ -1503,8 +1503,9 @@ describe('bytes-estimation-failed paired signal (Issue #149 残-B)', () => {
   });
 
   // estimateElementBytes は内部関数だが、stripPromptHeavyFields 内 array recurse
-  // 経路で `JSON.stringify` failure (BigInt / 循環参照) を発火させて aggregator が
-  // tick されることを behavior 経由で pin。
+  // 経路で `JSON.stringify` failure (BigInt / toJSON throw 等。循環参照は depth guard
+  // 上位で先処理されて到達しない) を発火させて aggregator が tick されることを
+  // behavior 経由で pin。
   // false positive ゼロ (T4) は normal JSON-safe data で aggregator emit ゼロを pin。
 
   function bytesEstimationCalls(): unknown[][] {
@@ -1531,7 +1532,7 @@ describe('bytes-estimation-failed paired signal (Issue #149 残-B)', () => {
     expect(payload.path).toMatch(/items\[\d+\]/);
   });
 
-  it('AC-5b: toJSON throwing element で aggregator.tick が emit', () => {
+  it('AC-5b: toJSON throwing element で aggregator.tick が emit (proxy for circular ref)', () => {
     // 循環参照は recurse 内 MAX_RECURSION_DEPTH (depth guard) で先に処理されて
     // RECURSION_DEPTH_EXCEEDED_MARKER に置換されるため、estimateElementBytes 段階
     // に到達しない (設計通り、depth guard が paired signal 上位)。代替として

--- a/server/utils/promptSafety.test.ts
+++ b/server/utils/promptSafety.test.ts
@@ -1495,3 +1495,78 @@ describe('stripPromptHeavyFields - collection-level guard (Issue #137 #2 残り)
     expect(overflowPayload.parentEvent).toBe('collection-overflow');
   });
 });
+
+describe('bytes-estimation-failed paired signal (Issue #149 残-B)', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+  });
+
+  // estimateElementBytes は内部関数だが、stripPromptHeavyFields 内 array recurse
+  // 経路で `JSON.stringify` failure (BigInt / 循環参照) を発火させて aggregator が
+  // tick されることを behavior 経由で pin。
+  // false positive ゼロ (T4) は normal JSON-safe data で aggregator emit ゼロを pin。
+
+  function bytesEstimationCalls(): unknown[][] {
+    return warnSpy.mock.calls.filter(
+      (c) => (c[0] as { safetyEvent?: string }).safetyEvent === 'bytes-estimation-failed'
+    );
+  }
+  function bytesEstimationBatchCalls(): unknown[][] {
+    return warnSpy.mock.calls.filter(
+      (c) => (c[0] as { safetyEvent?: string }).safetyEvent === 'bytes-estimation-failed-batch'
+    );
+  }
+
+  it('AC-5a: BigInt を含む array element で aggregator.tick が 1 回 emit', () => {
+    // JSON.stringify(BigInt) は TypeError throw
+    const input = { items: [{ id: BigInt(1) }, { id: BigInt(2) }] };
+    stripPromptHeavyFields(input);
+    const calls = bytesEstimationCalls();
+    // 2 element 分の tick (2 件 emit、batch 未発火 = 50 件未満)
+    expect(calls.length).toBe(2);
+    const payload = calls[0]![0] as { path: string; fallbackBytes: number; safetyEvent: string };
+    expect(payload.safetyEvent).toBe('bytes-estimation-failed');
+    expect(payload.fallbackBytes).toBe(4);
+    expect(payload.path).toMatch(/items\[\d+\]/);
+  });
+
+  it('AC-5b: toJSON throwing element で aggregator.tick が emit', () => {
+    // 循環参照は recurse 内 MAX_RECURSION_DEPTH (depth guard) で先に処理されて
+    // RECURSION_DEPTH_EXCEEDED_MARKER に置換されるため、estimateElementBytes 段階
+    // に到達しない (設計通り、depth guard が paired signal 上位)。代替として
+    // toJSON throw を使う (JSON.stringify が throw する確実な経路、BigInt とは
+    // 別 failure mode をカバー)。
+    const throwingItem = { toJSON: () => { throw new Error('toJSON throws'); } };
+    const input = { items: [throwingItem] };
+    stripPromptHeavyFields(input);
+    const calls = bytesEstimationCalls();
+    expect(calls.length).toBe(1);
+    const payload = calls[0]![0] as { path: string; fallbackBytes: number; safetyEvent: string };
+    expect(payload.safetyEvent).toBe('bytes-estimation-failed');
+    expect(payload.fallbackBytes).toBe(4);
+  });
+
+  it('AC-5c: 通常 JSON-safe data では aggregator.tick が 0 回 (false positive ゼロ)', () => {
+    const input = {
+      items: [
+        { id: 1, name: 'alice', tags: ['a', 'b'] },
+        { id: 2, name: 'bob', meta: { age: 30 } },
+        { id: 3, name: 'carol', score: 99.5 },
+      ],
+    };
+    stripPromptHeavyFields(input);
+    expect(bytesEstimationCalls().length).toBe(0);
+    expect(bytesEstimationBatchCalls().length).toBe(0);
+  });
+
+  it('AC-3 backward compat: estimateElementBytes callback 未指定経路で silent fallback', () => {
+    // 通常 JSON-safe data なら callback 未指定経路 (truncateOversizedStrings 等の
+    // 仮想的な間接利用想定) でも warn が emit されない (現状 callsite は 1 つだが
+    // backward compat 経路を pin)。stripPromptHeavyFields 経由で normal data の
+    // false positive を verify することで間接的に pin。
+    const input = { items: Array.from({ length: 10 }, (_, i) => ({ id: i })) };
+    stripPromptHeavyFields(input);
+    expect(bytesEstimationCalls().length).toBe(0);
+  });
+});

--- a/server/utils/promptSafety.ts
+++ b/server/utils/promptSafety.ts
@@ -141,10 +141,14 @@ export const COLLECTION_OVERFLOW_MARKER =
  * `processed element` = recurse 通過後の値 (image / non-image marker 化後の短文を含む) を想定。
  * 「leaf-level marker 化済の element は cumulative 圧迫しない」を保証する。
  */
-function estimateElementBytes(value: unknown): number {
+function estimateElementBytes(value: unknown, onStringifyFailure?: () => void): number {
   try {
     return Buffer.byteLength(JSON.stringify(value) ?? 'null', 'utf8');
   } catch {
+    // Issue #149 残-B: silent fail を許容する設計に対し、検知シグナルを callback DI で
+    // 注入する paired signal 規律 (feedback_silent_fail_paired_signal.md)。callback
+    // 未指定経路は backward compat で silent 維持 (callsite 側の責務とする)。
+    onStringifyFailure?.();
     return 4; // 'null' 相当
   }
 }
@@ -495,6 +499,14 @@ export function stripPromptHeavyFields(data: unknown): unknown {
     SAFETY_EVENTS.COLLECTION_OVERFLOW,
     'promptSafety: collection-level cumulative byte threshold exceeded'
   );
+  // Issue #149 残-B: estimateElementBytes の JSON.stringify failure (BigInt /
+  // 循環参照 / Proxy throw / toJSON throw) を paired signal 化。callback DI で
+  // collection / image 等と並列 scope。fallback 値 4 bytes 自体は維持 (検知でき
+  // れば fallback 量自体は重要でない)。
+  const bytesEstimationAggregator = createWarnAggregator(
+    SAFETY_EVENTS.BYTES_ESTIMATION_FAILED,
+    'promptSafety: byte estimation failed (JSON.stringify threw)'
+  );
 
   function recurse(value: unknown, path: string, depth: number): unknown {
     if (depth > MAX_RECURSION_DEPTH) {
@@ -560,7 +572,11 @@ export function stripPromptHeavyFields(data: unknown): unknown {
         next.push(replaced);
         if (replaced !== value[idx]) changed = true;
         // processed element の byte を加算 (marker 化された短文も計上、二重防御の補完)。
-        cumulativeBytes += estimateElementBytes(replaced);
+        // Issue #149 残-B: callback で paired signal 集約。fallback (4 bytes) 自体は
+        // 既存挙動を維持しつつ、JSON.stringify failure を Cloud Logging で観測可能化。
+        cumulativeBytes += estimateElementBytes(replaced, () =>
+          bytesEstimationAggregator.tick(() => ({ path: itemPath, fallbackBytes: 4 }), itemPath)
+        );
         keptCount++;
       }
       return changed ? next : value;
@@ -587,6 +603,7 @@ export function stripPromptHeavyFields(data: unknown): unknown {
   nonImageAggregator.flush();
   depthAggregator.flush();
   collectionAggregator.flush();
+  bytesEstimationAggregator.flush();
   return result;
 }
 

--- a/server/utils/promptSafetyEvents.test.ts
+++ b/server/utils/promptSafetyEvents.test.ts
@@ -11,8 +11,8 @@ import {
 // 既存 Cloud Logging クエリ / runbook / docs/spec の値表と byte-for-byte 一致を強制する。
 // drift は Cloud Logging metric filter regex を壊すため、ここで pin する。
 describe('promptSafetyEvents — enum literal pin (AC-1, AC-2)', () => {
-    it('SAFETY_EVENTS exports exactly 6 entries', () => {
-        expect(Object.keys(SAFETY_EVENTS)).toHaveLength(6);
+    it('SAFETY_EVENTS exports exactly 7 entries', () => {
+        expect(Object.keys(SAFETY_EVENTS)).toHaveLength(7);
     });
 
     it('SAFETY_EVENTS values are byte-for-byte expected literals', () => {
@@ -25,6 +25,7 @@ describe('promptSafetyEvents — enum literal pin (AC-1, AC-2)', () => {
                 'recursion-depth-exceeded',
                 'collection-overflow',
                 'histogram-overflow',
+                'bytes-estimation-failed',
             ])
         );
     });
@@ -39,9 +40,9 @@ describe('promptSafetyEvents — enum literal pin (AC-1, AC-2)', () => {
         expect(SAFETY_EVENT_BATCH_SUFFIX).toBe('-batch');
     });
 
-    it('ALL_SAFETY_EVENT_NAMES contains exactly 6 unique values', () => {
-        expect(ALL_SAFETY_EVENT_NAMES).toHaveLength(6);
-        expect(new Set(ALL_SAFETY_EVENT_NAMES).size).toBe(6);
+    it('ALL_SAFETY_EVENT_NAMES contains exactly 7 unique values', () => {
+        expect(ALL_SAFETY_EVENT_NAMES).toHaveLength(7);
+        expect(new Set(ALL_SAFETY_EVENT_NAMES).size).toBe(7);
     });
 
     it('ALL_SAFETY_EVENT_NAMES values are subset of SAFETY_EVENTS values', () => {

--- a/server/utils/promptSafetyEvents.ts
+++ b/server/utils/promptSafetyEvents.ts
@@ -20,6 +20,7 @@ export const SAFETY_EVENTS = {
     RECURSION_DEPTH_EXCEEDED: 'recursion-depth-exceeded',
     COLLECTION_OVERFLOW: 'collection-overflow',
     HISTOGRAM_OVERFLOW: 'histogram-overflow',
+    BYTES_ESTIMATION_FAILED: 'bytes-estimation-failed',
 } as const;
 
 export type SafetyEventName = typeof SAFETY_EVENTS[keyof typeof SAFETY_EVENTS];

--- a/tests/static/safety-events-lockstep.test.ts
+++ b/tests/static/safety-events-lockstep.test.ts
@@ -66,7 +66,7 @@ describe('safety-events lockstep — TS enum ↔ bash script SAFETY_EVENTS (AC-4
     });
 
     it('values match the design-doc canonical entries', () => {
-        // 設計文書 AC-2 の 6 entries (current). enum 拡張時はここを更新する規律
+        // 設計文書 AC-2 の canonical entries. enum 拡張時はここを更新する規律
         // (runbook §7.3 のチェックリスト項目)。
         const expected = new Set([
             'image-omitted',
@@ -75,6 +75,7 @@ describe('safety-events lockstep — TS enum ↔ bash script SAFETY_EVENTS (AC-4
             'recursion-depth-exceeded',
             'collection-overflow',
             'histogram-overflow',
+            'bytes-estimation-failed',
         ]);
         expect(tsEventValues()).toEqual(expected);
         expect(extractShEventValues()).toEqual(expected);


### PR DESCRIPTION
## Summary

- Issue #149 残-B (estimateElementBytes silent fallback paired signal) 対応
- 案 A (createWarnAggregator pattern 再利用) 採択、7 件目 safetyEvent 追加
- **Issue #149 全 3 件完了 → umbrella close**
- 観測性 / 保守性向上 (安定性向上ではない、PR #148/#150/#151 系統最終)

## 変更ファイル (8 files, +521/-17)

| ファイル | 規模 | 内容 |
|---|---|---|
| `server/utils/promptSafetyEvents.ts` | +1 | SAFETY_EVENTS.BYTES_ESTIMATION_FAILED 追加 |
| `server/utils/promptSafetyEvents.test.ts` | +3/-3 | expected set 6 → 7 件 |
| `server/utils/promptSafety.ts` | +18/-3 | estimateElementBytes に optional callback + bytesEstimationAggregator (5 件目) |
| `server/utils/promptSafety.test.ts` | +75 | paired signal test 4 件 (AC-5a/b/c + AC-3 backward compat) |
| `scripts/setup-safety-event-metrics.sh` | +1 | bash array 拡張 |
| `tests/static/safety-events-lockstep.test.ts` | +2/-1 | expected set 7 件 |
| `docs/runbook/cloud-logging-safety-event-metrics.md` | +30/-10 | §1/§3.7/§4.1/§5/§6.6 + drift fix (6→7) |
| `docs/spec/promptSafety/2026-06-04-bytes-estimation-paired-signal-design.md` | +391 | 設計文書 |

## Quality Gate 結果

| 段階 | 結果 |
|------|------|
| brainstorm Phase 1-9 | 設計文書 commit `1b8093f` |
| 実装 Phase A-C | 7 ファイル実装 `8456b87` |
| /safe-refactor | HIGH/MEDIUM 0、LOW 3 件 (将来検討) 修正なし |
| /code-review medium 7-angle 並列 | 1 MEDIUM (runbook drift 3 箇所) → fix |
| Evaluator | APPROVE、LOW 2 件 (§4.1 grep query drift) → fix |
| /codex review | 200+ 行未満で発動条件外 (skip) |

- 640 tests PASS (636 → 640、+4)、tsc エラーゼロ、bash -n syntax OK

## Acceptance Criteria (設計文書 §7)

- AC-1〜2: SAFETY_EVENTS 7 件目 + expected set 更新 ✅
- AC-3: callback 未指定で backward compat 維持 ✅
- AC-4: bytesEstimationAggregator + callsite + flush ✅
- AC-5a/b/c: paired signal test (BigInt / toJSON throw / false positive ゼロ) ✅
- AC-6〜9: lockstep / script / runbook 同期更新 ✅
- AC-10〜11: 640 tests PASS + tsc エラーゼロ + 既存 regression PASS ✅
- AC-12: failing path 手動確認 (TS enum 削除 → lockstep 3 fail → 復元で PASS) ✅

## 設計判断 (重要)

**観測性 / 保守性向上、安定性向上ではない**:
- 既存 backstop (collection-overflow / size guard) で token-bomb 攻撃自体は防御済
- 本 PR は「BigInt/Proxy/循環参照入力 (攻撃 or データ破損) が起きた時に Cloud Logging で早期検知」観測層整備
- 「多くのユーザー」想定 (2026-06-04 本田様判断) への規模拡大時の保守性整備

**循環参照テスト**: AC-5b は `toJSON` throw で代替 (循環参照は MAX_RECURSION_DEPTH=1000 で先処理されるため estimateElementBytes 段階に到達しない、設計通り depth guard が paired signal 上位)。test comment で設計制約を明示。

**fallback 値 4 bytes 維持**: paired signal で「fallback が起きたら必ず log」を達成すれば、fallback 量自体は重要でない (NFR-3)。

## Issue #149 進捗 (本 PR merge で全完了)

| 残課題 | 状態 | PR |
|---|---|---|
| 残-A: dry-run gcloud paired signal | ✅ | PR #151 |
| 残-B: estimateElementBytes silent fallback | ✅ | **本 PR** |
| 残-C: histogram-overflow path | ✅ | PR #150 |

**Closes #149** (umbrella close)。残課題は Issue #152 (update path、別 Issue で追跡) のみ。

## Test plan

- [x] 640 tests PASS (`npm run test`)
- [x] tsc --noEmit エラーゼロ (`npm run lint`)
- [x] bash -n syntax OK
- [x] AC-12 manual failing path 検証 (TS enum 削除 → lockstep 3 件 fail → 復元で PASS)
- [x] AC-7 dry-run 7 metric 出力確認
- [ ] **本田様運用**: Cloud Logging で `safetyEvent: 'bytes-estimation-failed'` 実発火確認 (本適用後)
- [ ] **本田様運用**: `./scripts/setup-safety-event-metrics.sh --project novel-writer-dev` で 7 件目 metric 作成 + alert policy disabled 初期で作成 → baseline 観察後 enable

🤖 Generated with [Claude Code](https://claude.com/claude-code)