### PR TITLE
feat(ui): 左カラムにデスクトップ用フッターを新設し、自動保存表示の移行と総文字数表示を追加

### DIFF
--- a/components/LeftPanel.tsx
+++ b/components/LeftPanel.tsx
@@ -29,6 +29,11 @@ export const LeftPanel: React.FC<LeftPanelProps> = ({ onExportProject, onExportT
     const isSimpleMode = useStore(state => activeProjectId ? state.allProjectsData[activeProjectId]?.isSimpleMode : undefined);
     const userMode = useStore(state => state.userMode);
     const setIsLeftSidebarOpen = useStore(state => state.setIsLeftSidebarOpen);
+    const totalCharCount = useStore(state => {
+        if (!activeProjectId) return 0;
+        const novelContent = state.allProjectsData[activeProjectId]?.novelContent;
+        return novelContent?.reduce((acc, chunk) => acc + (chunk.text?.length || 0), 0) ?? 0;
+    });
 
     const resizeTransitionClass = isMobile ? '' : 'transition-[width] duration-300 ease-in-out';
     const widthStyle = isMobile ? { width: '100%', height: '100%' } : { width: `${leftSidebarWidth}px` };
@@ -104,21 +109,20 @@ export const LeftPanel: React.FC<LeftPanelProps> = ({ onExportProject, onExportT
             <div className="flex-grow flex flex-col overflow-hidden">
                 {!isMobile && (
                     <div className="p-4 border-b border-border flex flex-col gap-4">
-                        <div className="flex justify-between items-center">
+                        <div className="flex items-center">
                             <Tooltip helpId="settings">
                                 <button onClick={() => setActiveProjectId(null)} className="flex items-center text-sm text-text-main hover:text-text-main transition btn-pressable">
                                     <Icons.ArrowLeftIcon />
                                     プロジェクト一覧へ
                                 </button>
                             </Tooltip>
-                            <SaveStatusIndicator status={saveStatus} />
                         </div>
                     </div>
                 )}
                 <div className="flex-grow overflow-y-auto pb-20 sm:pb-0">
                     {renderContent()}
                     {isMobile && (
-                         <div 
+                         <div
                             className="p-4 mt-4 border-t border-border"
                             style={{ paddingBottom: 'calc(1rem + env(safe-area-inset-bottom))' }}
                          >
@@ -129,6 +133,14 @@ export const LeftPanel: React.FC<LeftPanelProps> = ({ onExportProject, onExportT
                         </div>
                     )}
                 </div>
+                {!isMobile && (
+                    <div className="px-4 py-2 border-t border-border flex items-center justify-between flex-shrink-0 bg-panel-bg">
+                        <span className="text-xs text-text-muted" title="本文の総文字数">
+                            {totalCharCount.toLocaleString()} 文字
+                        </span>
+                        <SaveStatusIndicator status={saveStatus} />
+                    </div>
+                )}
             </div>
         </div>
     );


### PR DESCRIPTION
## Summary

- デスクトップ表示時に左カラム最下部にフッター行を新設
- ヘッダー右上にあった `SaveStatusIndicator`（「自動保存済」表示）をフッター右側へ移行
- フッター左側に本文の総文字数（3 桁区切り、`{count.toLocaleString()} 文字`）を表示
- 総文字数は Zustand selector で `novelContent` から算出し、本文以外の slice 変更では再レンダーされないよう範囲を限定
- モバイル表示時の既存フッター（「プロジェクト一覧へ」ボタン）は変更なし

## Background

「自動保存済」がヘッダー右上にあり、フッター情報領域が未使用だった。本文の総文字数も執筆時に確認したい情報として欠けていたため、左カラムのフッターを新設してまとめる構成に変更する。

## Scope

- `components/LeftPanel.tsx` (+15 / -3 lines、デスクトップフッター新設 + ヘッダー右上の SaveStatusIndicator 削除)

## Test plan

- [x] `npm run lint` PASS
- [x] `npm test` 全 640 件 PASS（既存の `LeftPanel.mount.test.ts` で MobileAuthSection grep pin を確認、影響なし）
- [ ] **マージ後デプロイで Playwright MCP 実機確認**:
  - [ ] デスクトップ表示で、ヘッダー右上から「自動保存済」が消えていることを確認
  - [ ] デスクトップ表示で、左カラム最下部にフッターが表示され、左に「N 文字」、右に SaveStatusIndicator が表示される
  - [ ] 本文を編集 → フッターの文字数がリアルタイム反映される
  - [ ] 保存中・編集中・保存済の各状態で SaveStatusIndicator がフッター内で正しく切り替わる
  - [ ] モバイル表示では既存の「プロジェクト一覧へ」ボタンのフッターが維持され、新フッターは出ない
  - [ ] `isSimpleMode` プロジェクトでもフッターが表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)