### PR TITLE
feat(ui): キャラクター / 世界観のアイテムをダブルクリックで編集モーダルを開けるようにする

### DIFF
--- a/components/panels/CharacterListPanel.tsx
+++ b/components/panels/CharacterListPanel.tsx
@@ -69,7 +69,12 @@ export const CharacterListPanel = ({ isFloating = false, isMobile = false }) => 
             )}
             <div className="flex-grow overflow-y-auto p-2 space-y-2">
                 {characters.map(char => (
-                    <div key={char.id} className={`p-2 rounded-lg flex gap-2 ${deletingId === char.id ? 'bg-red-900/20 border border-red-500' : 'bg-gray-800/50'}`}>
+                    <div
+                        key={char.id}
+                        className={`p-2 rounded-lg flex gap-2 ${deletingId === char.id ? 'bg-red-900/20 border border-red-500' : 'bg-gray-800/50'}`}
+                        onDoubleClick={() => openModal('character', char)}
+                        title="ダブルクリックで編集"
+                    >
                         <div className="w-12 h-12 flex-shrink-0 rounded-md bg-gray-700 flex items-center justify-center">
                             {char.appearance?.imageUrl ? (
                                 <img src={char.appearance.imageUrl} alt={char.name} className="w-full h-full object-cover object-top rounded-md" />
@@ -82,15 +87,15 @@ export const CharacterListPanel = ({ isFloating = false, isMobile = false }) => 
                                 <p className="font-bold text-sm truncate" style={{ color: char.themeColor || '#60a5fa' }}>{char.name}</p>
                                 <div className="flex gap-1 flex-shrink-0">
                                     {deletingId === char.id ? (
-                                        <div className="flex items-center gap-1 animate-fade-in">
+                                        <div className="flex items-center gap-1 animate-fade-in" onDoubleClick={(e) => e.stopPropagation()}>
                                             <span className="text-xs text-red-300 font-bold mr-1">削除?</span>
                                             <button onClick={(e) => confirmDelete(e, char.id)} className="px-2 py-1 text-xs bg-red-600 text-white rounded hover:bg-red-500 shadow-md">はい</button>
                                             <button onClick={cancelDelete} className="px-2 py-1 text-xs bg-gray-600 text-white rounded hover:bg-gray-500 shadow-md">いいえ</button>
                                         </div>
                                     ) : (
                                         <>
-                                            <button onClick={() => openModal('character', char)} className="p-1 text-gray-400 hover:text-yellow-400 btn-pressable" title="編集"><Icons.EditIcon /></button>
-                                            <button onClick={(e) => initiateDelete(e, char.id)} className="p-1 text-gray-400 hover:text-red-400 btn-pressable" title="削除"><Icons.TrashIcon /></button>
+                                            <button onClick={() => openModal('character', char)} onDoubleClick={(e) => e.stopPropagation()} className="p-1 text-gray-400 hover:text-yellow-400 btn-pressable" title="編集"><Icons.EditIcon /></button>
+                                            <button onClick={(e) => initiateDelete(e, char.id)} onDoubleClick={(e) => e.stopPropagation()} className="p-1 text-gray-400 hover:text-red-400 btn-pressable" title="削除"><Icons.TrashIcon /></button>
                                         </>
                                     )}
                                 </div>

--- a/components/panels/WorldListPanel.tsx
+++ b/components/panels/WorldListPanel.tsx
@@ -66,21 +66,26 @@ export const WorldListPanel = ({ isFloating = false, isMobile = false }) => {
             )}
             <div className="flex-grow overflow-y-auto p-2 space-y-2">
                 {worlds.map(world => (
-                    <div key={world.id} className={`p-2 rounded-lg flex items-center gap-2 ${deletingId === world.id ? 'bg-red-900/20 border border-red-500' : 'bg-gray-800/50'}`}>
+                    <div
+                        key={world.id}
+                        className={`p-2 rounded-lg flex items-center gap-2 ${deletingId === world.id ? 'bg-red-900/20 border border-red-500' : 'bg-gray-800/50'}`}
+                        onDoubleClick={() => openModal('world', world)}
+                        title="ダブルクリックで編集"
+                    >
                         <div className="flex-grow overflow-hidden">
                             <div className="flex justify-between items-start">
                                 <p className="font-bold text-sm text-green-400 truncate">{world.name}</p>
                                 <div className="flex gap-1 flex-shrink-0">
                                     {deletingId === world.id ? (
-                                        <div className="flex items-center gap-1 animate-fade-in">
+                                        <div className="flex items-center gap-1 animate-fade-in" onDoubleClick={(e) => e.stopPropagation()}>
                                             <span className="text-xs text-red-300 font-bold mr-1">削除?</span>
                                             <button onClick={(e) => confirmDelete(e, world.id)} className="px-2 py-1 text-xs bg-red-600 text-white rounded hover:bg-red-500 shadow-md">はい</button>
                                             <button onClick={cancelDelete} className="px-2 py-1 text-xs bg-gray-600 text-white rounded hover:bg-gray-500 shadow-md">いいえ</button>
                                         </div>
                                     ) : (
                                         <>
-                                            <button onClick={() => openModal('world', world)} className="p-1 text-gray-400 hover:text-yellow-400 btn-pressable" title="編集"><Icons.EditIcon /></button>
-                                            <button onClick={(e) => initiateDelete(e, world.id)} className="p-1 text-gray-400 hover:text-red-400 btn-pressable" title="削除"><Icons.TrashIcon /></button>
+                                            <button onClick={() => openModal('world', world)} onDoubleClick={(e) => e.stopPropagation()} className="p-1 text-gray-400 hover:text-yellow-400 btn-pressable" title="編集"><Icons.EditIcon /></button>
+                                            <button onClick={(e) => initiateDelete(e, world.id)} onDoubleClick={(e) => e.stopPropagation()} className="p-1 text-gray-400 hover:text-red-400 btn-pressable" title="削除"><Icons.TrashIcon /></button>
                                         </>
                                     )}
                                 </div>


### PR DESCRIPTION
## Summary

- 左カラムのキャラクター一覧 / 世界観一覧の各アイテム div に `onDoubleClick` を追加
- ダブルクリックで該当アイテムの編集モーダル（`CharacterForm` / `WorldForm`）を開く
- 編集 / 削除 / 削除確認系の各ボタンに `onDoubleClick={e => e.stopPropagation()}` を付与し、ボタン 2 回連打が親 div の `onDoubleClick` を発火させないよう bubbling を止める
- ホバー時の見え方として `title="ダブルクリックで編集"` を親 div に付与

## Background

既存の編集ボタン（EditIcon）はそのまま残し、操作経路を 1 つ増やす形。`openModal('character', char)` / `openModal('world', world)` は既存ボタンと同じ呼び出しを使う。

## Scope

- `components/panels/CharacterListPanel.tsx` (+9 / -4 lines)
- `components/panels/WorldListPanel.tsx` (+9 / -4 lines)

## Test plan

- [x] `npm run lint` PASS
- [x] `npm test` 全 640 件 PASS
- [ ] **マージ後デプロイで Playwright MCP 実機確認**:
  - [ ] 左カラム「キャラクター」タブ → 任意のキャラクター div をダブルクリック → CharacterForm モーダルが開く / 既存内容がロードされる
  - [ ] 左カラム「世界観」タブ → 任意の世界観 div をダブルクリック → WorldForm モーダルが開く / 既存内容がロードされる
  - [ ] 既存の編集ボタン（EditIcon）クリックも従来通り動く
  - [ ] 削除ボタン → 削除確認 (はい/いいえ) を 2 回連打しても親 div の編集モーダルが起動しない
  - [ ] 削除確認中の div をダブルクリックしても編集モーダルが開く（許可仕様、本 PR では制限しない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)