### PR TITLE
feat(ui): ヘルプモーダルの sections をアコーディオン化 (概要を先に読ませる UX 改善)

### DIFF
--- a/components/HelpModals.tsx
+++ b/components/HelpModals.tsx
@@ -485,6 +485,12 @@ AIに一度に書いてもらう長さです。
 
 
 export const HelpModal = ({ isOpen, onClose, topic }) => {
+    const [openIndices, setOpenIndices] = useState<number[]>([]);
+
+    useEffect(() => {
+        setOpenIndices([]);
+    }, [topic]);
+
     if (!isOpen || !topic) return null;
 
     const content = helpContent[topic];
@@ -503,6 +509,12 @@ export const HelpModal = ({ isOpen, onClose, topic }) => {
         );
     }
 
+    const toggleSection = (index: number) => {
+        setOpenIndices(prev =>
+            prev.includes(index) ? prev.filter(i => i !== index) : [...prev, index]
+        );
+    };
+
     return (
         <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex justify-center items-center z-[90]">
             <div className="bg-gray-800 rounded-lg shadow-xl w-full max-w-2xl p-6 border border-gray-700 max-h-[90vh] flex flex-col">
@@ -512,24 +524,41 @@ export const HelpModal = ({ isOpen, onClose, topic }) => {
                 </div>
                 <div className="flex-grow overflow-y-auto pr-2 space-y-6">
                     <p className="text-gray-300">{content.description}</p>
-                    {content.sections.map((section, index) => (
-                        <div key={index} className="border-t border-gray-700 pt-4">
-                            <h3 className="font-semibold text-lg text-lime-400">{section.heading}</h3>
-                            <p className="mt-1 text-sm whitespace-pre-wrap">{section.body}</p>
-                            {section.example && (
-                                <div className="mt-3 p-3 bg-gray-900/50 rounded-md">
-                                    <p className="text-xs text-gray-400 mb-1">文章例：</p>
-                                    <p className="text-sm font-mono italic" dangerouslySetInnerHTML={{ __html: `&quot;${renderMarkdown(section.example)}&quot;` }}></p>
-                                </div>
-                            )}
-                            {section.useCase && (
-                                <div className="mt-3 p-3 bg-gray-900/50 rounded-md">
-                                    <p className="text-xs text-gray-400 mb-1">おすすめの利用シーン：</p>
-                                    <p className="text-sm">{section.useCase}</p>
-                                </div>
-                            )}
-                        </div>
-                    ))}
+                    {content.sections.map((section, index) => {
+                        const isSectionOpen = openIndices.includes(index);
+                        const bodyId = `help-section-body-${index}`;
+                        return (
+                            <div key={index} className="border-t border-gray-700 pt-4">
+                                <button
+                                    type="button"
+                                    onClick={() => toggleSection(index)}
+                                    aria-expanded={isSectionOpen}
+                                    aria-controls={bodyId}
+                                    className="w-full flex justify-between items-center text-left rounded-md py-1 hover:bg-gray-700/30 transition"
+                                >
+                                    <h3 className="font-semibold text-lg text-lime-400">{section.heading}</h3>
+                                    <span aria-hidden="true" className="text-gray-400 text-xl select-none ml-2">{isSectionOpen ? '∧' : '∨'}</span>
+                                </button>
+                                {isSectionOpen && (
+                                    <div id={bodyId} className="mt-2">
+                                        <p className="text-sm whitespace-pre-wrap">{section.body}</p>
+                                        {section.example && (
+                                            <div className="mt-3 p-3 bg-gray-900/50 rounded-md">
+                                                <p className="text-xs text-gray-400 mb-1">文章例：</p>
+                                                <p className="text-sm font-mono italic" dangerouslySetInnerHTML={{ __html: `&quot;${renderMarkdown(section.example)}&quot;` }}></p>
+                                            </div>
+                                        )}
+                                        {section.useCase && (
+                                            <div className="mt-3 p-3 bg-gray-900/50 rounded-md">
+                                                <p className="text-xs text-gray-400 mb-1">おすすめの利用シーン：</p>
+                                                <p className="text-sm">{section.useCase}</p>
+                                            </div>
+                                        )}
+                                    </div>
+                                )}
+                            </div>
+                        );
+                    })}
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary

- ヘルプモーダルの `description` (機能全体の概要) を常時表示のまま、`sections` の各セクションをアコーディオン化
- 初期状態は **全閉じ**、クリック / Space / Enter で開閉、**複数同時開閉可**、topic 切替時に開閉状態リセット
- 共通コンポーネント (`components/HelpModals.tsx` の `HelpModal`) 変更のため **20 種すべてのヘルプモーダル** (AI設定 / キャラクター / 世界観 / プロット / タイムライン / 各 AI 設定項目 perspective/tone/creativity 等) に一括適用

## Motivation

ユーザー要望「ヘルプを開いたとき、機能全体の概要 (description) をまず読んでほしい」。現状は全 sections が縦に並んで表示されており、概要を読まずスクロールしてしまう懸念があった。

## Approach

Codex セカンドオピニオン (`/codex plan` 経由) でレビュー済み。以下の方針で実装:

- `useState<number[]>` で開いているセクション index を管理 (複数同時開閉可)
- セクション heading 行全体を `<button>` でラップし、`aria-expanded` / `aria-controls` を付与 (行全体クリック可能)
- アニメーションなし (Codex 推奨: 高さ計算による不安定さを避ける)
- `useEffect(() => setOpenIndices([]), [topic])` で topic 切替時に開閉状態リセット
- 既存の `description` / `body` / `example` / `useCase` / `renderMarkdown` 経路はそのまま (sanitize 経路維持)

## Before / After

**Before** (全 sections 表示):
```
# AI設定について
AIの挙動やアプリの表示設定を変更するための設定項目です。

# 設定項目
AIの文章生成スタイルや、アプリの表示設定などを細かくカスタマイズできます…

# ピン止め
よく使う設定項目を「クイック設定」に登録できます…
```

**After** (sections アコーディオン化、初期全閉じ):
```
# AI設定について
AIの挙動やアプリの表示設定を変更するための設定項目です。

# 設定項目  ∨
# ピン止め  ∨
```

## Scope

- `components/HelpModals.tsx` 1 ファイル / +47 / -18 行
- `constants.ts` の `helpContent` データ構造は **無修正**
- 外部ライブラリ追加なし

## Test plan

- [x] `npm run lint` PASS (型チェック)
- [x] `npm test` 649 件 ALL PASS (40 test files)
- [x] **ローカル Playwright MCP 実機確認** (http://localhost:3000):
  - [x] 初期状態: 全セクション閉じる + `∨` chevron 表示
  - [x] description (概要) は常時表示
  - [x] クリックで開く (`aria-expanded=true`, body 出現, chevron `∧`)
  - [x] 複数同時開閉: 片方を開いても他のセクションに影響なし
  - [x] 再クリックで閉じる
  - [x] Space キーで開閉
  - [x] Enter キーで開閉
  - [x] topic 切替時 (AI設定について → 文体・視点) に開閉状態がリセットされ全閉じになる
  - [x] Console error: favicon 404 のみ (本件無関係)
- [ ] **マージ後デプロイで本番 Playwright MCP 実機確認**:
  - [ ] AI 設定モーダルの「AI設定について」ヘルプを開いて初期全閉じ + ∨ 確認
  - [ ] セクションクリックで開閉、chevron 切替確認
  - [ ] 他のヘルプモーダル (例: 文体・視点 / トーン&マナー / 創造性のレベル) でも同じ挙動を確認
  - [ ] キャラクター / 世界観 / プロットボード / タイムライン のヘルプも同様に動作確認

## Notes

- `WorldHelpModal.tsx` / `CharacterHelpModal.tsx` は Tab 型で構造が異なり `description` フィールドを持たないため対象外 (既存挙動維持)
- `GeneralHelpModal` (取扱説明書) は別コンポーネントで TOC 型のため対象外
- Codex セカンドオピニオン結果は会話ログに記録済み (`/codex plan` MCP 版)

🤖 Generated with [Claude Code](https://claude.com/claude-code)