### PR TITLE
feat(ui): SettingsPanel から「バックアップから復元」ボタンを削除

### DIFF
--- a/components/panels/SettingsPanel.tsx
+++ b/components/panels/SettingsPanel.tsx
@@ -1,9 +1,8 @@
 
-import React, { useMemo, useRef } from 'react';
+import React, { useMemo } from 'react';
 import * as Icons from '../../icons';
 import { useStore } from '../../store/index';
 import { Tooltip } from '../Tooltip';
-import { readFileAsText } from '../../utils/readFileAsText';
 
 interface SettingsPanelProps {
     onExportProject: () => void;
@@ -14,28 +13,6 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({ onExportProject, o
     const openModal = useStore(state => state.openModal);
     const userMode = useStore(state => state.userMode);
     const isExporting = useStore(state => state.isExporting);
-    const prepareImport = useStore(state => state.prepareImport);
-    const showToast = useStore(state => state.showToast);
-    const importInputRef = useRef<HTMLInputElement>(null);
-
-    // Issue #104 evaluator MEDIUM: SettingsPanel から「バックアップから復元」が
-    // 消えた regression を解消する。主導線は ProjectSelectionScreen の「データ管理」
-    // に移ったが、編集中にも復元できる安全弁を残す。
-    const handleImportFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
-        const file = e.target.files?.[0];
-        e.target.value = '';
-        if (!file) return;
-        try {
-            const raw = await readFileAsText(file);
-            const result = await prepareImport(raw);
-            if (result.kind === 'plaintext') {
-                openModal('importConflict');
-            }
-        } catch (err: unknown) {
-            const msg = err instanceof Error ? err.message : 'インポートの準備に失敗しました';
-            showToast(msg, 'error');
-        }
-    };
 
 
     const tools = useMemo(() => [
@@ -66,7 +43,7 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({ onExportProject, o
                     </button>
                 </Tooltip>
             </div>
-            
+
             {visibleTools.length > 0 && (
                 <div>
                     <h3 className="text-sm font-semibold text-gray-400 mb-2">ツール</h3>
@@ -95,8 +72,7 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({ onExportProject, o
                 </div>
             </div>
 
-            {/* 全データバックアップ section: 主導線は ProjectSelectionScreen「データ管理」へ
-                移設 (issue #104)。ここではプロジェクト編集中の動線として最小ボタンを残す。 */}
+            {/* バックアップ作成のみ。復元動線は ProjectSelectionScreen「データ管理」に集約。 */}
             <div>
                 <h3 className="text-sm font-semibold text-gray-400 mb-2">バックアップ</h3>
                 <p className="text-xs text-gray-400 mb-2">
@@ -112,21 +88,6 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({ onExportProject, o
                         <Icons.DownloadIcon className="h-4 w-4 mr-1 flex-shrink-0" />
                         <span>{isExporting ? 'エクスポート中…' : 'バックアップを作成'}</span>
                     </button>
-                    <button
-                        type="button"
-                        onClick={() => importInputRef.current?.click()}
-                        className="w-full text-sm px-3 py-2 bg-gray-700 hover:bg-gray-600 rounded-md transition flex items-center gap-2 btn-pressable text-gray-300"
-                    >
-                        <Icons.UploadIcon className="h-4 w-4 mr-1 flex-shrink-0" />
-                        <span>バックアップから復元</span>
-                    </button>
-                    <input
-                        type="file"
-                        ref={importInputRef}
-                        onChange={handleImportFile}
-                        accept=".json,application/json"
-                        className="hidden"
-                    />
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary

- 左カラム (SettingsPanel) の「バックアップ」セクションから「バックアップから復元」ボタンを削除
- 「バックアップを作成」ボタンは残置
- 復元動線は ProjectSelectionScreen「データ管理」セクションに集約

## 背景

編集中に「バックアップから復元」を実行すると現プロジェクトを全上書きするため、誤操作リスクが高く認知負荷も高い。Issue #104 evaluator MEDIUM 指摘で「編集中の安全弁」として残していたが、本田様判断で「ここにあっても意味がない、タイトル画面にあれば充分」として撤去。

## 変更点

`components/panels/SettingsPanel.tsx`
- `handleImportFile` / `importInputRef` / 関連 `<input type="file">` / 「バックアップから復元」`<button>` を削除
- 未使用となった `useRef` / `readFileAsText` / `prepareImport` / `showToast` import を削除
- Issue #104 evaluator MEDIUM コメントを削除

`+3 / -42`、1 file changed

## Test plan

- [x] `npm run lint` (tsc --noEmit): PASS
- [x] `npm run test`: 640/640 PASS
- [ ] 本番デプロイ後 Playwright MCP で左カラムを視認し以下を確認:
  - [ ] 「バックアップから復元」ボタンが非表示
  - [ ] 「バックアップを作成」ボタンは引き続き表示・動作
  - [ ] ProjectSelectionScreen「データ管理」の復元動線は不変

🤖 Generated with [Claude Code](https://claude.com/claude-code)