### PR TITLE
fix(ui): 履歴ボタンを standard モードでも開けるよう SuggestionHistoryModal の mount 条件を修正

### DIFF
--- a/components/RightPanel.tsx
+++ b/components/RightPanel.tsx
@@ -433,8 +433,8 @@ export const RightPanel: React.FC<RightPanelProps> = ({ userInputRef, isMobile =
                     </div>
                 </> )}
             </div>
-            {userMode === 'pro' && (
-                <SuggestionHistoryModal 
+            {userMode !== 'simple' && (
+                <SuggestionHistoryModal
                     isOpen={isHistoryOpen}
                     onClose={() => setIsHistoryOpen(false)}
                     knowledgeSuggestions={archivedKnowledgeSuggestions}


### PR DESCRIPTION
## Summary

- ボタン表示条件 (`userMode !== 'simple'`) とモーダル mount 条件 (`userMode === 'pro'`) の不整合を解消
- `standard` モードで履歴ボタンを押しても何も起きない明確なバグを修正
- ボタン (line 387) とモーダル mount (line 436) の条件を `userMode !== 'simple'` に統一

## Background

`components/RightPanel.tsx` の構造:
- line 387: 履歴ボタンの表示条件 `{userMode !== 'simple' && ...}` → `standard` でも表示
- line 436 (修正前): モーダル mount 条件 `{userMode === 'pro' && <SuggestionHistoryModal />}` → `standard` では mount されない
- `userMode` のデフォルトは `'standard'` (`store/uiSlice.ts:28`)

→ デフォルトモードで「ボタンは見えるが押しても開かない」状態だった。

なお `HistoryPanel`（line 422 のドック表示）は別系統で、本 PR では触らない。

## Scope

- `components/RightPanel.tsx` 1 ファイル、2 行変更（条件式 + 末尾スペースの整形）

## Test plan

- [x] `npm run lint` PASS
- [x] `npm test` 全 640 件 PASS
- [ ] **マージ後デプロイで Playwright MCP 実機確認**:
  - [ ] `standard` モード（デフォルト）でアプリ起動 → 右カラム履歴ボタンを押す → SuggestionHistoryModal が開く
  - [ ] モーダル内で却下したナレッジ提案／プロット提案が表示される
  - [ ] `simple` モード切替時に履歴ボタンが非表示になる（既存挙動維持）
  - [ ] `pro` モード切替時に既存挙動が変わらない

🤖 Generated with [Claude Code](https://claude.com/claude-code)