### PR TITLE
feat(chapter): chapterId 移行で chapter merge バグを修正 (PR-2/2)

### DIFF
--- a/components/GlobalSearchModal.tsx
+++ b/components/GlobalSearchModal.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useMemo, useEffect, useRef } from 'react';
 import * as Icons from '../icons';
 import { SettingItem, KnowledgeItem, PlotItem, NovelChunk } from '../types';
+import { extractChapterTitle, isChapterTitleChunk } from '../utils';
 
 interface SearchResultItemProps {
     onClick: () => void;
@@ -194,7 +195,7 @@ export const GlobalSearchModal: React.FC<GlobalSearchModalProps> = ({
                                 key={item.id}
                                 onClick={() => onNavigateToChunk(item.id)}
                                 icon={<Icons.FileTextIcon className="h-5 w-5" />}
-                                title={item.text.startsWith('# ') ? item.text.split('\n')[0].substring(2) : `本文スニペット`}
+                                title={isChapterTitleChunk(item) ? extractChapterTitle(item) : `本文スニペット`}
                                 context={item.text}
                                 searchTerm={searchTerm}
                             />

--- a/components/NovelEditor.tsx
+++ b/components/NovelEditor.tsx
@@ -6,6 +6,11 @@ import { EditableParagraph } from './EditableParagraph';
 import { NovelChunk } from '../types';
 import { FONT_MAP, defaultDisplaySettings, EMPTY_ARRAY } from '../constants';
 import { Tooltip } from './Tooltip';
+import {
+    UNCATEGORIZED_CHAPTER_ID,
+    extractChapterTitle,
+    getChapterGroups,
+} from '../utils';
 
 export const NovelEditor: React.FC = () => {
     const activeProjectId = useStore(state => state.activeProjectId);
@@ -82,43 +87,26 @@ export const NovelEditor: React.FC = () => {
         }
     }, [editingChunkId]);
     
+    // chapterId 基準でグループ化 (PR-2 で位置依存ルールから移行)。`chapter-scroll-${groupId}` の anchor は
+     // OutlinePanel の handleChapterJump の対象、id は groupId (= UNCATEGORIZED_CHAPTER_ID か title chunk id)。
     const chapters = useMemo(() => {
         if (!novelContent) return [];
-        const result: { id: string; title: string; memo?: string; chunks: NovelChunk[] }[] = [];
-        let currentChapterChunks: NovelChunk[] = [];
-    
-        const extractTitleFromChunkText = (chunkText: string) => {
-            if (!chunkText.startsWith('# ')) return '';
-            const firstLine = chunkText.split('\n')[0];
-            return firstLine.substring(2).trim();
-        };
-    
-        novelContent.forEach((chunk, index) => {
-            const isTitle = chunk.text.startsWith('# ');
-            if (isTitle) {
-                if (currentChapterChunks.length > 0) {
-                    const firstChunkOfPreviousBlock = currentChapterChunks[0];
-                    const isPreviousBlockTitled = firstChunkOfPreviousBlock.text.startsWith('# ');
-    
-                    if (isPreviousBlockTitled) {
-                        result.push({ id: `chapter-${firstChunkOfPreviousBlock.id}-${index}`, title: extractTitleFromChunkText(firstChunkOfPreviousBlock.text) || '無題の章', memo: firstChunkOfPreviousBlock.memo, chunks: currentChapterChunks });
-                    } else {
-                        result.push({ id: `chapter-${firstChunkOfPreviousBlock.id}-${index}`, title: '章に属さない文章', chunks: currentChapterChunks });
-                    }
-                }
-                currentChapterChunks = [chunk];
-            } else {
-                currentChapterChunks.push(chunk);
+        return getChapterGroups(novelContent).map(group => {
+            if (group.kind === 'uncategorized') {
+                return {
+                    id: UNCATEGORIZED_CHAPTER_ID,
+                    title: '章に属さない文章',
+                    memo: undefined as string | undefined,
+                    chunks: group.chunks,
+                };
             }
+            return {
+                id: group.groupId,
+                title: extractChapterTitle(group.titleChunk) || '無題の章',
+                memo: group.titleChunk.memo,
+                chunks: group.chunks,
+            };
         });
-    
-        if (currentChapterChunks.length > 0) {
-            const firstChunk = currentChapterChunks[0];
-            const isTitled = firstChunk.text.startsWith('# ');
-            result.push({ id: `chapter-${firstChunk.id}-${novelContent.length}`, title: isTitled ? (extractTitleFromChunkText(firstChunk.text) || '無題の章') : '章に属さない文章', memo: isTitled ? firstChunk.memo : undefined, chunks: currentChapterChunks });
-        }
-    
-        return result;
     }, [novelContent]);
 
     const handleNewChunkKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {

--- a/components/panels/OutlinePanel.tsx
+++ b/components/panels/OutlinePanel.tsx
@@ -2,7 +2,11 @@
 import React, { useMemo, useState } from 'react';
 import * as Icons from '../../icons';
 import { useStore } from '../../store/index';
-import { NovelChunk } from '../../types';
+import {
+    UNCATEGORIZED_CHAPTER_ID,
+    extractChapterTitle,
+    getChapterGroups,
+} from '../../utils';
 
 const EMPTY_ARRAY: any[] = [];
 
@@ -19,29 +23,27 @@ export const OutlinePanel = ({ isFloating = false, isMobile = false }) => {
     const setIsLeftSidebarOpen = useStore(state => state.setIsLeftSidebarOpen);
 
     const [deletingChapterId, setDeletingChapterId] = useState<string | null>(null);
-    
+
+    // 章一覧は chapterId 基準で集約。drag/drop の id も groupId (= UNCATEGORIZED_CHAPTER_ID か
+    // title chunk id) を使い、chunk id とは区別する。
     const chapters = useMemo(() => {
         if (!novelContent) return [];
-        
-        return novelContent
-            .filter((chunk, index) => {
-                const isTitle = chunk.text.startsWith('# ');
-                const isFirstChunkAndNotTitle = index === 0 && !isTitle;
-                return isTitle || isFirstChunkAndNotTitle;
-            })
-            .map(chunk => {
-                const isUncategorized = !chunk.text.startsWith('# ');
-                const title = isUncategorized 
-                    ? '章に属さない文章' 
-                    : chunk.text.split('\n')[0].substring(2).trim() || '無題の章';
-                
+        return getChapterGroups(novelContent).map(group => {
+            if (group.kind === 'uncategorized') {
                 return {
-                    id: chunk.id,
-                    title: title,
-                    memo: isUncategorized ? undefined : chunk.memo,
-                    isUncategorized: isUncategorized
+                    id: UNCATEGORIZED_CHAPTER_ID,
+                    title: '章に属さない文章',
+                    memo: undefined as string | undefined,
+                    isUncategorized: true,
                 };
-            });
+            }
+            return {
+                id: group.groupId,
+                title: extractChapterTitle(group.titleChunk) || '無題の章',
+                memo: group.titleChunk.memo,
+                isUncategorized: false,
+            };
+        });
     }, [novelContent]);
 
     const handleChapterJump = (chapterId: string) => {
@@ -52,7 +54,7 @@ export const OutlinePanel = ({ isFloating = false, isMobile = false }) => {
     const handleOpenChapterSettings = (chapter: { id: string; title: string; memo?: string; isUncategorized: boolean }) => {
         openModal('chapterSettings', { id: chapter.id, title: chapter.title, memo: chapter.memo || '', isUncategorized: chapter.isUncategorized });
     };
-    
+
     const handleChapterDragStart = (e: React.DragEvent<HTMLDivElement>, chapterId: string) => {
         if (isMobile) return; // Mobile drag is not supported via HTML5 API
         useStore.setState({ draggedChapterId: chapterId });
@@ -64,21 +66,21 @@ export const OutlinePanel = ({ isFloating = false, isMobile = false }) => {
     };
 
     const handleChapterDragOver = (e: React.DragEvent<HTMLDivElement>) => e.preventDefault();
-    const handleChapterDragEnter = (e: React.DragEvent<HTMLDivElement>, chapterId: string) => { 
+    const handleChapterDragEnter = (e: React.DragEvent<HTMLDivElement>, chapterId: string) => {
         if (isMobile) return;
         if (draggedChapterId && draggedChapterId !== chapterId) {
             useStore.setState({ dropTargetId: chapterId });
         }
     };
-    
-    const onChapterDrop = (e: React.DragEvent<HTMLDivElement>, dropOnChapterId: string) => { 
-        e.preventDefault(); 
+
+    const onChapterDrop = (e: React.DragEvent<HTMLDivElement>, dropOnChapterId: string) => {
+        e.preventDefault();
         if (isMobile) return;
-        if (!draggedChapterId || draggedChapterId === dropOnChapterId) { 
-            useStore.setState({ dropTargetId: null }); 
-            return; 
-        } 
-        handleChapterDrop(dropOnChapterId); 
+        if (!draggedChapterId || draggedChapterId === dropOnChapterId) {
+            useStore.setState({ dropTargetId: null });
+            return;
+        }
+        handleChapterDrop(dropOnChapterId);
     };
     
     const handleChapterDragEnd = () => { 

--- a/store/aiSlice.continuation.test.ts
+++ b/store/aiSlice.continuation.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../novelApi', () => ({
+    generateNovelContinuation: vi.fn(),
+}));
+vi.mock('../utilityApi', () => ({
+    extractCharacterInfo: vi.fn(),
+}));
+
+import { createAiSlice } from './aiSlice';
+import { normalizeChapterIds, __resetChapterIdWarnState } from '../utils';
+import type { Project, NovelChunk } from '../types';
+
+// PR-2 F-E: aiSlice の chapterId 継承 (R2 + title invariant) の wiring guard。
+// handleAdoptContinuation が呼ばれたとき、新規追加 chunk の chapterId が
+// assignChapterIdForAppend 経由で正しく決まることを pin する。
+
+beforeEach(() => {
+    __resetChapterIdWarnState();
+});
+
+const baseProject = (novelContent: NovelChunk[] = []): Project => ({
+    id: 'p-1',
+    name: 'P',
+    lastModified: new Date(0).toISOString(),
+    settings: [],
+    novelContent,
+    chatHistory: [],
+    knowledgeBase: [],
+    plotBoard: [],
+    plotTypeColors: {},
+    plotRelations: [],
+    plotNodePositions: [],
+    timeline: [],
+    timelineLanes: [],
+    characterRelations: [],
+    nodePositions: [],
+    aiSettings: {} as Project['aiSettings'],
+    displaySettings: {} as Project['displaySettings'],
+});
+
+const mkChunk = (id: string, text: string): NovelChunk => ({ id, text });
+
+interface FakeStore {
+    state: Record<string, any>;
+    set: (partial: any) => void;
+    get: () => Record<string, any>;
+}
+
+const createFakeStore = (initial: Record<string, any>): FakeStore => {
+    const fake: FakeStore = { state: { ...initial }, set: () => ({}), get: () => fake.state };
+    fake.set = (partial: any) => {
+        const next = typeof partial === 'function' ? partial(fake.state) : partial;
+        fake.state = { ...fake.state, ...next };
+    };
+    fake.get = () => fake.state;
+    return fake;
+};
+
+const mountSlice = (project: Project) => {
+    const fake = createFakeStore({});
+    const slice = createAiSlice(fake.set, fake.get);
+    let capturedUpdater: ((d: Project) => Project) | null = null;
+    fake.state = {
+        ...slice,
+        activeProjectId: 'p-1',
+        allProjectsData: { 'p-1': project },
+        openModal: vi.fn(),
+        closeModal: vi.fn(),
+        showToast: vi.fn(),
+        addHistory: vi.fn(),
+        markDirty: vi.fn(),
+        setActiveProjectData: (updater: (d: Project) => Project) => {
+            capturedUpdater = updater;
+        },
+    };
+    return { slice, fake, getUpdated: () => capturedUpdater!(project) };
+};
+
+describe('handleAdoptContinuation (R2 + F-A title invariant)', () => {
+    it('採用テキストが body chunk なら最終章の chapterId を継承する (R2)', () => {
+        const content = normalizeChapterIds([
+            mkChunk('A', '# 第1章'),
+            mkChunk('B', '第1章本文'),
+        ]);
+        const project = baseProject(content);
+        const { slice, getUpdated } = mountSlice(project);
+
+        slice.handleAdoptContinuation('AIが生成した続きの本文');
+
+        const updated = getUpdated();
+        expect(updated.novelContent).toHaveLength(3);
+        const appended = updated.novelContent[2];
+        expect(appended.text).toBe('AIが生成した続きの本文');
+        expect(appended.chapterId).toBe('A'); // 末尾 chunk B の chapterId === 'A' を継承
+    });
+
+    it('採用テキストが `# 第2章` で始まる title chunk なら self.id (F-A)', () => {
+        const content = normalizeChapterIds([
+            mkChunk('A', '# 第1章'),
+            mkChunk('B', '第1章本文'),
+        ]);
+        const project = baseProject(content);
+        const { slice, getUpdated } = mountSlice(project);
+
+        slice.handleAdoptContinuation('# 第2章');
+
+        const updated = getUpdated();
+        const appended = updated.novelContent[updated.novelContent.length - 1];
+        expect(appended.text).toBe('# 第2章');
+        expect(appended.chapterId).toBe(appended.id); // F-A: title invariant
+    });
+
+    it('空 novel に採用すると chapterId === null (uncategorized)', () => {
+        const project = baseProject([]);
+        const { slice, getUpdated } = mountSlice(project);
+
+        slice.handleAdoptContinuation('最初の本文');
+
+        const updated = getUpdated();
+        expect(updated.novelContent[0].chapterId).toBe(null);
+    });
+
+    it('空 novel + title chunk 採用は self.id (uncategorized append にしない)', () => {
+        const project = baseProject([]);
+        const { slice, getUpdated } = mountSlice(project);
+
+        slice.handleAdoptContinuation('# はじめての章');
+
+        const updated = getUpdated();
+        const appended = updated.novelContent[0];
+        expect(appended.chapterId).toBe(appended.id);
+    });
+
+    it('末尾が uncategorized chunk のとき body 採用は null 継承', () => {
+        const content = normalizeChapterIds([mkChunk('A', '本文')]);
+        const project = baseProject(content);
+        const { slice, getUpdated } = mountSlice(project);
+
+        slice.handleAdoptContinuation('続きの本文');
+
+        const updated = getUpdated();
+        expect(updated.novelContent[updated.novelContent.length - 1].chapterId).toBe(null);
+    });
+});

--- a/store/aiSlice.ts
+++ b/store/aiSlice.ts
@@ -2,6 +2,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { AppState, ChatMessage, NovelChunk, PlotItem, SettingItem } from '../types';
 import * as novelApi from '../novelApi';
 import * as utilityApi from '../utilityApi';
+import { getChapterIdForNewChunk } from '../utils';
 
 const initialState = {
     userInput: '',
@@ -141,8 +142,11 @@ export const createAiSlice = (set, get): AiSlice => ({
         setActiveProjectData(d => {
             let finalNovelContent = d.novelContent;
             if (newChunk) {
-                finalNovelContent = [...d.novelContent, newChunk];
-                set({ highlightedChunkId: newChunk.id });
+                // R2: 末尾追加は最終章配下に継承
+                const chapterId = getChapterIdForNewChunk(d.novelContent);
+                const taggedChunk: NovelChunk = { ...newChunk, chapterId };
+                finalNovelContent = [...d.novelContent, taggedChunk];
+                set({ highlightedChunkId: taggedChunk.id });
             }
             return { ...d, chatHistory: [...d.chatHistory, assistantMessage], novelContent: finalNovelContent, lastModified: new Date().toISOString() };
         }, { type: 'ai', label: 'AIからの返答' });
@@ -154,9 +158,14 @@ export const createAiSlice = (set, get): AiSlice => ({
         set({ aiSuggestions: filteredSuggestions });
     },
     handleAdoptContinuation: (text) => {
-        const newChunk: NovelChunk = { id: uuidv4(), text };
-        get().setActiveProjectData(d => ({ ...d, novelContent: [...d.novelContent, newChunk], lastModified: new Date().toISOString() }), { type: 'editor', label: 'AIの提案を採用' });
-        set({ continuationChoices: null, highlightedChunkId: newChunk.id });
+        const newChunkId = uuidv4();
+        get().setActiveProjectData(d => {
+            // R2: 末尾追加は最終章配下に継承
+            const chapterId = getChapterIdForNewChunk(d.novelContent);
+            const newChunk: NovelChunk = { id: newChunkId, text, chapterId };
+            return { ...d, novelContent: [...d.novelContent, newChunk], lastModified: new Date().toISOString() };
+        }, { type: 'editor', label: 'AIの提案を採用' });
+        set({ continuationChoices: null, highlightedChunkId: newChunkId });
     },
     handleRejectContinuation: (id) => {
         set(state => ({

--- a/store/aiSlice.ts
+++ b/store/aiSlice.ts
@@ -2,7 +2,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { AppState, ChatMessage, NovelChunk, PlotItem, SettingItem } from '../types';
 import * as novelApi from '../novelApi';
 import * as utilityApi from '../utilityApi';
-import { getChapterIdForNewChunk } from '../utils';
+import { assignChapterIdForAppend } from '../utils';
 
 const initialState = {
     userInput: '',
@@ -142,8 +142,9 @@ export const createAiSlice = (set, get): AiSlice => ({
         setActiveProjectData(d => {
             let finalNovelContent = d.novelContent;
             if (newChunk) {
-                // R2: 末尾追加は最終章配下に継承
-                const chapterId = getChapterIdForNewChunk(d.novelContent);
+                // R2: 末尾追加は最終章配下に継承。AI が `# 章名` で始まる本文を返した場合は
+                // assignChapterIdForAppend が self.id を割り当てて title invariant を維持する。
+                const chapterId = assignChapterIdForAppend(d.novelContent, newChunk);
                 const taggedChunk: NovelChunk = { ...newChunk, chapterId };
                 finalNovelContent = [...d.novelContent, taggedChunk];
                 set({ highlightedChunkId: taggedChunk.id });
@@ -160,9 +161,10 @@ export const createAiSlice = (set, get): AiSlice => ({
     handleAdoptContinuation: (text) => {
         const newChunkId = uuidv4();
         get().setActiveProjectData(d => {
-            // R2: 末尾追加は最終章配下に継承
-            const chapterId = getChapterIdForNewChunk(d.novelContent);
-            const newChunk: NovelChunk = { id: newChunkId, text, chapterId };
+            // R2 + title invariant: assignChapterIdForAppend が `# ` 始まりなら self.id を返す
+            const draft: NovelChunk = { id: newChunkId, text };
+            const chapterId = assignChapterIdForAppend(d.novelContent, draft);
+            const newChunk: NovelChunk = { ...draft, chapterId };
             return { ...d, novelContent: [...d.novelContent, newChunk], lastModified: new Date().toISOString() };
         }, { type: 'editor', label: 'AIの提案を採用' });
         set({ continuationChoices: null, highlightedChunkId: newChunkId });

--- a/store/dataSlice.chapterDrop.test.ts
+++ b/store/dataSlice.chapterDrop.test.ts
@@ -288,11 +288,13 @@ describe('addChapter / handleAddNewChunk (AC-8: chapterId assignment on new chun
 });
 
 describe('handleNovelTextChange (AC-9: R1 sync — # add/remove updates chapterId)', () => {
-    it('adding "# " to a body chunk promotes it to a title chunk (chapterId = self.id)', () => {
+    it('adding "# " to a body chunk promotes it AND re-tags following same-chapter chunks (F-B)', () => {
+        // F-B: body→title 昇格時、編集 chunk 以降、次の title 直前までの同 chapterId chunks を
+        // 新 title 配下に取り込む (group 連続性 invariant 維持)
         const content = normalizeChapterIds([
-            mkChunk('A', '本文1'),
-            mkChunk('B', '本文2'), // about to become title
-            mkChunk('C', '本文3'),
+            mkChunk('A', '本文1'),         // chapterId=null
+            mkChunk('B', '本文2'),         // chapterId=null、これを title 化
+            mkChunk('C', '本文3'),         // chapterId=null (B と同じ章だったので B に取り込まれる)
         ]);
         const project = baseProject(content);
         const { slice, getUpdated } = mountSlice(project);
@@ -303,16 +305,35 @@ describe('handleNovelTextChange (AC-9: R1 sync — # add/remove updates chapterI
         const b = updated.novelContent.find(c => c.id === 'B')!;
         expect(b.text).toBe('# 第1章');
         expect(b.chapterId).toBe('B');
-        // A は元の chapterId を保持 (uncategorized)
-        expect(updated.novelContent.find(c => c.id === 'A')?.chapterId).toBe(null);
-        // C は uncategorized のまま (R1 sync は当該 chunk のみ昇格、後続を再 tag しない)
-        expect(updated.novelContent.find(c => c.id === 'C')?.chapterId).toBe(null);
+        expect(updated.novelContent.find(c => c.id === 'A')?.chapterId).toBe(null); // 前は touch しない
+        expect(updated.novelContent.find(c => c.id === 'C')?.chapterId).toBe('B'); // F-B: 後続が新章に取り込まれる
+    });
+
+    it('body→title 昇格は次の title chunk 直前で停止し、それ以降の章は触らない (F-B 境界)', () => {
+        const content = normalizeChapterIds([
+            mkChunk('A', '本文1'),         // null、編集対象に取り込まれる
+            mkChunk('B', '本文2'),         // null、これを title 化
+            mkChunk('C', '本文3'),         // null → B 配下
+            mkChunk('D', '# 既存章'),       // 境界、ここで stop
+            mkChunk('E', '既存章本文'),   // 元から D 配下、触らない
+        ]);
+        const project = baseProject(content);
+        const { slice, getUpdated } = mountSlice(project);
+
+        slice.handleNovelTextChange('B', '# 新章');
+
+        const updated = getUpdated();
+        expect(updated.novelContent.find(c => c.id === 'A')?.chapterId).toBe(null); // 前 chunk
+        expect(updated.novelContent.find(c => c.id === 'B')?.chapterId).toBe('B'); // self
+        expect(updated.novelContent.find(c => c.id === 'C')?.chapterId).toBe('B'); // F-B: 取り込み
+        expect(updated.novelContent.find(c => c.id === 'D')?.chapterId).toBe('D'); // 境界、不変
+        expect(updated.novelContent.find(c => c.id === 'E')?.chapterId).toBe('D'); // 触らない
     });
 
     it('removing "# " from a title chunk demotes it (chapterId inherited from previous chunk)', () => {
         const content = normalizeChapterIds([
             mkChunk('A', '本文'),
-            mkChunk('B', '# 第1章'), // about to lose title status
+            mkChunk('B', '# 第1章'),
             mkChunk('C', '第1章本文'),
         ]);
         const project = baseProject(content);
@@ -323,14 +344,11 @@ describe('handleNovelTextChange (AC-9: R1 sync — # add/remove updates chapterI
         const updated = getUpdated();
         const b = updated.novelContent.find(c => c.id === 'B')!;
         expect(b.text).toBe('もう章じゃない');
-        // B は A の chapterId (null) を継承
         expect(b.chapterId).toBe(null);
-        // C も B (= null) を継承して uncategorized になる
         expect(updated.novelContent.find(c => c.id === 'C')?.chapterId).toBe(null);
     });
 
     it('body→body edits do NOT trigger normalize (perf optimization)', () => {
-        // normalize が走ると warnedKeys が消費される (テスト用の副次効果)。代わりに chapterId 不変を確認。
         const content = normalizeChapterIds([
             mkChunk('A', '本文1'),
             mkChunk('B', '本文2'),
@@ -342,8 +360,58 @@ describe('handleNovelTextChange (AC-9: R1 sync — # add/remove updates chapterI
 
         const updated = getUpdated();
         expect(updated.novelContent.find(c => c.id === 'A')?.text).toBe('本文1 編集後');
-        // chapterId 不変 (normalize skip 経路)
         expect(updated.novelContent.find(c => c.id === 'A')?.chapterId).toBe(null);
         expect(updated.novelContent.find(c => c.id === 'B')?.chapterId).toBe(null);
+    });
+
+    it('!oldChunk 経路: 存在しない chunkId への onChange は state を変えず dev warn を出す (F-C: data loss 防止)', () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const content = normalizeChapterIds([mkChunk('A', '本文')]);
+        const project = baseProject(content);
+        const { slice, getUpdated } = mountSlice(project);
+
+        slice.handleNovelTextChange('GHOST', 'lost text');
+        const updated = getUpdated(); // updater を起動して warn 経路を実行 + 戻り値を確認
+
+        // updater は d をそのまま返す = state 不変
+        expect(updated.novelContent).toHaveLength(1);
+        expect(updated.novelContent[0].text).toBe('本文');
+        // paired signal: dev warn が text 喪失を可視化
+        expect(warn).toHaveBeenCalledWith(
+            expect.stringContaining('text 喪失リスク'),
+            expect.objectContaining({ chunkId: 'GHOST' }),
+        );
+        warn.mockRestore();
+    });
+});
+
+describe('handleAddNewChunk title invariant (F-A: # 始まりは self.id)', () => {
+    it('直接入力で `# 第2章\\n\\n本文` を一度に追加すると title chunk は self.id、後続 body は新章配下に入る', () => {
+        const content = normalizeChapterIds([mkChunk('A', '# 第1章'), mkChunk('B', '本文')]);
+        const project = baseProject(content);
+        const { slice, getUpdated } = mountSlice(project, { newChunkText: '# 第2章\n\n第2章の本文' });
+
+        slice.handleAddNewChunk();
+
+        const updated = getUpdated();
+        expect(updated.novelContent).toHaveLength(4);
+        const newTitle = updated.novelContent[2];
+        const newBody = updated.novelContent[3];
+        expect(newTitle.text).toBe('# 第2章');
+        expect(newTitle.chapterId).toBe(newTitle.id); // F-A: title chunk は self.id
+        expect(newBody.text).toBe('第2章の本文');
+        expect(newBody.chapterId).toBe(newTitle.id); // 直前 chunk (= 新 title) を継承
+    });
+
+    it('直接入力が title 単独 (`# 第2章` のみ) でも self.id', () => {
+        const content = normalizeChapterIds([mkChunk('A', '# 第1章'), mkChunk('B', '本文')]);
+        const project = baseProject(content);
+        const { slice, getUpdated } = mountSlice(project, { newChunkText: '# 第2章' });
+
+        slice.handleAddNewChunk();
+
+        const updated = getUpdated();
+        const last = updated.novelContent[updated.novelContent.length - 1];
+        expect(last.chapterId).toBe(last.id);
     });
 });

--- a/store/dataSlice.chapterDrop.test.ts
+++ b/store/dataSlice.chapterDrop.test.ts
@@ -1,0 +1,349 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../analysisApi', () => ({
+    analyzeText: vi.fn(),
+}));
+
+import { createDataSlice } from './dataSlice';
+import { normalizeChapterIds, UNCATEGORIZED_CHAPTER_ID, __resetChapterIdWarnState } from '../utils';
+import type { Project, NovelChunk } from '../types';
+
+// PR-2 (chapterId 移行): handleChapterDrop / handleSaveChapterSettings / handleDeleteChapter /
+// addChapter / handleAddNewChunk / handleNovelTextChange の挙動を pin する。
+// AC-1 (バグ修正本丸) / AC-2 (逆方向) / AC-6 (削除範囲) / AC-7 (昇格時 chapterId 一括) /
+// AC-8 (末尾 append → 最終章) / AC-9 (R1 sync) を網羅。
+
+beforeEach(() => {
+    __resetChapterIdWarnState();
+});
+
+const baseProject = (novelContent: NovelChunk[] = []): Project => ({
+    id: 'p-1',
+    name: 'P',
+    lastModified: new Date(0).toISOString(),
+    settings: [],
+    novelContent,
+    chatHistory: [],
+    knowledgeBase: [],
+    plotBoard: [],
+    plotTypeColors: {},
+    plotRelations: [],
+    plotNodePositions: [],
+    timeline: [],
+    timelineLanes: [],
+    characterRelations: [],
+    nodePositions: [],
+    aiSettings: {} as Project['aiSettings'],
+    displaySettings: {} as Project['displaySettings'],
+});
+
+interface FakeStore {
+    state: Record<string, any>;
+    set: (partial: any) => void;
+    get: () => Record<string, any>;
+}
+
+const createFakeStore = (initial: Record<string, any>): FakeStore => {
+    const fake: FakeStore = { state: { ...initial }, set: () => ({}), get: () => fake.state };
+    fake.set = (partial: any) => {
+        const next = typeof partial === 'function' ? partial(fake.state) : partial;
+        fake.state = { ...fake.state, ...next };
+    };
+    fake.get = () => fake.state;
+    return fake;
+};
+
+const mountSlice = (project: Project, extraState: Record<string, any> = {}) => {
+    const fake = createFakeStore({});
+    const slice = createDataSlice(fake.set, fake.get);
+    let capturedUpdater: ((d: Project) => Project) | null = null;
+    fake.state = {
+        ...slice,
+        activeProjectId: 'p-1',
+        allProjectsData: { 'p-1': project },
+        openModal: vi.fn(),
+        closeModal: vi.fn(),
+        showToast: vi.fn(),
+        addHistory: vi.fn(),
+        markDirty: vi.fn(),
+        setActiveProjectData: (updater: (d: Project) => Project) => {
+            capturedUpdater = updater;
+        },
+        ...extraState,
+    };
+    return { slice, fake, getUpdated: () => capturedUpdater!(project) };
+};
+
+const mkChunk = (id: string, text: string, chapterIdOverride?: string | null): NovelChunk => ({
+    id,
+    text,
+    ...(chapterIdOverride !== undefined ? { chapterId: chapterIdOverride } : {}),
+});
+
+describe('handleChapterDrop (AC-1, AC-2: uncategorized chunks are not absorbed by named chapter on drag)', () => {
+    it('AC-1: drag 名前付き章 ONTO uncategorized → uncategorized chunks の chapterId は null のまま', () => {
+        const content = normalizeChapterIds([
+            mkChunk('A', '本文A'),         // uncategorized
+            mkChunk('B', '# 第1章'),       // title
+            mkChunk('C', '第1章本文'),    // body of 第1章
+        ]);
+        const project = baseProject(content);
+        const { slice, getUpdated } = mountSlice(project, { draggedChapterId: 'B' });
+
+        // drop 第1章 onto uncategorized group
+        slice.handleChapterDrop(UNCATEGORIZED_CHAPTER_ID);
+
+        const updated = getUpdated();
+        // 配列順は変わったが chunk A の chapterId は null のまま (バグ修正本丸)
+        expect(updated.novelContent.map(c => ({ id: c.id, chapterId: c.chapterId }))).toEqual([
+            { id: 'B', chapterId: 'B' },
+            { id: 'C', chapterId: 'B' },
+            { id: 'A', chapterId: null },
+        ]);
+    });
+
+    it('AC-2: drag uncategorized ONTO 第2章 → uncategorized chunks の chapterId は null のまま', () => {
+        const content = normalizeChapterIds([
+            mkChunk('A', '本文A'),
+            mkChunk('B', '# 第1章'),
+            mkChunk('C', '第1章本文'),
+            mkChunk('D', '# 第2章'),
+            mkChunk('E', '第2章本文'),
+        ]);
+        const project = baseProject(content);
+        const { slice, getUpdated } = mountSlice(project, { draggedChapterId: UNCATEGORIZED_CHAPTER_ID });
+
+        slice.handleChapterDrop('D');
+
+        const updated = getUpdated();
+        // A は配列上 D の前に入っているが chapterId は null 維持
+        expect(updated.novelContent.map(c => ({ id: c.id, chapterId: c.chapterId }))).toEqual([
+            { id: 'B', chapterId: 'B' },
+            { id: 'C', chapterId: 'B' },
+            { id: 'A', chapterId: null },
+            { id: 'D', chapterId: 'D' },
+            { id: 'E', chapterId: 'D' },
+        ]);
+    });
+
+    it('drag 第2章 ONTO 第1章 → 第2章 chunks が第1章の前に移動、chapterId は維持', () => {
+        const content = normalizeChapterIds([
+            mkChunk('A', '# 第1章'),
+            mkChunk('B', '第1章本文'),
+            mkChunk('C', '# 第2章'),
+            mkChunk('D', '第2章本文'),
+        ]);
+        const project = baseProject(content);
+        const { slice, getUpdated } = mountSlice(project, { draggedChapterId: 'C' });
+
+        slice.handleChapterDrop('A');
+
+        const updated = getUpdated();
+        expect(updated.novelContent.map(c => c.id)).toEqual(['C', 'D', 'A', 'B']);
+        expect(updated.novelContent.find(c => c.id === 'D')?.chapterId).toBe('C');
+        expect(updated.novelContent.find(c => c.id === 'B')?.chapterId).toBe('A');
+    });
+
+    it('drag same group on itself → no-op', () => {
+        const content = normalizeChapterIds([mkChunk('A', '# 第1章'), mkChunk('B', '本文')]);
+        const project = baseProject(content);
+        const { slice, fake } = mountSlice(project, { draggedChapterId: 'A' });
+        const before = JSON.stringify(fake.state.allProjectsData['p-1'].novelContent);
+        slice.handleChapterDrop('A');
+        const after = JSON.stringify(fake.state.allProjectsData['p-1'].novelContent);
+        expect(after).toBe(before);
+    });
+});
+
+describe('handleDeleteChapter (AC-6: deletion limited to chapterId range)', () => {
+    it('deletes only chunks belonging to the target chapterId group', () => {
+        const content = normalizeChapterIds([
+            mkChunk('A', '本文A'),
+            mkChunk('B', '# 第1章'),
+            mkChunk('C', '第1章本文'),
+            mkChunk('D', '# 第2章'),
+            mkChunk('E', '第2章本文'),
+        ]);
+        const project = baseProject(content);
+        const { slice, getUpdated } = mountSlice(project);
+
+        slice.handleDeleteChapter('B'); // delete 第1章 group
+
+        const updated = getUpdated();
+        expect(updated.novelContent.map(c => c.id)).toEqual(['A', 'D', 'E']);
+        expect(updated.novelContent.find(c => c.id === 'A')?.chapterId).toBe(null);
+        expect(updated.novelContent.find(c => c.id === 'D')?.chapterId).toBe('D');
+    });
+
+    it('handler accepts UNCATEGORIZED_CHAPTER_ID even though UI hides the delete button for it', () => {
+        const content = normalizeChapterIds([
+            mkChunk('A', '本文A'),
+            mkChunk('B', '# 第1章'),
+        ]);
+        const project = baseProject(content);
+        const { slice, getUpdated } = mountSlice(project);
+
+        slice.handleDeleteChapter(UNCATEGORIZED_CHAPTER_ID);
+
+        const updated = getUpdated();
+        expect(updated.novelContent.map(c => c.id)).toEqual(['B']);
+    });
+
+    it('no-op when groupId is unknown', () => {
+        const content = normalizeChapterIds([mkChunk('A', '# 第1章')]);
+        const project = baseProject(content);
+        const { slice, fake } = mountSlice(project);
+
+        slice.handleDeleteChapter('GHOST');
+
+        // setActiveProjectData が呼ばれないので fake.state は不変
+        expect(fake.state.allProjectsData['p-1'].novelContent).toHaveLength(1);
+    });
+});
+
+describe('handleSaveChapterSettings (AC-7: uncategorized → named promotion sets chapterId on all uncategorized chunks)', () => {
+    it('inserts a new title chunk and re-tags all chapterId=null chunks with the new title chunk id', () => {
+        const content = normalizeChapterIds([
+            mkChunk('A', '本文A'),
+            mkChunk('B', '本文B'),
+            mkChunk('C', '# 既存章'),
+            mkChunk('D', '既存章本文'),
+        ]);
+        const project = baseProject(content);
+        const { slice, getUpdated } = mountSlice(project);
+
+        slice.handleSaveChapterSettings({ id: UNCATEGORIZED_CHAPTER_ID, newTitle: '新章', newMemo: 'メモ', isUncategorized: true });
+
+        const updated = getUpdated();
+        // 新 title chunk が最初の uncategorized chunk の位置に挿入される
+        expect(updated.novelContent[0].text).toBe('# 新章');
+        expect(updated.novelContent[0].chapterId).toBe(updated.novelContent[0].id);
+        // 元 uncategorized chunks (A, B) は新 title chunk の id を継承
+        const newId = updated.novelContent[0].id;
+        expect(updated.novelContent[1].id).toBe('A');
+        expect(updated.novelContent[1].chapterId).toBe(newId);
+        expect(updated.novelContent[2].id).toBe('B');
+        expect(updated.novelContent[2].chapterId).toBe(newId);
+        // 既存章は不変
+        expect(updated.novelContent.find(c => c.id === 'C')?.chapterId).toBe('C');
+        expect(updated.novelContent.find(c => c.id === 'D')?.chapterId).toBe('C');
+    });
+
+    it('renaming an existing named chapter does NOT change chapterId', () => {
+        const content = normalizeChapterIds([
+            mkChunk('A', '# 旧名'),
+            mkChunk('B', '本文'),
+        ]);
+        const project = baseProject(content);
+        const { slice, getUpdated } = mountSlice(project);
+
+        slice.handleSaveChapterSettings({ id: 'A', newTitle: '新名', newMemo: 'メモ', isUncategorized: false });
+
+        const updated = getUpdated();
+        expect(updated.novelContent[0].text).toBe('# 新名');
+        expect(updated.novelContent[0].chapterId).toBe('A');
+        expect(updated.novelContent[1].chapterId).toBe('A');
+    });
+});
+
+describe('addChapter / handleAddNewChunk (AC-8: chapterId assignment on new chunks)', () => {
+    it('addChapter assigns chapterId === self.id on the new title chunk', () => {
+        const project = baseProject([]);
+        const { slice, getUpdated } = mountSlice(project);
+
+        slice.addChapter();
+
+        const updated = getUpdated();
+        expect(updated.novelContent).toHaveLength(1);
+        const created = updated.novelContent[0];
+        expect(created.text).toBe('# 無題の章');
+        expect(created.chapterId).toBe(created.id);
+    });
+
+    it('handleAddNewChunk inherits chapterId from the last chunk (R2: last-chapter append)', () => {
+        const content = normalizeChapterIds([
+            mkChunk('A', '# 第1章'),
+            mkChunk('B', '本文'),
+        ]);
+        const project = baseProject(content);
+        const { slice, getUpdated } = mountSlice(project, { newChunkText: '新しい段落' });
+
+        slice.handleAddNewChunk();
+
+        const updated = getUpdated();
+        expect(updated.novelContent).toHaveLength(3);
+        // 末尾 chunk が 'A' の chapterId を継承
+        expect(updated.novelContent[2].chapterId).toBe('A');
+    });
+
+    it('handleAddNewChunk on an empty novel assigns chapterId=null', () => {
+        const project = baseProject([]);
+        const { slice, getUpdated } = mountSlice(project, { newChunkText: '初めての段落' });
+
+        slice.handleAddNewChunk();
+
+        const updated = getUpdated();
+        expect(updated.novelContent[0].chapterId).toBe(null);
+    });
+});
+
+describe('handleNovelTextChange (AC-9: R1 sync — # add/remove updates chapterId)', () => {
+    it('adding "# " to a body chunk promotes it to a title chunk (chapterId = self.id)', () => {
+        const content = normalizeChapterIds([
+            mkChunk('A', '本文1'),
+            mkChunk('B', '本文2'), // about to become title
+            mkChunk('C', '本文3'),
+        ]);
+        const project = baseProject(content);
+        const { slice, getUpdated } = mountSlice(project);
+
+        slice.handleNovelTextChange('B', '# 第1章');
+
+        const updated = getUpdated();
+        const b = updated.novelContent.find(c => c.id === 'B')!;
+        expect(b.text).toBe('# 第1章');
+        expect(b.chapterId).toBe('B');
+        // A は元の chapterId を保持 (uncategorized)
+        expect(updated.novelContent.find(c => c.id === 'A')?.chapterId).toBe(null);
+        // C は uncategorized のまま (R1 sync は当該 chunk のみ昇格、後続を再 tag しない)
+        expect(updated.novelContent.find(c => c.id === 'C')?.chapterId).toBe(null);
+    });
+
+    it('removing "# " from a title chunk demotes it (chapterId inherited from previous chunk)', () => {
+        const content = normalizeChapterIds([
+            mkChunk('A', '本文'),
+            mkChunk('B', '# 第1章'), // about to lose title status
+            mkChunk('C', '第1章本文'),
+        ]);
+        const project = baseProject(content);
+        const { slice, getUpdated } = mountSlice(project);
+
+        slice.handleNovelTextChange('B', 'もう章じゃない');
+
+        const updated = getUpdated();
+        const b = updated.novelContent.find(c => c.id === 'B')!;
+        expect(b.text).toBe('もう章じゃない');
+        // B は A の chapterId (null) を継承
+        expect(b.chapterId).toBe(null);
+        // C も B (= null) を継承して uncategorized になる
+        expect(updated.novelContent.find(c => c.id === 'C')?.chapterId).toBe(null);
+    });
+
+    it('body→body edits do NOT trigger normalize (perf optimization)', () => {
+        // normalize が走ると warnedKeys が消費される (テスト用の副次効果)。代わりに chapterId 不変を確認。
+        const content = normalizeChapterIds([
+            mkChunk('A', '本文1'),
+            mkChunk('B', '本文2'),
+        ]);
+        const project = baseProject(content);
+        const { slice, getUpdated } = mountSlice(project);
+
+        slice.handleNovelTextChange('A', '本文1 編集後');
+
+        const updated = getUpdated();
+        expect(updated.novelContent.find(c => c.id === 'A')?.text).toBe('本文1 編集後');
+        // chapterId 不変 (normalize skip 経路)
+        expect(updated.novelContent.find(c => c.id === 'A')?.chapterId).toBe(null);
+        expect(updated.novelContent.find(c => c.id === 'B')?.chapterId).toBe(null);
+    });
+});

--- a/store/dataSlice.ts
+++ b/store/dataSlice.ts
@@ -3,12 +3,16 @@ import { v4 as uuidv4 } from 'uuid';
 import { Project, SettingItem, KnowledgeItem, PlotItem, Relation, NodePosition, TimelineEvent, PlotRelation, PlotNodePosition, TimelineLane, DisplaySettings, NovelChunk, HistoryType, AnalysisResult } from '../types';
 import {
     UNCATEGORIZED_CHAPTER_ID,
+    assignChapterIdForAppend,
+    buildExportChapterEntries,
+    exportChapterAnchorId,
     isChapterTitleChunk,
     extractChapterTitle,
     getChapterChunksByGroupId,
     getChapterGroups,
     getChapterIdForNewChunk,
     normalizeChapterIds,
+    warnOnceInDev,
 } from '../utils';
 import { renderMarkdown } from '../utils/sanitizeHtml';
 import { FONT_MAP } from '../constants';
@@ -310,7 +314,17 @@ export const createDataSlice = (set, get): DataSlice => ({
                 // uncategorized → 名前付き章への昇格: 新 title chunk を生成し、
                 // それまで chapterId === null だった全 chunks に新 title chunk の id を付与する。
                 const firstUncatIndex = d.novelContent.findIndex(c => c.chapterId == null);
-                if (firstUncatIndex === -1) return d;
+                if (firstUncatIndex === -1) {
+                    // uncategorized chunks が 1 件もない状態で昇格依頼 = UI と store の不整合。
+                    // 入力された title/memo が黙って消えるため paired signal を出す。
+                    warnOnceInDev(
+                        'save-chapter-no-uncategorized',
+                        'handleSaveChapterSettings: 昇格対象の uncategorized chunks が見つからない',
+                        { newTitle },
+                        'dataSlice',
+                    );
+                    return d;
+                }
                 const newTitleChunkId = uuidv4();
                 const newTitleChunk: NovelChunk = {
                     id: newTitleChunkId,
@@ -321,14 +335,14 @@ export const createDataSlice = (set, get): DataSlice => ({
                 const reassigned = d.novelContent.map(c =>
                     c.chapterId == null ? { ...c, chapterId: newTitleChunkId } : c
                 );
-                return {
-                    ...d,
-                    novelContent: [
-                        ...reassigned.slice(0, firstUncatIndex),
-                        newTitleChunk,
-                        ...reassigned.slice(firstUncatIndex),
-                    ],
-                };
+                const inserted = [
+                    ...reassigned.slice(0, firstUncatIndex),
+                    newTitleChunk,
+                    ...reassigned.slice(firstUncatIndex),
+                ];
+                // 非連続 uncategorized 入力 (drag 後の散在等) でも group 連続性 invariant を
+                // 回復するため最後に normalize を通す。冪等のため副作用なし。
+                return { ...d, novelContent: normalizeChapterIds(inserted) };
             }
             // 既存名前付き章のリネーム: title chunk の text と memo のみ更新、chapterId は不変
             return {
@@ -347,7 +361,15 @@ export const createDataSlice = (set, get): DataSlice => ({
         const activeProject = allProjectsData[activeProjectId];
         if (!activeProject) return;
         const targetChunks = getChapterChunksByGroupId(activeProject.novelContent, groupId);
-        if (targetChunks.length === 0) return;
+        if (targetChunks.length === 0) {
+            warnOnceInDev(
+                'delete-chapter-empty-target',
+                'handleDeleteChapter: 削除対象 group が見つからない (UI と store の不整合の可能性)',
+                { groupId },
+                'dataSlice',
+            );
+            return;
+        }
         const targetIds = new Set(targetChunks.map(c => c.id));
 
         const titleChunk = targetChunks.find(isChapterTitleChunk);
@@ -360,17 +382,50 @@ export const createDataSlice = (set, get): DataSlice => ({
         }), { type: 'outline', label: `章「${chapterTitle}」を削除` });
     },
     handleNovelTextChange: (chunkId, newText) => {
-        // R1 (sync): chunk text の `# ` 有無が変わったら chapterId を再正規化する。
-        //   - body → title (`# ` 追加): その chunk の chapterId が self.id に矯正される
-        //   - title → body (`# ` 削除): その chunk を参照していた body chunks は直前 chunk から継承し直す
+        // R1 (sync): chunk text の `# ` 有無が変わったら chapterId を再構築する。
+        //   - body → title (`# ` 追加): その chunk の chapterId を self.id に矯正。
+        //     さらに編集 chunk 以降、次の title chunk 直前までの body chunks を新章配下に再 tag。
+        //     (normalize 単独だと旧 chapterId 参照が valid なので新章に取り込まれず group 連続性が崩れる)
+        //   - title → body (`# ` 削除): normalize の dangling 修復で前 chunk から継承し直される
         // 変化なし (body → body / title → title) のときは normalize を skip し perf を確保する。
         get().setActiveProjectData(d => {
-            const oldChunk = d.novelContent.find(c => c.id === chunkId);
-            if (!oldChunk) return d;
-            const titleStatusChanged = isChapterTitleChunk(oldChunk) !== newText.startsWith('# ');
-            const updated = d.novelContent.map(chunk =>
+            const editedIndex = d.novelContent.findIndex(c => c.id === chunkId);
+            if (editedIndex === -1) {
+                warnOnceInDev(
+                    'text-change-missing-chunk',
+                    '編集対象 chunk が novelContent に存在しません (text 喪失リスク)',
+                    { chunkId, newTextLen: newText.length },
+                    'dataSlice',
+                );
+                return d;
+            }
+            const oldChunk = d.novelContent[editedIndex];
+            const wasTitle = isChapterTitleChunk(oldChunk);
+            const willBeTitle = newText.startsWith('# ');
+            const titleStatusChanged = wasTitle !== willBeTitle;
+
+            let updated: NovelChunk[] = d.novelContent.map(chunk =>
                 chunk.id === chunkId ? { ...chunk, text: newText } : chunk
             );
+
+            if (titleStatusChanged && willBeTitle) {
+                // body → title 昇格: 編集 chunk 以降、次の title chunk 直前までの body chunks のうち、
+                // 旧 chapterId と一致するものを新章 (chunkId) 配下に再 tag。
+                // 次の title chunk 以降は触らない (章境界が確立しているため)。
+                const oldChapterId = oldChunk.chapterId ?? null;
+                let crossedNextTitle = false;
+                updated = updated.map((chunk, idx) => {
+                    if (idx <= editedIndex) return chunk;
+                    if (crossedNextTitle) return chunk;
+                    if (isChapterTitleChunk(chunk)) {
+                        crossedNextTitle = true;
+                        return chunk;
+                    }
+                    if ((chunk.chapterId ?? null) !== oldChapterId) return chunk;
+                    return { ...chunk, chapterId: chunkId };
+                });
+            }
+
             return {
                 ...d,
                 novelContent: titleStatusChanged ? normalizeChapterIds(updated) : updated,
@@ -387,13 +442,22 @@ export const createDataSlice = (set, get): DataSlice => ({
     handleAddNewChunk: () => {
         const { newChunkText } = get();
         if (!newChunkText.trim()) return;
-        const rawNewChunks = newChunkText.split(/\n\s*\n/).map(text => ({ id: uuidv4(), text: text.trim() })).filter(chunk => chunk.text);
+        const rawNewChunks: NovelChunk[] = newChunkText
+            .split(/\n\s*\n/)
+            .map(text => ({ id: uuidv4(), text: text.trim() }))
+            .filter(chunk => chunk.text);
         if (rawNewChunks.length > 0) {
             get().setActiveProjectData(d => {
-                // R2: 末尾 chunk の chapterId を継承 (最終章配下に append)
-                const inheritId = getChapterIdForNewChunk(d.novelContent);
-                const newChunks: NovelChunk[] = rawNewChunks.map(c => ({ ...c, chapterId: inheritId }));
-                return { ...d, novelContent: [...d.novelContent, ...newChunks] };
+                // 順次 append: 各 chunk について title か body かを判定し chapterId を決定する。
+                // title chunk なら self.id、body なら直前 chunk (累積後) の chapterId を継承。
+                // 直接入力で `# 第2章\n\n本文` のように title + body を一度に追加するケースで
+                // title chunk の self.id invariant と後続 body の新章配下追加を両立する。
+                const accumulated: NovelChunk[] = [...d.novelContent];
+                for (const raw of rawNewChunks) {
+                    const chapterId = assignChapterIdForAppend(accumulated, raw);
+                    accumulated.push({ ...raw, chapterId });
+                }
+                return { ...d, novelContent: accumulated };
             }, { type: 'editor', label: '新しい段落を追加' });
         }
         set({ newChunkText: '' });
@@ -415,17 +479,34 @@ export const createDataSlice = (set, get): DataSlice => ({
         // chunks の chapterId は維持されるため、uncategorized chunks が名前付き章配下に絡め取られる
         // 旧バグ (位置依存ルール起因) は構造的に起こらない。
         const { draggedChapterId } = get();
-        if (!draggedChapterId || draggedChapterId === dropOnGroupId) return;
+        if (!draggedChapterId || draggedChapterId === dropOnGroupId) return; // 正常系: self drop / cancel
 
         get().setActiveProjectData(d => {
             const novelContent = [...d.novelContent];
             const draggedChunks = getChapterChunksByGroupId(novelContent, draggedChapterId);
             const dropOnChunks = getChapterChunksByGroupId(novelContent, dropOnGroupId);
-            if (draggedChunks.length === 0 || dropOnChunks.length === 0) return d;
+            if (draggedChunks.length === 0 || dropOnChunks.length === 0) {
+                // UI 上にある章が store 側で 0 件解決される = invariant 違反 (paired signal)
+                warnOnceInDev(
+                    'drop-empty-group',
+                    'handleChapterDrop: dragged/drop group が 0 件 (UI と store の不整合)',
+                    { draggedChapterId, dropOnGroupId, draggedLen: draggedChunks.length, dropLen: dropOnChunks.length },
+                    'dataSlice',
+                );
+                return d;
+            }
             const draggedChunkIds = new Set(draggedChunks.map(c => c.id));
             const contentWithoutDragged = novelContent.filter(c => !draggedChunkIds.has(c.id));
             const dropIndex = contentWithoutDragged.findIndex(c => c.id === dropOnChunks[0].id);
-            if (dropIndex === -1) return d;
+            if (dropIndex === -1) {
+                warnOnceInDev(
+                    'drop-index-missing',
+                    'handleChapterDrop: dropOnChunks の先頭 chunk が contentWithoutDragged に見つからない',
+                    { draggedChapterId, dropOnGroupId },
+                    'dataSlice',
+                );
+                return d;
+            }
             const newNovelContent = [
                 ...contentWithoutDragged.slice(0, dropIndex),
                 ...draggedChunks,
@@ -589,14 +670,10 @@ export const createDataSlice = (set, get): DataSlice => ({
         const escapeHtml = (unsafe) => unsafe.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#039;");
         const charactersToExport = settings.filter(s => s.type === 'character' && options.selectedCharacterIds.includes(s.id));
         const worldSettingsToExport = settings.filter(s => s.type === 'world' && options.selectedWorldIds.includes(s.id));
-        // 章一覧は title chunk から 1 度だけ生成し、TOC リンクと本文 anchor の id を共有する
-        // (片方だけ chapterId 化するとリンク切れになるため AC-11 で pin)。
-        const titleChunks = novelContent.filter(isChapterTitleChunk);
-        const chapterAnchorId = (chunk: NovelChunk) => `ch-${chunk.id}`;
-        const chapters = titleChunks.map(chunk => ({
-            id: chapterAnchorId(chunk),
-            title: extractChapterTitle(chunk) || '無題の章',
-        }));
+        // 章一覧は utils.buildExportChapterEntries で生成し、本文 anchor は同じ
+        // utils.exportChapterAnchorId で生成する。TOC と本文 anchor の id 形式不一致を
+        // 構造的に防ぐため必ず両者を utils 経由にする (AC-11)。
+        const chapters = buildExportChapterEntries(novelContent);
         const body = `
             <div class="container">
                 ${options.coverType !== 'none' ? `
@@ -618,7 +695,7 @@ export const createDataSlice = (set, get): DataSlice => ({
                 ` : ''}
                 <div class="content">
                     ${novelContent.map(chunk => {
-                        const anchorId = isChapterTitleChunk(chunk) ? chapterAnchorId(chunk) : '';
+                        const anchorId = isChapterTitleChunk(chunk) ? exportChapterAnchorId(chunk) : '';
                         return `<div id="${anchorId}">${renderMarkdown(chunk.text, settings.filter(s => s.type === 'character'), knowledgeBase, aiSettings)}</div>`;
                     }).join('')}
                 </div>

--- a/store/dataSlice.ts
+++ b/store/dataSlice.ts
@@ -1,7 +1,15 @@
 
 import { v4 as uuidv4 } from 'uuid';
 import { Project, SettingItem, KnowledgeItem, PlotItem, Relation, NodePosition, TimelineEvent, PlotRelation, PlotNodePosition, TimelineLane, DisplaySettings, NovelChunk, HistoryType, AnalysisResult } from '../types';
-import { getChapterChunks } from '../utils';
+import {
+    UNCATEGORIZED_CHAPTER_ID,
+    isChapterTitleChunk,
+    extractChapterTitle,
+    getChapterChunksByGroupId,
+    getChapterGroups,
+    getChapterIdForNewChunk,
+    normalizeChapterIds,
+} from '../utils';
 import { renderMarkdown } from '../utils/sanitizeHtml';
 import { FONT_MAP } from '../constants';
 import * as analysisApi from '../analysisApi';
@@ -299,46 +307,76 @@ export const createDataSlice = (set, get): DataSlice => ({
     handleSaveChapterSettings: ({ id, newTitle, newMemo, isUncategorized }) => {
         get().setActiveProjectData(d => {
             if (isUncategorized) {
-                const chapter = d.novelContent.find(c => c.id === id);
-                if (!chapter) return d;
-                const newTitleChunk: NovelChunk = { id: uuidv4(), text: `# ${newTitle}`, memo: newMemo };
-                const firstContentChunkIndex = d.novelContent.findIndex(c => c.id === id);
-                return { ...d, novelContent: [...d.novelContent.slice(0, firstContentChunkIndex), newTitleChunk, ...d.novelContent.slice(firstContentChunkIndex)] };
-            } else {
-                return { ...d, novelContent: d.novelContent.map(c => c.id === id ? { ...c, text: `# ${newTitle}`, memo: newMemo } : c) };
+                // uncategorized → 名前付き章への昇格: 新 title chunk を生成し、
+                // それまで chapterId === null だった全 chunks に新 title chunk の id を付与する。
+                const firstUncatIndex = d.novelContent.findIndex(c => c.chapterId == null);
+                if (firstUncatIndex === -1) return d;
+                const newTitleChunkId = uuidv4();
+                const newTitleChunk: NovelChunk = {
+                    id: newTitleChunkId,
+                    text: `# ${newTitle}`,
+                    memo: newMemo,
+                    chapterId: newTitleChunkId,
+                };
+                const reassigned = d.novelContent.map(c =>
+                    c.chapterId == null ? { ...c, chapterId: newTitleChunkId } : c
+                );
+                return {
+                    ...d,
+                    novelContent: [
+                        ...reassigned.slice(0, firstUncatIndex),
+                        newTitleChunk,
+                        ...reassigned.slice(firstUncatIndex),
+                    ],
+                };
             }
+            // 既存名前付き章のリネーム: title chunk の text と memo のみ更新、chapterId は不変
+            return {
+                ...d,
+                novelContent: d.novelContent.map(c =>
+                    c.id === id ? { ...c, text: `# ${newTitle}`, memo: newMemo } : c
+                ),
+            };
         }, { type: 'outline', label: `章「${newTitle}」の設定を更新` });
     },
-    handleDeleteChapter: (chapterId) => {
+    handleDeleteChapter: (groupId) => {
+        // groupId: UNCATEGORIZED_CHAPTER_ID または title chunk の id。
+        // UI 上は「章を削除」ボタンが名前付き章にのみ表示される (OutlinePanel) ため uncategorized
+        // 削除はトリガされないが、handler 単体では同じインタフェースで動作する。
         const { activeProjectId, allProjectsData } = get();
         const activeProject = allProjectsData[activeProjectId];
         if (!activeProject) return;
-        const chunks = activeProject.novelContent;
-        const chapterIndex = chunks.findIndex(c => c.id === chapterId);
-        if (chapterIndex === -1) return;
-        let endIndex = chunks.length;
-        for (let i = chapterIndex + 1; i < chunks.length; i++) {
-            if (chunks[i].text.startsWith('# ')) {
-                endIndex = i;
-                break;
-            }
-        }
-        const chapterTitle = chunks[chapterIndex].text.startsWith('# ') 
-            ? chunks[chapterIndex].text.substring(2).trim() 
-            : '章に属さない文章';
+        const targetChunks = getChapterChunksByGroupId(activeProject.novelContent, groupId);
+        if (targetChunks.length === 0) return;
+        const targetIds = new Set(targetChunks.map(c => c.id));
 
-        get().setActiveProjectData(d => {
-            const newNovelContent = [...d.novelContent];
-            newNovelContent.splice(chapterIndex, endIndex - chapterIndex);
-            return { ...d, novelContent: newNovelContent, lastModified: new Date().toISOString() };
-        }, { type: 'outline', label: `章「${chapterTitle}」を削除` });
-    },
-    handleNovelTextChange: (chunkId, newText) => {
+        const titleChunk = targetChunks.find(isChapterTitleChunk);
+        const chapterTitle = titleChunk ? extractChapterTitle(titleChunk) : '章に属さない文章';
+
         get().setActiveProjectData(d => ({
             ...d,
-            novelContent: d.novelContent.map(chunk => chunk.id === chunkId ? { ...chunk, text: newText } : chunk),
-            lastModified: new Date().toISOString()
-        }), { type: 'editor', label: '本文を編集' });
+            novelContent: d.novelContent.filter(c => !targetIds.has(c.id)),
+            lastModified: new Date().toISOString(),
+        }), { type: 'outline', label: `章「${chapterTitle}」を削除` });
+    },
+    handleNovelTextChange: (chunkId, newText) => {
+        // R1 (sync): chunk text の `# ` 有無が変わったら chapterId を再正規化する。
+        //   - body → title (`# ` 追加): その chunk の chapterId が self.id に矯正される
+        //   - title → body (`# ` 削除): その chunk を参照していた body chunks は直前 chunk から継承し直す
+        // 変化なし (body → body / title → title) のときは normalize を skip し perf を確保する。
+        get().setActiveProjectData(d => {
+            const oldChunk = d.novelContent.find(c => c.id === chunkId);
+            if (!oldChunk) return d;
+            const titleStatusChanged = isChapterTitleChunk(oldChunk) !== newText.startsWith('# ');
+            const updated = d.novelContent.map(chunk =>
+                chunk.id === chunkId ? { ...chunk, text: newText } : chunk
+            );
+            return {
+                ...d,
+                novelContent: titleStatusChanged ? normalizeChapterIds(updated) : updated,
+                lastModified: new Date().toISOString(),
+            };
+        }, { type: 'editor', label: '本文を編集' });
     },
     handleToggleChunkPin: (chunkId) => {
         get().setActiveProjectData(d => ({
@@ -349,25 +387,40 @@ export const createDataSlice = (set, get): DataSlice => ({
     handleAddNewChunk: () => {
         const { newChunkText } = get();
         if (!newChunkText.trim()) return;
-        const newChunks = newChunkText.split(/\n\s*\n/).map(text => ({ id: uuidv4(), text: text.trim() })).filter(chunk => chunk.text);
-        if (newChunks.length > 0) {
-            get().setActiveProjectData(d => ({ ...d, novelContent: [...d.novelContent, ...newChunks] }), { type: 'editor', label: '新しい段落を追加' });
+        const rawNewChunks = newChunkText.split(/\n\s*\n/).map(text => ({ id: uuidv4(), text: text.trim() })).filter(chunk => chunk.text);
+        if (rawNewChunks.length > 0) {
+            get().setActiveProjectData(d => {
+                // R2: 末尾 chunk の chapterId を継承 (最終章配下に append)
+                const inheritId = getChapterIdForNewChunk(d.novelContent);
+                const newChunks: NovelChunk[] = rawNewChunks.map(c => ({ ...c, chapterId: inheritId }));
+                return { ...d, novelContent: [...d.novelContent, ...newChunks] };
+            }, { type: 'editor', label: '新しい段落を追加' });
         }
         set({ newChunkText: '' });
     },
     addChapter: () => {
-        const newChapterChunk: NovelChunk = { id: uuidv4(), text: '# 無題の章', memo: '' };
+        const newChapterId = uuidv4();
+        const newChapterChunk: NovelChunk = {
+            id: newChapterId,
+            text: '# 無題の章',
+            memo: '',
+            chapterId: newChapterId, // title chunk は self.id を chapterId として持つ
+        };
         get().setActiveProjectData(d => ({ ...d, novelContent: [...d.novelContent, newChapterChunk] }), { type: 'outline', label: '新しい章を追加' });
         get().openModal('chapterSettings', { id: newChapterChunk.id, title: '無題の章', memo: '', isUncategorized: false });
     },
-    handleChapterDrop: (dropOnChapterId) => {
+    handleChapterDrop: (dropOnGroupId) => {
+        // OutlinePanel 経由で渡されるのは groupId (= UNCATEGORIZED_CHAPTER_ID か title chunk id)。
+        // 章 group の chunks を chapterId で抽出し、配列上の dropOn group 先頭位置にまるごと差し込む。
+        // chunks の chapterId は維持されるため、uncategorized chunks が名前付き章配下に絡め取られる
+        // 旧バグ (位置依存ルール起因) は構造的に起こらない。
         const { draggedChapterId } = get();
-        if (!draggedChapterId || draggedChapterId === dropOnChapterId) return;
+        if (!draggedChapterId || draggedChapterId === dropOnGroupId) return;
 
         get().setActiveProjectData(d => {
             const novelContent = [...d.novelContent];
-            const draggedChunks = getChapterChunks(novelContent, draggedChapterId);
-            const dropOnChunks = getChapterChunks(novelContent, dropOnChapterId);
+            const draggedChunks = getChapterChunksByGroupId(novelContent, draggedChapterId);
+            const dropOnChunks = getChapterChunksByGroupId(novelContent, dropOnGroupId);
             if (draggedChunks.length === 0 || dropOnChunks.length === 0) return d;
             const draggedChunkIds = new Set(draggedChunks.map(c => c.id));
             const contentWithoutDragged = novelContent.filter(c => !draggedChunkIds.has(c.id));
@@ -536,16 +589,14 @@ export const createDataSlice = (set, get): DataSlice => ({
         const escapeHtml = (unsafe) => unsafe.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#039;");
         const charactersToExport = settings.filter(s => s.type === 'character' && options.selectedCharacterIds.includes(s.id));
         const worldSettingsToExport = settings.filter(s => s.type === 'world' && options.selectedWorldIds.includes(s.id));
-        const chapters = novelContent.map((chunk, index) => {
-            if (chunk.text.startsWith('# ')) {
-                return {
-                    id: `ch-${chunk.id}`,
-                    title: chunk.text.split('\n')[0].substring(2).trim(),
-                    index: index
-                };
-            }
-            return null;
-        }).filter(Boolean);
+        // 章一覧は title chunk から 1 度だけ生成し、TOC リンクと本文 anchor の id を共有する
+        // (片方だけ chapterId 化するとリンク切れになるため AC-11 で pin)。
+        const titleChunks = novelContent.filter(isChapterTitleChunk);
+        const chapterAnchorId = (chunk: NovelChunk) => `ch-${chunk.id}`;
+        const chapters = titleChunks.map(chunk => ({
+            id: chapterAnchorId(chunk),
+            title: extractChapterTitle(chunk) || '無題の章',
+        }));
         const body = `
             <div class="container">
                 ${options.coverType !== 'none' ? `
@@ -567,9 +618,8 @@ export const createDataSlice = (set, get): DataSlice => ({
                 ` : ''}
                 <div class="content">
                     ${novelContent.map(chunk => {
-                        const isTitle = chunk.text.startsWith('# ');
-                        const chapterId = isTitle ? `ch-${chunk.id}` : '';
-                        return `<div id="${chapterId}">${renderMarkdown(chunk.text, settings.filter(s => s.type === 'character'), knowledgeBase, aiSettings)}</div>`;
+                        const anchorId = isChapterTitleChunk(chunk) ? chapterAnchorId(chunk) : '';
+                        return `<div id="${anchorId}">${renderMarkdown(chunk.text, settings.filter(s => s.type === 'character'), knowledgeBase, aiSettings)}</div>`;
                     }).join('')}
                 </div>
                 ${charactersToExport.length > 0 ? `

--- a/utils.chapterId.test.ts
+++ b/utils.chapterId.test.ts
@@ -7,11 +7,26 @@ import {
     getChapterGroups,
     getChapterChunksByGroupId,
     getChapterIdForNewChunk,
-    getChapterChunks,
     validateAndSanitizeProjectData,
     __resetChapterIdWarnState,
 } from './utils';
 import { NovelChunk } from './types';
+
+// PR-2 で utils.getChapterChunks (位置依存ルールの旧 API) を削除済み。
+// migration 等価性テスト (C-1) は新 API が旧挙動と一致することを保証する regression guard として、
+// 旧 API のロジックを test-local にインライン保持する。
+const legacyGetChapterChunks = (novelContent: NovelChunk[], chapterId: string): NovelChunk[] => {
+    const isUncategorizedChapter = novelContent.find(c => c.id === chapterId && !c.text.startsWith('# '));
+    if (isUncategorizedChapter) {
+        const firstTitleIndex = novelContent.findIndex(c => c.text.startsWith('# '));
+        return firstTitleIndex === -1 ? [...novelContent] : novelContent.slice(0, firstTitleIndex);
+    }
+    const chapterStartIndex = novelContent.findIndex(c => c.id === chapterId);
+    if (chapterStartIndex === -1) return [];
+    let chapterEndIndex = novelContent.findIndex((c, i) => i > chapterStartIndex && c.text.startsWith('# '));
+    if (chapterEndIndex === -1) chapterEndIndex = novelContent.length;
+    return novelContent.slice(chapterStartIndex, chapterEndIndex);
+};
 
 // dev-only warn は module-level Set で 1 度だけ発火するため、warn 検証テストの前に clear する。
 beforeEach(() => {
@@ -372,7 +387,7 @@ describe('legacy getChapterChunks ↔ getChapterChunksByGroupId migration equiva
             const newApiResult = getChapterChunksByGroupId(normalized, grp.groupId).map(c => c.id);
             const legacyKey = grp.kind === 'uncategorized' ? uncatLegacyId : grp.groupId;
             if (legacyKey == null) continue; // uncategorized が空 group のケース
-            const legacyResult = getChapterChunks(content, legacyKey).map(c => c.id);
+            const legacyResult = legacyGetChapterChunks(content, legacyKey).map(c => c.id);
             expect(newApiResult).toEqual(legacyResult);
         }
     });
@@ -380,7 +395,7 @@ describe('legacy getChapterChunks ↔ getChapterChunksByGroupId migration equiva
     it('returns empty array on unknown groupId / chunkId in both APIs', () => {
         const normalized = normalizeChapterIds([chunk('A', '# 第1章'), chunk('B', '本文')]);
         expect(getChapterChunksByGroupId(normalized, 'GHOST')).toEqual([]);
-        expect(getChapterChunks([chunk('A', '# 第1章')], 'GHOST')).toEqual([]);
+        expect(legacyGetChapterChunks([chunk('A', '# 第1章')], 'GHOST')).toEqual([]);
     });
 });
 

--- a/utils.chapterId.test.ts
+++ b/utils.chapterId.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import {
     UNCATEGORIZED_CHAPTER_ID,
+    assignChapterIdForAppend,
+    buildExportChapterEntries,
+    exportChapterAnchorId,
     isChapterTitleChunk,
     extractChapterTitle,
     normalizeChapterIds,
@@ -422,6 +425,78 @@ describe('normalizeChapterIds — duplicate title id handling (C-3)', () => {
         ];
         const out = normalizeChapterIds(input);
         expect(out.map(c => c.chapterId)).toEqual(['X', 'X', 'X', 'X']);
+    });
+});
+
+describe('assignChapterIdForAppend (F-A: title invariant 維持)', () => {
+    it('title chunk (`# ` 始まり) なら self.id を返す (継承無視)', () => {
+        const existing = normalizeChapterIds([chunk('A', '# 第1章'), chunk('B', '本文')]);
+        const newTitle = chunk('NEW', '# 第2章');
+        expect(assignChapterIdForAppend(existing, newTitle)).toBe('NEW');
+    });
+
+    it('body chunk なら末尾 chunk の chapterId を継承する (R2)', () => {
+        const existing = normalizeChapterIds([chunk('A', '# 第1章'), chunk('B', '本文')]);
+        const newBody = chunk('NEW', '追記本文');
+        expect(assignChapterIdForAppend(existing, newBody)).toBe('A');
+    });
+
+    it('chunks が空のとき body chunk は null を返す', () => {
+        expect(assignChapterIdForAppend([], chunk('NEW', '本文'))).toBeNull();
+    });
+
+    it('chunks が空のとき title chunk でも self.id を返す (uncategorized append にしない)', () => {
+        expect(assignChapterIdForAppend([], chunk('NEW', '# 第1章'))).toBe('NEW');
+    });
+});
+
+describe('exportChapterAnchorId / buildExportChapterEntries (AC-11: TOC ↔ body anchor 同一 source)', () => {
+    it('exportChapterAnchorId は `ch-${chunk.id}` を返す', () => {
+        expect(exportChapterAnchorId(chunk('B', '# 第1章'))).toBe('ch-B');
+        expect(exportChapterAnchorId(chunk('XYZ', '本文'))).toBe('ch-XYZ'); // body でも formula は同じ
+    });
+
+    it('buildExportChapterEntries は title chunks のみを配列順で抽出する', () => {
+        const content = [
+            chunk('A', '本文1'),
+            chunk('B', '# 第1章'),
+            chunk('C', '第1章本文'),
+            chunk('D', '# 第2章'),
+        ];
+        expect(buildExportChapterEntries(content)).toEqual([
+            { id: 'ch-B', title: '第1章' },
+            { id: 'ch-D', title: '第2章' },
+        ]);
+    });
+
+    it('TOC entry の id と本文 anchor の id が完全一致する (リンク切れ防止)', () => {
+        const content = [
+            chunk('A', '本文1'),
+            chunk('B', '# 第1章'),
+            chunk('C', '# 第2章'),
+            chunk('D', '# 第3章'),
+        ];
+        const tocEntries = buildExportChapterEntries(content);
+        const titleChunks = content.filter(isChapterTitleChunk);
+        // すべての TOC entry に対応する本文 anchor id が存在する
+        for (const titleChunk of titleChunks) {
+            const bodyAnchor = exportChapterAnchorId(titleChunk);
+            expect(tocEntries.find(e => e.id === bodyAnchor)).toBeDefined();
+        }
+        // 逆方向: すべての TOC entry id が title chunk から生成された anchor と一致
+        for (const entry of tocEntries) {
+            const correspondingChunk = titleChunks.find(c => exportChapterAnchorId(c) === entry.id);
+            expect(correspondingChunk).toBeDefined();
+        }
+    });
+
+    it('空のタイトル (`# ` のみ) は `無題の章` fallback で表示する', () => {
+        const entries = buildExportChapterEntries([chunk('A', '# ')]);
+        expect(entries[0].title).toBe('無題の章');
+    });
+
+    it('title chunk が存在しない場合は空配列を返す', () => {
+        expect(buildExportChapterEntries([chunk('A', '本文1'), chunk('B', '本文2')])).toEqual([]);
     });
 });
 

--- a/utils.ts
+++ b/utils.ts
@@ -261,12 +261,22 @@ export const extractChapterTitle = (chunk: NovelChunk): string => {
  */
 const warnedKeys = new Set<string>();
 
-const warnOnceInDev = (key: string, message: string, detail: Record<string, unknown>): void => {
+/**
+ * dev 環境で paired signal を 1 度だけ出力する。grow-MEMORY `feedback_silent_fail_paired_signal.md`
+ * の規律に従い、normalize / store write path の silent fail を可視化する。production では noop。
+ * 呼び出し側で異なる category (`key`) を渡すこと。`__resetChapterIdWarnState` で test 時にリセット可能。
+ */
+export const warnOnceInDev = (
+    key: string,
+    message: string,
+    detail: Record<string, unknown>,
+    scope = 'normalizeChapterIds',
+): void => {
     if (typeof process !== 'undefined' && process.env?.NODE_ENV === 'production') return;
     if (warnedKeys.has(key)) return;
     warnedKeys.add(key);
     // eslint-disable-next-line no-console
-    console.warn(`[normalizeChapterIds] ${message}`, detail);
+    console.warn(`[${scope}] ${message}`, detail);
 };
 
 /** test-only: warnOnceInDev の dedup state をクリアする (vitest beforeEach 用)。 */
@@ -423,6 +433,41 @@ export const getChapterIdForNewChunk = (chunks: NovelChunk[]): string | null => 
     const last = chunks[chunks.length - 1];
     return last.chapterId ?? null;
 };
+
+/**
+ * 末尾追加する chunk の chapterId を決定する。title chunk (`# ` 始まり) なら self.id、
+ * それ以外は `getChapterIdForNewChunk` の末尾継承 (R2)。
+ *
+ * `handleAddNewChunk` (直接入力) / aiSlice continuation 等の末尾 append 経路で利用し、
+ * title chunk invariant (`chapterId === self.id`) を必ず満たすようにする。
+ */
+export const assignChapterIdForAppend = (
+    existingChunks: NovelChunk[],
+    newChunk: NovelChunk,
+): string | null => {
+    if (isChapterTitleChunk(newChunk)) return newChunk.id;
+    return getChapterIdForNewChunk(existingChunks);
+};
+
+/**
+ * export HTML 出力で title chunk の anchor id を生成する単一の formula。
+ * TOC リンクと本文 div の id を必ず一致させるため、必ずこの関数経由で id を生成する。
+ */
+export const exportChapterAnchorId = (chunk: NovelChunk): string => `ch-${chunk.id}`;
+
+/**
+ * export HTML の TOC に出力する章エントリを生成する (title chunks のみ、配列順)。
+ * 各 entry の `id` は `exportChapterAnchorId` 経由で生成され、本文 anchor と同形式。
+ */
+export const buildExportChapterEntries = (
+    novelContent: NovelChunk[],
+): { id: string; title: string }[] =>
+    novelContent
+        .filter(isChapterTitleChunk)
+        .map(chunk => ({
+            id: exportChapterAnchorId(chunk),
+            title: extractChapterTitle(chunk) || '無題の章',
+        }));
 
 // --- Project Data Validation ---
 const isObject = (value: any): value is Record<string, any> => value !== null && typeof value === 'object' && !Array.isArray(value);

--- a/utils.ts
+++ b/utils.ts
@@ -424,34 +424,6 @@ export const getChapterIdForNewChunk = (chunks: NovelChunk[]): string | null => 
     return last.chapterId ?? null;
 };
 
-/**
- * @deprecated 位置依存ルール (`# ` 始まり chunk の物理順序) で章を決める旧 API。
- * 新規呼び出しは `getChapterChunksByGroupId(chunks, groupId)` を使うこと。
- * 残存呼び出し元 (現在は `store/dataSlice.ts` の `handleChapterDrop` のみ) を移行し終えたら削除する。
- */
-export const getChapterChunks = (novelContent: NovelChunk[], chapterId: string): NovelChunk[] => {
-    const isUncategorizedChapter = novelContent.find(c => c.id === chapterId && !c.text.startsWith('# '));
-
-    if (isUncategorizedChapter) {
-        const firstTitleIndex = novelContent.findIndex(c => c.text.startsWith('# '));
-        if (firstTitleIndex === -1) {
-            return [...novelContent];
-        }
-        return novelContent.slice(0, firstTitleIndex);
-    }
-
-    const chapterStartIndex = novelContent.findIndex(c => c.id === chapterId);
-    if (chapterStartIndex === -1) return [];
-
-    let chapterEndIndex = novelContent.findIndex((c, i) => i > chapterStartIndex && c.text.startsWith('# '));
-    if (chapterEndIndex === -1) {
-        chapterEndIndex = novelContent.length;
-    }
-
-    return novelContent.slice(chapterStartIndex, chapterEndIndex);
-};
-
-
 // --- Project Data Validation ---
 const isObject = (value: any): value is Record<string, any> => value !== null && typeof value === 'object' && !Array.isArray(value);
 const isString = (value: any): value is string => typeof value === 'string';

--- a/utils/backupSchema.test.ts
+++ b/utils/backupSchema.test.ts
@@ -264,10 +264,10 @@ describe('resolveImportProjects (AC-3)', () => {
 
 // --- M6 PR-B: parseAnyBackup + isEncryptedBackup + parseEncryptedEnvelope (AC-8) ---
 
-import { encryptBackup, IV_BYTES, PBKDF2_ITERATIONS, randomBytes, SALT_BYTES, toBase64 } from './backupCrypto';
+import { decryptBackup, encryptBackup, IV_BYTES, PBKDF2_ITERATIONS, randomBytes, SALT_BYTES, toBase64 } from './backupCrypto';
 import { isEncryptedBackup, parseAnyBackup, parseEncryptedEnvelope } from './backupSchema';
 import { buildSampleBackup } from '../tests/fixtures/backup';
-import type { BackupV1 } from '../types';
+import type { BackupV1, EncryptedBackupV1 } from '../types';
 
 const VALID_PASSPHRASE = 'test-passphrase-12-chars-ok';
 
@@ -412,5 +412,72 @@ describe('parseEncryptedEnvelope parse-time guards (AC-4)', () => {
         const env = baseEnv();
         (env.kdfParams as { iterations: number }).iterations = 10_000_000;
         expect(() => parseEncryptedEnvelope(env)).not.toThrow();
+    });
+});
+
+describe('chapterId roundtrip (PR-2 AC-10)', () => {
+    // chapterId 付きの novelContent が plaintext / encrypted / legacy bare の 3 経路で
+    // export → parse → import の往復で保存・推論されることを pin する (review M4 指摘対応)。
+    // 注: parseBackup は内部で validateAndSanitizeProjectData を呼ぶため、3 経路すべてで
+    // chapterId の正規化が走る (legacy bare の chapterId 推論もここで完了)。
+
+    const projectWithChapters = (): Project => ({
+        ...makeProject({ id: 'chap-p', name: '章付き物語' }),
+        novelContent: [
+            { id: 'A', text: '本文1', chapterId: null },
+            { id: 'B', text: '# 第1章', chapterId: 'B' },
+            { id: 'C', text: '第1章本文', chapterId: 'B' },
+            { id: 'D', text: '# 第2章', chapterId: 'D' },
+            { id: 'E', text: '第2章本文', chapterId: 'D' },
+        ],
+    });
+
+    it('plaintext BackupV1 → parseBackup で chapterId が完全に保持される', () => {
+        const backup = buildBackupV1({
+            projects: [projectWithChapters()],
+            tutorialState: {},
+            analysisHistory: [],
+            appVersion: '1.0.0',
+        });
+        const raw = serializeBackup(backup);
+        const parsed = parseBackup(raw, { rawSize: raw.length });
+        expect(parsed.projects[0].novelContent.map(c => ({ id: c.id, chapterId: c.chapterId }))).toEqual([
+            { id: 'A', chapterId: null },
+            { id: 'B', chapterId: 'B' },
+            { id: 'C', chapterId: 'B' },
+            { id: 'D', chapterId: 'D' },
+            { id: 'E', chapterId: 'D' },
+        ]);
+    });
+
+    it('encrypted BackupV1 → decrypt → parseBackup で chapterId が保持される (passphrase 経路)', async () => {
+        const backup = buildBackupV1({
+            projects: [projectWithChapters()],
+            tutorialState: {},
+            analysisHistory: [],
+            appVersion: '1.0.0',
+        });
+        const env = await encryptBackup(backup, VALID_PASSPHRASE, '1.0.0');
+        const raw = JSON.stringify(env);
+        const top = parseAnyBackup(raw);
+        expect((top as { encrypted?: boolean }).encrypted).toBe(true);
+        const decrypted = await decryptBackup(top as EncryptedBackupV1, VALID_PASSPHRASE);
+        const innerRaw = JSON.stringify(decrypted);
+        const inner = parseBackup(innerRaw, { rawSize: innerRaw.length });
+        expect(inner.projects[0].novelContent.map(c => c.chapterId)).toEqual([null, 'B', 'B', 'D', 'D']);
+    });
+
+    it('legacy bare-project JSON (chapterId 不在) は parseBackup 内の validateAndSanitizeProjectData で推論される', () => {
+        const legacy = JSON.stringify({
+            ...makeProject({ id: 'legacy-chap-p' }),
+            novelContent: [
+                { id: 'A', text: '本文1' },
+                { id: 'B', text: '# 第1章' },
+                { id: 'C', text: '第1章本文' },
+            ],
+        });
+        const parsed = parseBackup(legacy, { rawSize: legacy.length });
+        // parseBackup → wrapLegacyProject → validateAndSanitizeProjectData → normalizeChapterIds
+        expect(parsed.projects[0].novelContent.map(c => c.chapterId)).toEqual([null, 'B', 'B']);
     });
 });


### PR DESCRIPTION
## 背景

PR-1 (#173) で導入した `NovelChunk.chapterId` 型と純粋関数を全 write/read path に展開し、
アウトラインドラッグで「章に属さない文章」が名前付き章に統合される旧バグを構造的に解決する。

## 修正対象バグ

**Before** (位置依存ルール):
```
[本文A(uncat), # 第1章, 本文B(in chapter)]
↓ "# 第1章" を "章に属さない文章" の上にドラッグ
[# 第1章, 本文B, 本文A]  ← 本文A が物理的に章の後に来たため第1章配下に統合 (バグ)
```

**After** (chapterId 所属優先):
```
[本文A(chapterId=null), # 第1章(chapterId=B.id), 本文B(chapterId=B.id)]
↓ 同操作
[# 第1章, 本文B, 本文A(chapterId=null は維持)]  ← uncategorized のまま、独立表示
```

## Summary

### ロジック層 (`store/`)
| Handler | 変更内容 | AC |
|---------|---------|-----|
| `handleChapterDrop` | `getChapterChunksByGroupId` で group 単位移動。chapterId 維持で位置変更 ≠ 所属変更 | **AC-1 / AC-2 (本丸)** |
| `handleSaveChapterSettings` | uncategorized → 名前付き昇格時に新 title chunk 挿入 + 元 chapterId=null chunks に新 id 一括付与 | AC-7 |
| `handleDeleteChapter` | `getChapterChunksByGroupId` で group 範囲のみ filter 削除 | AC-6 |
| `addChapter` | 新 title chunk に `chapterId === self.id` 設定 | - |
| `handleAddNewChunk` | `getChapterIdForNewChunk` で末尾 chunk の chapterId 継承 (R2) | AC-8 |
| `handleNovelTextChange` | `# ` 有無変化時のみ `normalizeChapterIds` 再同期 (perf 最適化) | **AC-9 (R1 sync)** |
| `exportHtml` (TOC/本文) | title chunks から chapter list を 1 度だけ生成、TOC リンクと本文 anchor 同一 id | **AC-11** |
| `aiSlice` continuation | `getChapterIdForNewChunk` で chapterId 継承 (R2) | - |

### UI 層 (`components/`)
- `panels/OutlinePanel.tsx`: `getChapterGroups` で章一覧構築、drag id を groupId 化
- `NovelEditor.tsx`: chapters useMemo を `getChapterGroups` ベースに、anchor id を OutlinePanel と一致
- `GlobalSearchModal.tsx`: `extractChapterTitle` / `isChapterTitleChunk` 経由に切替

### クリーンアップ
- `utils.ts`: 旧 `getChapterChunks` (位置依存) 削除。equivalence test 用に test-local の `legacyGetChapterChunks` でインライン保持し migration 等価性を継続 pin

## Test Plan

- [x] `npm run lint` (tsc --noEmit) pass
- [x] `npm run test`: 42 files / 708 tests pass (PR-1 後 690 → 708、+18 新規)
  - `store/dataSlice.chapterDrop.test.ts` (新規 15 件): AC-1/AC-2/AC-6/AC-7/AC-8/AC-9
  - `utils/backupSchema.test.ts` (+3 件): plaintext / encrypted / legacy の 3 経路 roundtrip (AC-10)
- [x] `npm run build` 成功
- [ ] **マージ後 dev 環境にデプロイし、Playwright MCP で AC-1 (uncategorized → named ドラッグ) と AC-2 (逆方向) を実機確認**

## Acceptance Criteria

- [x] **AC-1**: 名前付き章を「章に属さない文章」の上にドラッグしても uncategorized chunks の chapterId は null のまま (バグ修正本丸、`dataSlice.chapterDrop.test.ts:71`)
- [x] **AC-2**: 「章に属さない文章」を名前付き章の上にドラッグしても uncategorized chunks の chapterId は null のまま (`dataSlice.chapterDrop.test.ts:93`)
- [x] **AC-6**: `handleDeleteChapter` が chapterId 範囲の chunks のみ削除し、他章 / uncategorized は不変
- [x] **AC-7**: uncategorized → 名前付き昇格時に元 chapterId=null の全 chunks に新 title chunk の id が付与される
- [x] **AC-8**: `getChapterIdForNewChunk` で末尾 append 時に最終章配下に継承される (R2)
- [x] **AC-9 (R1 sync)**: chunk text に `# ` 追加 → title 化、削除 → body 化
- [x] **AC-10**: BackupV1 / encrypted backup / legacy bare の 3 経路で chapterId が保持・推論される
- [x] **AC-11**: export TOC と本文 anchor が同一 chapter list から生成されリンク切れなし

## 依存

PR-1 (#173) を前提とする。本 PR は PR-1 で導入した型と純粋関数を write/read path に展開する。

## 関連

- impl-plan セッション: 2026-06-08
- Codex セカンドオピニオン: PR-1 で High 4 件反映済
- OQ 確定: R1=②sync / R2=①最終章配下 / R3=③null+仮想id / R4=N/A / R5=2 PR / R6=D-2 維持

🤖 Generated with [Claude Code](https://claude.com/claude-code)