### PR TITLE
docs(handoff): 2026-06-07 AI支援メニューアイコン明瞭化 (PR #158 完走)

### DIFF
--- a/docs/handoff/2026-06-07-ai-menu-icons.md
+++ b/docs/handoff/2026-06-07-ai-menu-icons.md
@@ -1,0 +1,90 @@
+# Handoff: AI支援メニューアイコン明瞭化 (PR #158 完走)
+
+- Session Date: 2026-06-07
+- Owner: yasushi-honda
+- Status: ✅ **完了** — PR #158 マージ + Cloud Run デプロイ + Playwright MCP 実機 E2E 確認まで全工程完走
+- Previous: [2026-06-04-prompt-safety-observability-series.md](./2026-06-04-prompt-safety-observability-series.md) (promptSafety 5 連続 PR シリーズ)
+
+## 本セッション PR
+
+| PR | 内容 | 状態 |
+|---|---|---|
+| **#158** | feat(ui): AI支援メニューの「続きを書いて」「アクション描写の強化」を鉛筆/炎アイコンに変更 (2 files, +4/-2) | ✅ `866aeab` |
+
+### 変更内容
+- `icons.tsx`: `PencilIcon` / `FlameIcon` を新規追加 (lucide.dev 標準 SVG path)
+- `components/RightPanel.tsx` menuData:
+  - 「続きを書いて」: `SparklesIcon` → `PencilIcon`
+  - 「アクション描写の強化」: `MagicWandIcon` → `FlameIcon`
+- `SparklesIcon` / `MagicWandIcon` 自体は他箇所 (「表現を豊かに」/「修正して再生成」) で継続利用のため残置
+
+### E2E 確認 (Playwright MCP)
+- 本番 URL: https://novel-writer-ramnh3ulya-an.a.run.app
+- 操作経路: プロジェクト選択 → 右パネル開閉 → AI支援メニュー (＋) → 執筆支援
+- 結果: 「続きを書いて」が鉛筆 / 「アクション描写の強化」が炎で表示されることを画面で確認
+
+## Issue Net 変化 (本セッション)
+
+- **Close 数**: 0 件
+- **起票数**: 0 件
+- **Net**: **0 件**
+
+(UI cosmetic change で構造的問題なし、新規 Issue triage 基準に該当する事象なし)
+
+## 残 Open Issue (前 handoff から不変、本田様判断待ち)
+
+| Issue | 内容 | 緊急性 |
+|---|---|---|
+| #137 | promptSafety umbrella (サブ #7 完了、残 #6 #8) | LOW、別 milestone (blast radius 大) |
+| #147 | PII path leak (codex review 由来) | LOW、規模拡大時 |
+| #152 | update path paired signal | LOW、SDK rename 時 |
+| #155 | AC-3 backward compat test gap | LOW、本田様判断待ち |
+| #156 | callback register-or-forget リスク | LOW、本田様判断待ち |
+
+## 本田様判断待ち (継続、前 handoff から不変)
+
+- `./scripts/setup-safety-event-metrics.sh --project novel-writer-dev` 実行 → 7 metric 作成 + alert policy 初期 disabled で create
+- Cloud Logging で 7 種 safetyEvent 実発火 + baseline 観察 → alert enable 判断 (1〜4 週間後)
+- Issue #137 残サブ #6 / #8 の milestone 計画
+- Issue #147 / #152 / #155 / #156 の優先順位
+
+## 学び (本セッション)
+
+1. **UI cosmetic change の最小スコープ実装**: 2 ファイル / +4-2 行で要望完結。`SparklesIcon` / `MagicWandIcon` 残置で他箇所への影響ゼロを構造的に担保
+2. **lucide.dev path の直接埋め込み**: 既存 icons.tsx の stroke-based pattern に統一、追加依存なし
+3. **Playwright MCP による本番実機 E2E**: ログイン状態 (IndexedDB + Firebase Auth session) が保持されており、AI でも操作 → スクリーンショット → 視覚確認まで完走可能
+4. **catchup → /impl-plan 不要判定 → 即実装 → PR → merge 認可 → E2E** の小規模フローが 1 セッション内で完結 (シリーズ PR との対比)
+
+## 次のアクション (3 分割構造)
+
+### 即着手タスク
+即着手タスクなし
+
+### 条件待ち (明示 trigger 付き)
+
+| # | 項目 | A/B/C | trigger | 充足時のタスク |
+|---|------|------|---------|--------------|
+| 1 | setup-safety-event-metrics.sh 実行 (7 metric + alert disabled で create) | B 修正 (write、GCP リソース作成) | 本田様からの番号単位明示認可 | `./scripts/setup-safety-event-metrics.sh --project novel-writer-dev` 実行 |
+| 2 | Cloud Logging baseline 観察 → alert enable 判断 | B 検出 | metric 作成後 1〜4 週間経過 + 本田様からの enable 指示 | alert policy を enable 化 |
+| 3 | Issue #137 残サブ #6 / #8 の milestone 計画 | C (起点未確定) | 本田様からの milestone 着手指示 | impl-plan 起動 |
+| 4 | Issue #147 / #152 / #155 / #156 の着手判断 | C (優先度未確定) | 本田様からの優先順位指示 + 番号単位着手指示 | impl-plan 起動 |
+
+### 却下候補 (記録のみ)
+
+| # | 項目 | A/B/C | 着手しない理由 |
+|---|------|------|--------------|
+| 1 | docs/handoff/ の整理・古いハンドオフファイル統廃合 | A (指示なし) | housekeeping、明示指示なし → 4 原則 §1 越権防止 |
+| 2 | 残 Open Issue 5 件への AI 側からの実装提案 | C (起点 unclear) | 全件 LOW + 本田様判断待ち。AI 起点提案は越権 |
+| 3 | テストカバレッジ向上・追加リファクタ等の「攻め」タスク | C (起点 unclear) | 起点アイデア unclear、decision-maker 領分 |
+
+## 再開可能性判定
+
+| 項目 | 状態 |
+|------|------|
+| Git Status | ✅ clean |
+| Open PR | ✅ ゼロ |
+| Active Issue | 5 件 (全て LOW + 本田様判断待ち、前 handoff から不変) |
+| CI | ✅ Deploy to Cloud Run #27087564095 success (3m5s) |
+| 残留プロセス | ✅ なし |
+| 即着手タスク | 0 件 |
+| 条件待ち | 4 件 (全て decision-maker trigger) |

--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -1,55 +1,65 @@
-# Handoff: promptSafety 観測性整備 5 連続 PR 完走 (Issue #137 #7 + #149 全 3 件 完了)
+# Handoff: AI支援メニューアイコン明瞭化 (PR #158 完走)
 
-- Session Date: 2026-06-04 (本セッション = 2026-06-04 series 再開セッション)
+- Session Date: 2026-06-07
 - Owner: yasushi-honda
-- Status: ✅ **完了** — PR #153 マージで Issue #149 umbrella close、paired signal pattern 6 段確立
-- Detail: [2026-06-04-prompt-safety-observability-series.md](./2026-06-04-prompt-safety-observability-series.md)
-- Previous: [2026-06-03f-collection-level-guard-impl.md](./2026-06-03f-collection-level-guard-impl.md) (PR #143/#144/#145)
+- Status: ✅ **完了** — PR #158 マージ + Cloud Run デプロイ + Playwright MCP 実機 E2E 確認まで全工程完走
+- Detail: [2026-06-07-ai-menu-icons.md](./2026-06-07-ai-menu-icons.md)
+- Previous: [2026-06-04-prompt-safety-observability-series.md](./2026-06-04-prompt-safety-observability-series.md) (promptSafety 5 連続 PR シリーズ)
 
-## 本セッション PR 進捗 (再開セッション分、5 件マージ完了)
+## 本セッション PR
 
 | PR | 内容 | 状態 |
 |---|---|---|
-| #148 | feat: observability metric counter (Refs #137 #7) | ✅ `298af7d` |
-| #150 | fix: histogram-overflow firstOverflowPath (Refs #149 残-C) | ✅ `e22f835` |
-| #151 | fix: dry-run gcloud command paired signal (Refs #149 残-A) | ✅ `e177a09` |
-| #154 | docs: 中断時 handoff (再開用) | ✅ `c8f9eb9` |
-| **#153** | feat: bytes-estimation-failed paired signal (Closes #149) | ✅ **`cdbe187`** |
+| **#158** | feat(ui): AI支援メニューの「続きを書いて」「アクション描写の強化」を鉛筆/炎アイコンに変更 (2 files, +4/-2) | ✅ `866aeab` |
 
-paired signal pattern 6 段確立 (SAFETY_EVENTS enum + lockstep test / firstOverflowPath / dry-run command echo / bytes-estimation-failed aggregator / 7 件目拡張実証 / review-pr drift 修正)。テスト 619 → 640 (+21)。
+E2E: Playwright MCP で本番 URL (https://novel-writer-ramnh3ulya-an.a.run.app) → プロジェクト選択 → 右パネル → AI支援メニュー → 執筆支援 まで実機操作。両アイコン (鉛筆 / 炎) 視覚確認済み。
 
-## Issue Net 変化 (本セッション最終、再開セッション分のみ)
+## Issue Net 変化 (本セッション)
 
-- **Close 数**: 1 件 (#149 umbrella、PR #153 マージで auto-close)
-- **起票数**: 2 件 (#155 AC-3 backward compat gap / #156 callback register-or-forget リスク)
-- **Net**: **-1 件**
+- **Close 数**: 0 件
+- **起票数**: 0 件
+- **Net**: **0 件**
 
-(series 全体 = 中断前 + 再開後の通算は handoff series doc 末尾参照)
+UI cosmetic change で構造的問題なし、triage 基準該当事象なし。
 
-**Net 負だが構造的価値あり**: 起票 2 件はいずれも PR #153 review-pr 4 並列の Medium 指摘 (本田様承認済 follow-up)。triage 基準満たす (rating ≥ 7 + 構造的 surface)。
-
-## 残 Open Issue
+## 残 Open Issue (前 handoff から不変、本田様判断待ち)
 
 | Issue | 内容 | 緊急性 |
 |---|---|---|
-| #137 | promptSafety umbrella (サブ #7 完了、残 #6 #8) | LOW、別 milestone (blast radius 大) |
-| #147 | PII path leak (codex review 由来) | LOW、規模拡大時 |
-| #152 | update path paired signal | LOW、SDK rename 時 |
-| #155 | AC-3 backward compat test gap | LOW、本田様判断待ち |
-| #156 | callback register-or-forget リスク (lint rule / aggregator 必須化検討) | LOW、本田様判断待ち |
+| #137 | promptSafety umbrella (サブ #7 完了、残 #6 #8) | LOW |
+| #147 | PII path leak (codex review 由来) | LOW |
+| #152 | update path paired signal | LOW |
+| #155 | AC-3 backward compat test gap | LOW |
+| #156 | callback register-or-forget リスク | LOW |
 
-## 本田様判断待ち (継続)
+## 本田様判断待ち (前 handoff から不変)
 
-- `./scripts/setup-safety-event-metrics.sh --project novel-writer-dev` 実行 → 7 metric 作成 + alert policy 初期 disabled で create
-- Cloud Logging で 7 種 safetyEvent 実発火 + baseline 観察 → alert enable 判断 (1〜4 週間後)
-- Issue #137 残サブ #6 (logger.warnSampled altitude) / #8 (truncateOversizedStrings path 追跡) の milestone 計画
+- `./scripts/setup-safety-event-metrics.sh --project novel-writer-dev` 実行
+- Cloud Logging baseline 観察 → alert enable 判断 (1〜4 週間後)
+- Issue #137 残サブ #6 / #8 の milestone 計画
 - Issue #147 / #152 / #155 / #156 の優先順位
 
-## 学び (本セッション総括 = 中断 + 再開)
+## 次のアクション (3 分割構造)
 
-1. **paired signal pattern 6 段完成**: SAFETY_EVENTS enum + lockstep test + firstOverflowPath + dry-run command echo + bytes-estimation aggregator + review-pr drift 修正
-2. **brainstorm Phase 9 → impl-plan → 4 段 Quality Gate → review-pr** の流れが 5 連続実証、70-90 分/PR で安定
-3. **review-pr が PR ごとに新 MEDIUM 残課題発見** → Net 負だが構造的 surface 可視化の価値
-4. **中断 handoff → 再開 → 完走** の 3 段サイクルが成立、context 72% 中断 → series doc + LATEST.md drift 修正で次セッション drift ゼロ復帰可能
-5. **observability / 保守性整備の連続 PR** は本田様「多くのユーザー」想定方針と整合した投資判断
-6. **review-pr 指摘の処理分類確立**: 本 PR 内 fix (drift / 誤記) ↔ 別 Issue 起票 (Medium follow-up) の二段振り分けが定着
+### 即着手タスク
+即着手タスクなし
+
+### 条件待ち
+4 件 (全て decision-maker からの明示指示が trigger) — 詳細は [2026-06-07-ai-menu-icons.md](./2026-06-07-ai-menu-icons.md) §「次のアクション」参照
+
+### 却下候補
+- handoff 整理 (housekeeping、明示指示なし)
+- 残 Issue への AI 起点実装提案 (4 原則 §1 越権防止)
+- テストカバレッジ向上・追加リファクタ等の攻めタスク (起点 unclear)
+
+## 再開可能性判定
+
+| 項目 | 状態 |
+|------|------|
+| Git Status | ✅ clean |
+| Open PR | ✅ ゼロ |
+| Active Issue | 5 件 (全て LOW + 本田様判断待ち) |
+| CI | ✅ Deploy to Cloud Run #27087564095 success |
+| 残留プロセス | ✅ なし |
+| 即着手タスク | 0 件 |
+| 条件待ち | 4 件 (全て decision-maker trigger) |


### PR DESCRIPTION
## Summary

PR #158 (AI支援メニューの「続きを書いて」→ 鉛筆 / 「アクション描写の強化」→ 炎) のマージ + Cloud Run デプロイ + Playwright MCP 実機 E2E 確認まで全工程完走をハンドオフドキュメントに記録。

- 新規 handoff: `docs/handoff/2026-06-07-ai-menu-icons.md`
- `docs/handoff/LATEST.md` を新 handoff へのリンクに更新

## Issue Net 変化 (本セッション)

- Close 数: 0 件
- 起票数: 0 件
- **Net: 0 件**

UI cosmetic change で triage 基準該当事象なし。

## 残状態 (前 handoff から不変)

- Open Issue: #137 / #147 / #152 / #155 / #156 (全て LOW、本田様判断待ち)
- 本田様判断待ち: setup-safety-event-metrics.sh 実行 / Cloud Logging baseline 観察 / Issue 優先順位

## Test plan

- [x] docs only PR (構文・リンク先存在確認)
- [x] LATEST.md → 2026-06-07-ai-menu-icons.md → 2026-06-04-prompt-safety-observability-series.md のチェーン整合
- [ ] 次セッション `/catchup` で新 LATEST.md が正しく読まれることを確認 (構文検証 + 次セッション確認)

🤖 Generated with [Claude Code](https://claude.com/claude-code)