### PR TITLE
feat(plotboard): カード/イベント単体保存で upsert action を即時発火 (PR-A2)

### DIFF
--- a/components/PlotBoardModal.tsx
+++ b/components/PlotBoardModal.tsx
@@ -325,6 +325,9 @@ export const PlotBoardModal = ({ isOpen, onClose, onSave, plotItems, relations, 
     const createEventFromPlot = useStore(state => state.createEventFromPlot);
     const navigateToEvent = useStore(state => state.navigateToEvent);
     const userMode = useStore(state => state.userMode);
+    // PR-A2: カード単体保存を即時 Redux 反映 (local state 維持 + 二重書き)
+    // タイトル同期 (computePlotTitleSync) と debounce 自動保存をフッター保存待ちなく発火させるため。
+    const upsertPlotItem = useStore(state => state.upsertPlotItem);
 
     const hasCompletedGlobalPlotBoardTutorial = useStore(state => state.hasCompletedGlobalPlotBoardTutorial);
     const startPlotBoardTutorial = useStore(state => state.startPlotBoardTutorial);
@@ -418,6 +421,8 @@ export const PlotBoardModal = ({ isOpen, onClose, onSave, plotItems, relations, 
             setItems([...items, card]);
             setPositions(prev => ({...prev, [card.id]: {x: 120, y: 120}}));
         }
+        // PR-A2: 即時 Redux 反映 (タイトル同期 + 自動保存 trigger)。フッター保存を待たない。
+        upsertPlotItem(card);
         setEditingCard(null);
     };
     

--- a/components/TimelineModal.tsx
+++ b/components/TimelineModal.tsx
@@ -37,6 +37,9 @@ export const TimelineModal: React.FC<{
     const highlightedEventId = useStore(state => state.highlightedEventId);
     const setHighlightedEventId = useStore(state => state.setHighlightedEventId);
     const navigateToPlot = useStore(state => state.navigateToPlot);
+    // PR-A2: イベント単体保存を即時 Redux 反映 (local state 維持 + 二重書き)
+    // タイトル同期 (computeEventTitleSync) と debounce 自動保存をフッター保存待ちなく発火させるため。
+    const upsertTimelineEvent = useStore(state => state.upsertTimelineEvent);
     const eventsContainerRef = useRef<HTMLDivElement>(null);
 
 
@@ -137,6 +140,8 @@ export const TimelineModal: React.FC<{
         } else {
             setLocalTimeline([...localTimeline, eventToSave]);
         }
+        // PR-A2: 即時 Redux 反映 (タイトル同期 + 自動保存 trigger)。フッター保存を待たない。
+        upsertTimelineEvent(eventToSave);
         setEditingEvent(null);
     };
 


### PR DESCRIPTION
## Summary

PR-A1 で追加した `upsertPlotItem` / `upsertTimelineEvent` action を caller (`CardEditorModal` / `TimelineModal` の保存ハンドラ) から呼び、**当初オーダー (タイトル同期解消 + 単体更新が全体保存と同等) を達成**する。

## 変更内容

| ファイル | 変更 |
|---------|------|
| `components/PlotBoardModal.tsx` | `handleSaveCard` で `upsertPlotItem(card)` 追加発火 (+3 行) |
| `components/TimelineModal.tsx` | `handleSaveEvent` で `upsertTimelineEvent(eventToSave)` 追加発火 (+3 行) |

合計 +10 行の極小変更。

## 設計判断 (本田様合意)

- **local state は維持** (二重書き、廃止しない)
- **フッター保存ボタンは残す** (位置・関係・色の保存役割を維持、当初オーダー通り)
- **削除挙動・キャンセル挙動は現状維持** (Codex H1 stale overwrite / H2 キャンセル semantics は本田様判断で許容)
- **新規 action 追加なし** (PR-A1 で追加した既存 action を呼ぶだけ)

## 達成される結果

| 当初オーダー | 達成状態 |
|------------|---------|
| 1. タイムライン側でタイトル変更したらプロット側も同期 | ✅ 達成 (computeEventTitleSync 経由) |
| 2. 単体更新が全体保存と同等 | ✅ 達成 (upsert action が 2 秒 debounce で IndexedDB 反映) |
| 3. フッターボタン = 位置関係と相関関係の保存役割 | ✅ 達成 (実態としてその役割が残る) |

## Test plan

- [x] `npm run lint` PASS (型エラーなし)
- [x] `npm run test` 全 PASS (744/744、回帰なし)
- [x] PR-A1 で追加した action contract test (27 件) で upsert ロジックは検証済
- [ ] CI green
- [ ] 実機 (Cloud Run dev) で以下のフローを確認:
  - [ ] プロットボードでカード A の title を「序章」→「プロローグ」に変更、CardEditorModal 保存
  - [ ] フッター保存ボタンを **押さずに** モーダルを閉じる
  - [ ] タイムラインを開き、リンク済み event の title が「プロローグ」になっていること
  - [ ] トースト「タイムラインの 1 件のリンクイベントのタイトルを同期しました」が表示されること
  - [ ] 逆方向 (タイムライン側 title 変更 → プロット側反映) も同様に確認
  - [ ] フッター保存ボタンで位置を変更した状態が IndexedDB に保存されること (既存挙動維持)

## 設計議論との整合 (経緯記録)

- 当初オーダー (本田様): タイトル同期解消 + 単体更新即反映 + フッター = 位置/関係保存役割
- PR-A1 で基盤 (純粋関数 + upsert/delete action) を整備
- 中盤 AI 側が「Codex H1-H4 指摘を理由に案 A (フッター削除まで) に方向転換」を誘導 → これは 4 原則 §1 越権
- 本田様の指摘で当初オーダー (フッター残す) に立ち戻り、本 PR で「最小変更 = caller 追加のみ」のスコープに修正
- Codex H1/H2 指摘は本田様判断で許容、追加対応なし
- 当初の代替 C (PR-1A) と実質同じ着地点

🤖 Generated with [Claude Code](https://claude.com/claude-code)