### PR TITLE
feat(sync): タイムライン⇔プロットボードのタイトル差異を保存時に自動同期 + トースト通知

### DIFF
--- a/store/dataSlice.titleSync.test.ts
+++ b/store/dataSlice.titleSync.test.ts
@@ -1,0 +1,279 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../analysisApi', () => ({
+    analyzeText: vi.fn(),
+}));
+
+import { createDataSlice } from './dataSlice';
+import type { Project, TimelineEvent, PlotItem } from '../types';
+
+const baseProject = (): Project => ({
+    id: 'p-1',
+    name: 'P',
+    lastModified: new Date(0).toISOString(),
+    settings: [],
+    novelContent: [],
+    chatHistory: [],
+    knowledgeBase: [],
+    plotBoard: [],
+    plotTypeColors: {},
+    plotRelations: [],
+    plotNodePositions: [],
+    timeline: [],
+    timelineLanes: [],
+    characterRelations: [],
+    nodePositions: [],
+    aiSettings: {} as Project['aiSettings'],
+    displaySettings: {} as Project['displaySettings'],
+});
+
+interface FakeStore {
+    state: Record<string, any>;
+    set: (partial: any) => void;
+    get: () => Record<string, any>;
+}
+
+const createFakeStore = (initial: Record<string, any>): FakeStore => {
+    const fake: FakeStore = { state: { ...initial }, set: () => ({}), get: () => fake.state };
+    fake.set = (partial: any) => {
+        const next = typeof partial === 'function' ? partial(fake.state) : partial;
+        fake.state = { ...fake.state, ...next };
+    };
+    fake.get = () => fake.state;
+    return fake;
+};
+
+const mountSlice = (project: Project) => {
+    const fake = createFakeStore({});
+    const slice = createDataSlice(fake.set, fake.get);
+    const openModal = vi.fn();
+    const showToast = vi.fn();
+    let capturedUpdater: ((d: Project) => Project) | null = null;
+    fake.state = {
+        ...slice,
+        activeProjectId: 'p-1',
+        allProjectsData: { 'p-1': project },
+        openModal,
+        showToast,
+        addHistory: vi.fn(),
+        markDirty: vi.fn(),
+        closeModal: vi.fn(),
+        setActiveProjectData: (updater: (d: Project) => Project) => {
+            capturedUpdater = updater;
+        },
+    };
+    return { slice, openModal, showToast, project, getUpdated: () => capturedUpdater!(project) };
+};
+
+describe('handleSaveTimeline — タイトル自動同期 (タイムライン → プロット)', () => {
+    const makeProject = (overrides?: { plotSummary?: string; plotLastModified?: number; eventLastModified?: number }): Project => ({
+        ...baseProject(),
+        plotBoard: [{
+            id: 'plot-1',
+            title: '旧タイトル',
+            summary: overrides?.plotSummary ?? 'プロットの要約',
+            type: 'main',
+            linkedEventId: 'event-1',
+            lastModified: overrides?.plotLastModified ?? 100,
+        }],
+        timeline: [{
+            id: 'event-1',
+            title: '旧タイトル',
+            timestamp: '2026-01-01',
+            description: 'プロットの要約',
+            laneId: 'lane-1',
+            linkedPlotId: 'plot-1',
+            lastModified: overrides?.eventLastModified ?? 100,
+        }],
+        timelineLanes: [{ id: 'lane-1', name: 'L', color: '#fff' }],
+    });
+
+    it('タイムライン側のタイトル変更で、リンク済みプロットのタイトルが同期され、SyncDialog は開かない', () => {
+        const project = makeProject();
+        const { slice, openModal, showToast, getUpdated } = mountSlice(project);
+
+        const newTimeline: TimelineEvent[] = [{
+            ...project.timeline[0],
+            title: '新タイトル',
+            lastModified: 200,
+        }];
+
+        slice.handleSaveTimeline(newTimeline, project.timelineLanes);
+
+        const updated = getUpdated();
+        const syncedPlot = updated.plotBoard.find(p => p.id === 'plot-1')!;
+        expect(syncedPlot.title).toBe('新タイトル');
+        expect(syncedPlot.lastModified).toBe(200);
+        expect(syncedPlot.summary).toBe('プロットの要約');
+
+        expect(openModal).not.toHaveBeenCalled();
+        expect(showToast).toHaveBeenCalledWith(expect.stringContaining('1件'), 'success');
+    });
+
+    it('タイトル一致 + description (= プロットの summary) 違いのみの場合は SyncDialog が開く', () => {
+        const project = makeProject({ plotSummary: '旧要約' });
+        const { slice, openModal, showToast } = mountSlice(project);
+
+        const newTimeline: TimelineEvent[] = [{
+            ...project.timeline[0],
+            description: '新しい記述',
+            lastModified: 200,
+        }];
+
+        slice.handleSaveTimeline(newTimeline, project.timelineLanes);
+
+        expect(openModal).toHaveBeenCalledWith('syncDialog', { plotId: 'plot-1', eventId: 'event-1' });
+        expect(showToast).not.toHaveBeenCalled();
+    });
+
+    it('差分なしの場合は openModal も showToast も呼ばれない', () => {
+        const project = makeProject();
+        const { slice, openModal, showToast } = mountSlice(project);
+
+        slice.handleSaveTimeline(project.timeline, project.timelineLanes);
+
+        expect(openModal).not.toHaveBeenCalled();
+        expect(showToast).not.toHaveBeenCalled();
+    });
+
+    it('lastModified が同一の場合は自動同期されない', () => {
+        const project = makeProject({ plotLastModified: 200, eventLastModified: 200 });
+        const { slice, openModal, showToast } = mountSlice(project);
+
+        const newTimeline: TimelineEvent[] = [{
+            ...project.timeline[0],
+            title: '新タイトル',
+            lastModified: 200,
+        }];
+
+        slice.handleSaveTimeline(newTimeline, project.timelineLanes);
+
+        expect(openModal).not.toHaveBeenCalled();
+        expect(showToast).not.toHaveBeenCalled();
+    });
+
+    it('linkedPlotId なしのイベントでは同期されない', () => {
+        const project = makeProject();
+        const { slice, openModal, showToast } = mountSlice(project);
+        const newTimeline: TimelineEvent[] = [{
+            ...project.timeline[0],
+            linkedPlotId: undefined,
+            title: '新タイトル',
+            lastModified: 200,
+        }];
+
+        slice.handleSaveTimeline(newTimeline, project.timelineLanes);
+
+        expect(openModal).not.toHaveBeenCalled();
+        expect(showToast).not.toHaveBeenCalled();
+    });
+
+    it('リンク切れ (linkedPlotId が指す plot が存在しない) の場合は同期されない', () => {
+        const project = { ...makeProject(), plotBoard: [] as PlotItem[] };
+        const { slice, openModal, showToast } = mountSlice(project);
+
+        const newTimeline: TimelineEvent[] = [{
+            ...project.timeline[0],
+            title: '新タイトル',
+            lastModified: 200,
+        }];
+
+        slice.handleSaveTimeline(newTimeline, project.timelineLanes);
+
+        expect(openModal).not.toHaveBeenCalled();
+        expect(showToast).not.toHaveBeenCalled();
+    });
+});
+
+describe('handleSavePlotBoard — タイトル自動同期 (プロット → タイムライン)', () => {
+    const makeProject = (overrides?: { eventDescription?: string; plotLastModified?: number; eventLastModified?: number }): Project => ({
+        ...baseProject(),
+        plotBoard: [{
+            id: 'plot-1',
+            title: '旧タイトル',
+            summary: 'プロットの要約',
+            type: 'main',
+            linkedEventId: 'event-1',
+            lastModified: overrides?.plotLastModified ?? 100,
+        }],
+        timeline: [{
+            id: 'event-1',
+            title: '旧タイトル',
+            timestamp: '2026-01-01',
+            description: overrides?.eventDescription ?? 'プロットの要約',
+            laneId: 'lane-1',
+            linkedPlotId: 'plot-1',
+            lastModified: overrides?.eventLastModified ?? 100,
+        }],
+        timelineLanes: [{ id: 'lane-1', name: 'L', color: '#fff' }],
+    });
+
+    it('プロット側のタイトル変更で、リンク済みイベントのタイトルが同期される + showToast', () => {
+        const project = makeProject();
+        const { slice, openModal, showToast, getUpdated } = mountSlice(project);
+
+        const newPlots: PlotItem[] = [{
+            ...project.plotBoard[0],
+            title: '新タイトル',
+            lastModified: 200,
+        }];
+
+        slice.handleSavePlotBoard({
+            items: newPlots,
+            relations: project.plotRelations,
+            positions: project.plotNodePositions,
+            colors: project.plotTypeColors,
+        });
+
+        const updated = getUpdated();
+        const syncedEvent = updated.timeline.find(e => e.id === 'event-1')!;
+        expect(syncedEvent.title).toBe('新タイトル');
+        expect(syncedEvent.lastModified).toBe(200);
+        expect(syncedEvent.description).toBe('プロットの要約');
+
+        expect(openModal).not.toHaveBeenCalled();
+        expect(showToast).toHaveBeenCalledWith(expect.stringContaining('1件'), 'success');
+    });
+
+    it('タイトル一致 + summary (= イベントの description) 違いのみの場合は SyncDialog が開く', () => {
+        const project = makeProject({ eventDescription: '旧記述' });
+        const { slice, openModal, showToast } = mountSlice(project);
+
+        const newPlots: PlotItem[] = [{
+            ...project.plotBoard[0],
+            summary: '新しい要約',
+            lastModified: 200,
+        }];
+
+        slice.handleSavePlotBoard({
+            items: newPlots,
+            relations: project.plotRelations,
+            positions: project.plotNodePositions,
+            colors: project.plotTypeColors,
+        });
+
+        expect(openModal).toHaveBeenCalledWith('syncDialog', { plotId: 'plot-1', eventId: 'event-1' });
+        expect(showToast).not.toHaveBeenCalled();
+    });
+
+    it('lastModified が同一の場合は自動同期されない', () => {
+        const project = makeProject({ plotLastModified: 200, eventLastModified: 200 });
+        const { slice, openModal, showToast } = mountSlice(project);
+
+        const newPlots: PlotItem[] = [{
+            ...project.plotBoard[0],
+            title: '新タイトル',
+            lastModified: 200,
+        }];
+
+        slice.handleSavePlotBoard({
+            items: newPlots,
+            relations: project.plotRelations,
+            positions: project.plotNodePositions,
+            colors: project.plotTypeColors,
+        });
+
+        expect(openModal).not.toHaveBeenCalled();
+        expect(showToast).not.toHaveBeenCalled();
+    });
+});

--- a/store/dataSlice.ts
+++ b/store/dataSlice.ts
@@ -183,18 +183,26 @@ export const createDataSlice = (set, get): DataSlice => ({
         get().closeModal();
     },
     handleSavePlotBoard: (data: { items: PlotItem[], relations: PlotRelation[], positions: PlotNodePosition[], colors: { [key: string]: string } }) => {
-        const { openModal, allProjectsData, activeProjectId, setActiveProjectData } = get();
+        const { openModal, allProjectsData, activeProjectId, setActiveProjectData, showToast } = get();
         const oldProject = allProjectsData[activeProjectId];
+        // タイトルのみ自動同期 (プロット → タイムライン方向)。summary/description は SyncDialog 経路維持。
+        const titleSyncTargets: Array<{ eventId: string; newTitle: string; newLastModified: number }> = [];
         if (oldProject) {
             const oldPlotsMap = new Map(oldProject.plotBoard.map(p => [p.id, p]));
             const timelineMap = new Map(oldProject.timeline.map(e => [e.id, e]));
-    
+
             for (const newPlot of data.items) {
                 const oldPlot = oldPlotsMap.get(newPlot.id) as PlotItem | undefined;
                 if (oldPlot && newPlot.linkedEventId && (newPlot.lastModified || 0) > (oldPlot.lastModified || 0)) {
                     const linkedEvent = timelineMap.get(newPlot.linkedEventId) as TimelineEvent | undefined;
                     if (linkedEvent && (linkedEvent.lastModified || 0) < (newPlot.lastModified || 0)) {
-                        if(linkedEvent.title !== newPlot.title || linkedEvent.description !== newPlot.summary) {
+                        if (linkedEvent.title !== newPlot.title) {
+                            titleSyncTargets.push({
+                                eventId: linkedEvent.id,
+                                newTitle: newPlot.title,
+                                newLastModified: newPlot.lastModified || Date.now(),
+                            });
+                        } else if (linkedEvent.description !== newPlot.summary) {
                             openModal('syncDialog', { plotId: newPlot.id, eventId: newPlot.linkedEventId });
                         }
                     }
@@ -204,11 +212,15 @@ export const createDataSlice = (set, get): DataSlice => ({
 
         const currentProject = allProjectsData[activeProjectId];
         const newPlotIds = new Set(data.items.map(p => p.id));
+        const titleSyncMap = new Map(titleSyncTargets.map(t => [t.eventId, t]));
         const updatedTimeline = currentProject ? currentProject.timeline.map(event => {
-            if (event.linkedPlotId && !newPlotIds.has(event.linkedPlotId)) {
-                return { ...event, linkedPlotId: undefined };
-            }
-            return event;
+            const sync = titleSyncMap.get(event.id);
+            const linkCleared = event.linkedPlotId && !newPlotIds.has(event.linkedPlotId)
+                ? { ...event, linkedPlotId: undefined }
+                : event;
+            return sync
+                ? { ...linkCleared, title: sync.newTitle, lastModified: sync.newLastModified }
+                : linkCleared;
         }) : [];
 
         setActiveProjectData(d => ({
@@ -220,6 +232,10 @@ export const createDataSlice = (set, get): DataSlice => ({
             timeline: updatedTimeline,
             lastModified: new Date().toISOString(),
         }), { type: 'plot', label: 'プロットボードを更新' });
+
+        if (titleSyncTargets.length > 0) {
+            showToast(`タイムラインの${titleSyncTargets.length}件のリンクイベントのタイトルを同期しました`, 'success');
+        }
     },
     handleDisplaySettingChange: (key, value) => {
         get().setActiveProjectData(d => ({ ...d, displaySettings: { ...d.displaySettings, [key]: value } }), { type: 'settings', label: '表示設定を更新' });
@@ -228,18 +244,26 @@ export const createDataSlice = (set, get): DataSlice => ({
         get().setActiveProjectData(d => ({ ...d, characterRelations: relations, nodePositions: positions, lastModified: new Date().toISOString() }), { type: 'chart', label: '相関図を更新' });
     },
     handleSaveTimeline: (timeline: TimelineEvent[], lanes: TimelineLane[]) => {
-        const { openModal, allProjectsData, activeProjectId, setActiveProjectData } = get();
+        const { openModal, allProjectsData, activeProjectId, setActiveProjectData, showToast } = get();
         const oldProject = allProjectsData[activeProjectId];
+        // タイトルのみ自動同期 (タイムライン → プロット方向)。summary/description は SyncDialog 経路維持。
+        const titleSyncTargets: Array<{ plotId: string; newTitle: string; newLastModified: number }> = [];
         if (oldProject) {
             const oldEventsMap = new Map(oldProject.timeline.map(e => [e.id, e]));
             const plotBoardMap = new Map(oldProject.plotBoard.map(p => [p.id, p]));
-    
+
             for (const newEvent of timeline) {
                 const oldEvent = oldEventsMap.get(newEvent.id) as TimelineEvent | undefined;
                 if (oldEvent && newEvent.linkedPlotId && (newEvent.lastModified || 0) > (oldEvent.lastModified || 0)) {
                     const linkedPlot = plotBoardMap.get(newEvent.linkedPlotId) as PlotItem | undefined;
                     if (linkedPlot && (linkedPlot.lastModified || 0) < (newEvent.lastModified || 0)) {
-                        if (linkedPlot.title !== newEvent.title || linkedPlot.summary !== newEvent.description) {
+                        if (linkedPlot.title !== newEvent.title) {
+                            titleSyncTargets.push({
+                                plotId: linkedPlot.id,
+                                newTitle: newEvent.title,
+                                newLastModified: newEvent.lastModified || Date.now(),
+                            });
+                        } else if (linkedPlot.summary !== newEvent.description) {
                             openModal('syncDialog', { plotId: newEvent.linkedPlotId, eventId: newEvent.id });
                         }
                     }
@@ -249,20 +273,28 @@ export const createDataSlice = (set, get): DataSlice => ({
 
         const currentProject = allProjectsData[activeProjectId];
         const newEventIds = new Set(timeline.map(e => e.id));
+        const titleSyncMap = new Map(titleSyncTargets.map(t => [t.plotId, t]));
         const updatedPlotBoard = currentProject ? currentProject.plotBoard.map(plot => {
-            if (plot.linkedEventId && !newEventIds.has(plot.linkedEventId)) {
-                return { ...plot, linkedEventId: undefined };
-            }
-            return plot;
+            const sync = titleSyncMap.get(plot.id);
+            const linkCleared = plot.linkedEventId && !newEventIds.has(plot.linkedEventId)
+                ? { ...plot, linkedEventId: undefined }
+                : plot;
+            return sync
+                ? { ...linkCleared, title: sync.newTitle, lastModified: sync.newLastModified }
+                : linkCleared;
         }) : [];
 
-        setActiveProjectData(d => ({ 
-            ...d, 
-            timeline: timeline, 
-            timelineLanes: lanes, 
+        setActiveProjectData(d => ({
+            ...d,
+            timeline: timeline,
+            timelineLanes: lanes,
             plotBoard: updatedPlotBoard,
-            lastModified: new Date().toISOString() 
+            lastModified: new Date().toISOString()
         }), { type: 'timeline', label: 'タイムラインを更新' });
+
+        if (titleSyncTargets.length > 0) {
+            showToast(`プロットボードの${titleSyncTargets.length}件のリンクカードのタイトルを同期しました`, 'success');
+        }
     },
     handleSaveChapterSettings: ({ id, newTitle, newMemo, isUncategorized }) => {
         get().setActiveProjectData(d => {


### PR DESCRIPTION
## Summary

タイムライン側 / プロットボード側のいずれかでリンクされたアイテムのタイトルを編集して保存した時、相手側のタイトルを自動的に同じ値に書き換えて、結果をトーストでユーザーに通知する。SyncDialog による確認ダイアログのワンクッションを廃止して即時反映に変更する。

## 設計

- **同期対象は title のみ**: summary / description (説明) の差異は引き続き `SyncDialog` 経路で確認する（既存挙動維持）
- **同期方向は更新元 → リンク先の単方向**: 編集された側のタイトルを正として、リンク先にコピーする
- **同期先の `lastModified` は更新元と同値**: 次回保存時に「相手が新しく更新された」と再検出される循環同期を防ぐ
- **既存の `syncLinkedData()` は温存**: SyncDialog 経由で呼ばれた時の summary 同期パスとして残す
- **`showToast` は typed 取得**: `(get() as any)` ではなく `const { ..., showToast } = get()` パターンに寄せる

## 動作シナリオ

1. タイムラインで既存リンク済みイベントのタイトル変更 → 保存
   → SyncDialog は開かず、プロット側のタイトルが自動更新
   → トースト「プロットボードの N 件のリンクカードのタイトルを同期しました」表示
2. プロットボードで既存リンク済みカードのタイトル変更 → 保存
   → タイムライン側のタイトルが自動更新 + トースト
3. タイトル一致 + summary/description 差異のみの場合
   → 既存通り SyncDialog が開く

## Scope

- `store/dataSlice.ts` (+51 / -19 lines)
- `store/dataSlice.titleSync.test.ts` (新規 +279 lines)

## Codex セカンドオピニオン反映

Codex plan モードでの主要指摘を以下のように反映:

- ✅ `syncLinkedData()` の単方向固定問題 → `handleSaveTimeline` / `handleSavePlotBoard` の内部で source 別に処理を分離（helper export ではなく closure 実装）
- ✅ SyncDialog 廃止リスク → タイトルのみ自動同期に scope 限定、summary は SyncDialog 維持
- ✅ `lastModified` の同期先更新ルール → 更新元と同値にして循環防止
- ✅ `showToast` 型回避は不要 → typed 取得パターンに寄せた

## Test plan

- [x] `npm run lint` PASS
- [x] `npm test` 全 649 件 PASS（新規 9 件追加: 双方向同期 / SyncDialog 経路 / 差分なし / 同一 lastModified / リンクなし / リンク切れ）
- [ ] **マージ後デプロイで Playwright MCP 実機確認**:
  - [ ] タイムラインから「タイムラインに送る」機能でプロットを起点としたリンク済みイベントを 1 件用意（または逆）
  - [ ] タイムライン側でタイトル編集 → 保存 → プロット側のタイトルが同じ値になっていること + トースト表示
  - [ ] プロット側でタイトル編集 → 保存 → タイムライン側のタイトルが同じ値になっていること + トースト表示
  - [ ] タイトル一致のまま description だけ編集 → SyncDialog が開くこと（既存挙動）
  - [ ] リンクされていないイベント/プロットのタイトル変更ではトーストもダイアログも出ないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)