### PR TITLE
docs(handoff): 2026-06-18 PR #183 完走 (タイムライン孤児化バグ Phase 1 hotfix)

### DIFF
--- a/docs/handoff/2026-06-14b-pr178-plotboard-single-save.md
+++ b/docs/handoff/2026-06-14b-pr178-plotboard-single-save.md
@@ -1,0 +1,164 @@
+# Handoff: プロットボード単体保存 当初オーダー C 完走 (PR #176 + #178)
+
+- Session Date: 2026-06-14 (2 セッション分の連続作業を 1 ファイルに集約)
+- Owner: yasushi-honda
+- Status: ✅ **PR #176 + #178 マージ完了、当初オーダー 3 件すべて達成**
+- Previous: [2026-06-09-pr173-174-chapter-id-migration.md](./2026-06-09-pr173-174-chapter-id-migration.md)
+
+## 本セッション PR
+
+| PR | コミット | 内容 |
+|----|---------|------|
+| **#176** | `204411b` | feat(plotboard): タイトル同期判定の純粋関数化 + カード/イベント単体保存 action 追加 (PR-A1) — dataSlice 基盤整備、UI 変更なし、挙動完全不変 |
+| **#177** | `1140780` | docs(handoff): PR #176 中間 handoff (PR-A1 完走時点) |
+| **#178** | `dc0cd9f` | feat(plotboard): カード/イベント単体保存で upsert action を即時発火 (PR-A2) — caller 2 ファイルに +10 行追加、当初オーダー達成 |
+
+## 当初オーダー (本田様) 達成状況
+
+| # | オーダー | 達成 |
+|---|---------|------|
+| 1 | タイムライン側でタイトル変更したらプロットボード側も同期 | ✅ `computeEventTitleSync` 経由で発火 (PR-A2) |
+| 2 | 単体更新が全体保存と同等の状態 | ✅ `upsertPlotItem` / `upsertTimelineEvent` が 2 秒 debounce で IndexedDB 反映 (PR-A2) |
+| 3 | フッターボタン = 位置関係と相関関係の保存役割 | ✅ フッター削除せず残置、実態として位置・関係・色の保存役割に絞られた |
+
+## 実装サマリ (PR-A1 + PR-A2 合算)
+
+### PR-A1 (基盤、`204411b`)
+- `store/dataSlice.ts`:
+  - 純粋関数 `computePlotTitleSync` / `computeEventTitleSync` を切り出し (戻り値で `counterpartPatch` / `syncDialog` を返す、副作用ゼロ)
+  - 新規 action: `upsertPlotItem` / `deletePlotItem` / `upsertTimelineEvent` / `deleteTimelineEvent`
+  - history ノード非積みポリシー (`setActiveProjectData` に historyLabel 渡さない → markDirty のみ)
+  - title 変更検知時のみ `lastModified` を `Date.now()` で更新
+  - 既存 `handleSavePlotBoard` / `handleSaveTimeline` を純粋関数経由にリファクタ (挙動不変)
+- `store/dataSlice.upsert.test.ts`: 新規 18 テスト (純粋関数 6 × 2 + action contract 6)
+
+### PR-A2 (caller 追加、`dc0cd9f`)
+- `components/PlotBoardModal.tsx`:
+  - `useStore` から `upsertPlotItem` 取得 (+3 行)
+  - `handleSaveCard` で `upsertPlotItem(card)` 追加発火 (+2 行)
+- `components/TimelineModal.tsx`:
+  - `useStore` から `upsertTimelineEvent` 取得 (+3 行)
+  - `handleSaveEvent` で `upsertTimelineEvent(eventToSave)` 追加発火 (+2 行)
+- 合計 +10 行、local state は維持 (二重書き)、フッター保存ボタンも維持
+
+### 削除されなかったもの (意図的)
+- PlotBoardModal / TimelineModal の local state (items / localTimeline / positions / etc.)
+- フッター保存ボタン (位置・関係・色の保存役割で残置)
+- ConfirmCloseModal / キャンセル / 削除挙動
+- `handleSavePlotBoard` / `handleSaveTimeline` (既存テスト 9 件と互換維持)
+
+## 設計議論の経緯と反省点 (重要、次セッション AI 向け学習資料)
+
+### 経緯
+1. **当初オーダー (本田様)**: タイトル同期 + 単体更新即反映 + フッター = 位置/関係保存役割 (= 案 C)
+2. **AI 提案**: 代替 A (全自動 + フッター削除) / 代替 C (PR-1A だけ) / 二層モデル を比較提示し、案 C で着地
+3. **Codex セカンドオピニオン**: H1 stale overwrite / H2 キャンセル semantics / H3 削除非対称 / H4 history 汚染 の 4 件指摘
+4. **AI の越権 (反省点)**: 「H1-H4 を吸収するなら最終的に A の方が筋」「PR-1A 経由で段階的に A に行こう」と方向転換を誘導 → 案 Y (A 直行 + 3 PR 段階分割) を採用、PR-A1 を「dataSlice 基盤整備、UI 変更なし」スコープに縮小
+5. **PR #176 (PR-A1) マージ**: 基盤は整ったが、caller がないため体感バグ未解消
+6. **本田様の指摘**: 「PR-A2 のスコープにフッター削除が入ってる? それは当初オーダーから外れるよね?」
+7. **AI の越権撤回**: 反論せず初回指摘で認め、当初オーダー (フッター残す) に立ち戻り、PR-A2 のスコープを「caller 追加発火のみ」に縮小
+8. **PR #178 (PR-A2) マージ**: 当初オーダー 3 件達成、Codex H1-H2 は本田様判断で許容
+
+### 反省点と次セッション AI 向けメタ学習
+
+| 反省点 | 教訓 |
+|------|------|
+| AI が Codex 指摘 (H1-H4) を「許容不可」と独断判断し、当初オーダーを上書きする方向転換を提案した | **Codex 指摘の「許容するか / しないか」は decision-maker 領分** (AI は指摘内容と影響範囲を提示するだけに留め、許容可否を勝手に判断しない、4 原則 §1) |
+| 「最終形は A の方がメンテコストが低い」と AI が論じて 3 PR 段階分割を提案 | **「最終形どうあるべきか」も decision-maker 領分**。AI が「最適解」を推す姿勢自体が越権 |
+| 本田様の「シンプル設計はどんなアドバイス?」「C で十分?」の問いに、AI が常に複数選択肢で答えるあまり、当初の合意が薄れた | **decision-maker の当初オーダーには常に立ち戻る**。AI 側から「もっと良い案」を提案するのは、明示的にアドバイス求められた時だけ。それも「当初オーダーを変えるべき強い根拠」がない限り、当初オーダーを「現状解」として推す |
+| PR-A2 着手段階で本田様が指摘するまで AI 自身が越権に気づかなかった | **handoff / 計画提示時に「当初オーダーと現スコープの整合性」を毎回明示する**。乖離していれば自分で立ち戻る |
+
+### 関連グローバル feedback (既存)
+- [feedback_ai_executable_scope_abc.md](../../memory/feedback_ai_executable_scope_abc.md) — A/B/C 分類 (C 案は起点 unclear なら却下候補)
+- [feedback_oq_decision_maker_vs_executor_role_check.md](../../memory/feedback_oq_decision_maker_vs_executor_role_check.md) — OQ 提案時の決裁者/実作業者分離
+- [feedback_global_vs_project_ai_scope.md](../../memory/feedback_global_vs_project_ai_scope.md) — project-scope AI は global 設定への能動提案禁止
+
+本事案で得た学習は、上記既存 feedback の「設計議論中における Codex 指摘の許容可否判断は decision-maker 領分」という側面に追加価値あり。グローバル memory への追加は本セッションでは行わず、handoff 内に記録 (次回類似事案が再発したら追加判断)。
+
+## Issue Net 変化
+
+- Close: 0 件
+- 起票: 0 件
+- Net: **0 件** (Issue 起票なし、PR で完結)
+
+## 残 Open Issue (前 handoff から不変)
+
+| Issue | 内容 | 緊急性 |
+|------|------|--------|
+| #137 | promptSafety umbrella (サブ #7 完了、残 #6 / #8) | LOW |
+| #147 | PII path leak | LOW |
+| #152 | update path paired signal | LOW |
+| #155 | AC-3 backward compat test gap | LOW |
+| #156 | callback register-or-forget リスク | LOW |
+
+## 次のアクション (3 分割構造)
+
+### 即着手タスク
+なし
+
+### 条件待ち (明示 trigger 付き)
+
+| # | 項目 | A/B/C | trigger | 充足時タスク |
+|---|------|-------|---------|------------|
+| 1 | **PR-A2 の実機確認** (Cloud Run dev デプロイ完了後、本田様による) | B 検出 | Cloud Run dev デプロイ完了 + 本田様の実機操作 | 本田様: プロットボードでカード title 変更 → CardEditorModal 保存 → フッター押さず閉じる → タイムラインで title 同期確認 + トースト表示確認。問題なければ完走、想定外なら追加調整指示 |
+| 2 | Issue #137 / #147 / #152 / #155 / #156 着手 | B 修正 | decision-maker が「Issue #XXX 着手して」等の番号単位指示 | impl-plan → tdd → safe-refactor → code-review |
+| 3 | 前 handoff の条件待ち 7 件 (description セクション視覚強調 / タイムライン未反映切り分け / prod 構築 / setup-safety-event-metrics / Cloud Logging baseline / 残 Issue 優先順位 / D1〜D5 起票判断) | 各種 | 前 handoff [2026-06-09-pr173-174-chapter-id-migration.md](./2026-06-09-pr173-174-chapter-id-migration.md) 参照 | 同左 |
+| 4 | プロットボード関連の dead code 整理 (`deletePlotItem` / `deleteTimelineEvent` は PR-A1 で追加したが、PR-A2 のスコープ縮小で caller なし → 将来使うなら維持、不要なら別 PR で削除) | A 修正 (housekeeping) | decision-maker の明示指示 | 削除する場合: dataSlice.ts から該当 action 削除 + dataSlice.upsert.test.ts の対応テスト削除。維持する場合: 用途のコメント追加のみ |
+
+### 却下候補 (記録のみ、包括指示の対象外)
+
+| # | 項目 | A/B/C | 着手しない理由 |
+|---|------|-------|--------------|
+| 1 | Codex H1 (stale overwrite) / H2 (キャンセル semantics) の追加対応 | C | 本田様判断で許容済。実害発生時に再判断 |
+| 2 | local state 廃止 / フッター保存ボタン削除 (元 PR-A2 案 Y 部分) | C | 当初オーダーから外れる、AI 起点提案は越権 |
+| 3 | プロットボード以外の UI 改善提案 | C | 起点 unclear、4 原則 §1 違反 |
+| 4 | `0002-plotboard-autosync` ADR 起票 | A | 本田様明示指示なし、handoff 内記録で十分 |
+| 5 | グローバル memory への新規 feedback 追加 (本セッションの AI 越権事案) | A | 既存 feedback (ai_executable_scope_abc 等) で当該観点はカバー済、追加価値判定は次回類似事案再発時 |
+
+## 構造的整合性チェック
+
+| 観点 | 該当性 | 状態 |
+|------|-------|------|
+| 型・共有ロジック・設定ファイル変更 | ❌ 該当なし | ⏭️ スキップ |
+| 新規テーブル / API 追加 | ❌ 該当なし | ⏭️ スキップ |
+| データフロー実装 | ✅ 該当 (CardEditorModal → upsertPlotItem → setActiveProjectData → markDirty → 2秒 debounce → IndexedDB) | ⚠️ `/trace-dataflow` 未実行。次セッションで本田様の実機確認が「全レイヤー到達」の実証となる、または追加で `/trace-dataflow` を `condition` ベースで実行可能 |
+
+## グローバル memory scope チェック (§4.5)
+
+本セッションで `memory/feedback_*.md` / `memory/reference_*.md` / `memory/MEMORY.md` への編集なし → ⏭️ スキップ
+
+## CI 状態
+
+- PR #178 (PR-A2) マージ後の main の `Deploy to Cloud Run` workflow が handoff 取得時点で `in_progress` (46s 経過)
+- 実機 URL: https://novel-writer-ramnh3ulya-an.a.run.app (Cloud Run dev)
+- デプロイ完了後、本田様の実機確認待ち (条件待ち #1)
+
+## 残留プロセス
+
+| プロセス | 所属プロジェクト | 扱い |
+|---------|--------------|------|
+| firebase emulators (`demo-visitcare` project) | visitcare-shift-optimizer | 本プロジェクト外、kill 提案なし (越権回避) |
+| cloud-firestore-emulator-v1.20.2.jar | 同上 | 同上 |
+
+本プロジェクト由来の残留プロセスは ✅ なし。
+
+## 再開可能性判定
+
+| 項目 | 状態 |
+|------|------|
+| Git Status | ✅ clean (本 handoff ブランチを除く) |
+| Open PR | 本 handoff PR のみ |
+| Active Issue | 5 件 (全て LOW + decision-maker 判断待ち、前 handoff から不変) |
+| CI | ⏳ main の Deploy to Cloud Run in_progress (PR #178 由来) |
+| 残留プロセス | ✅ なし (本プロジェクト由来) |
+| 即着手タスク | 0 件 |
+| 条件待ち | 4 件 (本田様の実機確認 / Issue 着手 / 前 handoff 7 件 / dead code 整理) |
+
+## 最終結論
+
+✅ **セッション終了可**
+
+- PR #176 + #178 マージ完了、当初オーダー 3 件すべてコード上達成
+- 即着手 0 / 条件待ちはすべて decision-maker trigger 待ち (本田様の実機確認 / Issue 番号指示)
+- 設計議論で AI 側越権あり、handoff 内に反省と教訓を記録 (次セッション AI 向け学習資料として)
+- CI deploy 結果は本田様の実機確認で代替検証されるため、本セッション目的達成は CI 結果に依存しない

--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -1,127 +1,161 @@
-# Handoff: プロットボード単体保存 当初オーダー C 完走 (PR #176 + #178)
+# Handoff: タイムライン孤児化バグ Phase 1 hotfix 完走 (PR #183) + Issue 整理 (#180/#181/#182)
 
-- Session Date: 2026-06-14 (2 セッション分の連続作業を 1 ファイルに集約)
+- Session Date: 2026-06-18
 - Owner: yasushi-honda
-- Status: ✅ **PR #176 + #178 マージ完了、当初オーダー 3 件すべて達成**
-- Previous: [2026-06-09-pr173-174-chapter-id-migration.md](./2026-06-09-pr173-174-chapter-id-migration.md)
+- Status: ✅ **PR #183 マージ完了、Issue #181 Phase 1 達成**
+- Previous: [2026-06-14b-pr178-plotboard-single-save.md](./2026-06-14b-pr178-plotboard-single-save.md)
 
-## 本セッション PR
+## 本セッション PR / Issue
 
-| PR | コミット | 内容 |
-|----|---------|------|
-| **#176** | `204411b` | feat(plotboard): タイトル同期判定の純粋関数化 + カード/イベント単体保存 action 追加 (PR-A1) — dataSlice 基盤整備、UI 変更なし、挙動完全不変 |
-| **#177** | `1140780` | docs(handoff): PR #176 中間 handoff (PR-A1 完走時点) |
-| **#178** | `dc0cd9f` | feat(plotboard): カード/イベント単体保存で upsert action を即時発火 (PR-A2) — caller 2 ファイルに +10 行追加、当初オーダー達成 |
+| 種別 | # | 内容 | 状態 |
+|------|---|------|------|
+| **PR** | **#183** | fix(timeline): デフォルトレーン uuid 再生成解消 + 孤児 event 救済 (Issue #181 Phase 1) | ✅ Squash merged into main (`84237d2`) |
+| Issue | #180 | プロットボード: フッター保存ボタン廃止 → 全項目を自動保存化 (enhancement, P2) | open (Phase 3 候補) |
+| Issue | #181 | タイムライン: 新規イベント作成 / レーン操作で各所にバグ (bug, P1) | open (Phase 1 完了、Phase 2/3 残) |
+| Issue | #182 | createEventFromPlot: laneId フォールバック不整合 (bug, P2) | open (Phase 4 候補) |
 
 ## 当初オーダー (本田様) 達成状況
 
 | # | オーダー | 達成 |
 |---|---------|------|
-| 1 | タイムライン側でタイトル変更したらプロットボード側も同期 | ✅ `computeEventTitleSync` 経由で発火 (PR-A2) |
-| 2 | 単体更新が全体保存と同等の状態 | ✅ `upsertPlotItem` / `upsertTimelineEvent` が 2 秒 debounce で IndexedDB 反映 (PR-A2) |
-| 3 | フッターボタン = 位置関係と相関関係の保存役割 | ✅ フッター削除せず残置、実態として位置・関係・色の保存役割に絞られた |
+| 1 | プロットボード全自動保存化のプランへ移行可能か検討 | ✅ Issue #180 で起票、本 PR では未着手 (Phase 3 統合候補) |
+| 2 | タイムラインのバグ Issue 化 + 根本コードチェック | ✅ Issue #181 起票、Phase 1 hotfix で根治バグ修正完了 (PR #183) |
 
-## 実装サマリ (PR-A1 + PR-A2 合算)
+## 根本原因と修正内容 (Issue #181 Phase 1)
 
-### PR-A1 (基盤、`204411b`)
-- `store/dataSlice.ts`:
-  - 純粋関数 `computePlotTitleSync` / `computeEventTitleSync` を切り出し (戻り値で `counterpartPatch` / `syncDialog` を返す、副作用ゼロ)
-  - 新規 action: `upsertPlotItem` / `deletePlotItem` / `upsertTimelineEvent` / `deleteTimelineEvent`
-  - history ノード非積みポリシー (`setActiveProjectData` に historyLabel 渡さない → markDirty のみ)
-  - title 変更検知時のみ `lastModified` を `Date.now()` で更新
-  - 既存 `handleSavePlotBoard` / `handleSaveTimeline` を純粋関数経由にリファクタ (挙動不変)
-- `store/dataSlice.upsert.test.ts`: 新規 18 テスト (純粋関数 6 × 2 + action contract 6)
+### 症状 (decision-maker 報告)
+「タイムラインで新規イベント作成ができない / 追加してもすぐ消える / レーン操作にバグ」「どれもこれも駄目」
 
-### PR-A2 (caller 追加、`dc0cd9f`)
-- `components/PlotBoardModal.tsx`:
-  - `useStore` から `upsertPlotItem` 取得 (+3 行)
-  - `handleSaveCard` で `upsertPlotItem(card)` 追加発火 (+2 行)
-- `components/TimelineModal.tsx`:
-  - `useStore` から `upsertTimelineEvent` 取得 (+3 行)
-  - `handleSaveEvent` で `upsertTimelineEvent(eventToSave)` 追加発火 (+2 行)
-- 合計 +10 行、local state は維持 (二重書き)、フッター保存ボタンも維持
+### 根本原因 (Codex セカンドオピニオン PASS 92%)
 
-### 削除されなかったもの (意図的)
-- PlotBoardModal / TimelineModal の local state (items / localTimeline / positions / etc.)
-- フッター保存ボタン (位置・関係・色の保存役割で残置)
-- ConfirmCloseModal / キャンセル / 削除挙動
-- `handleSavePlotBoard` / `handleSaveTimeline` (既存テスト 9 件と互換維持)
+**PR-A2 (#178) リグレッション**: `upsertTimelineEvent` 即時 store 反映 + `useEffect([isOpen, timeline, lanes])` 依存配列 + `lanes?.length > 0 ? [...lanes] : [{ id: uuidv4(), ... }]` パターンの組み合わせで event.laneId 孤児化。
 
-## 設計議論の経緯と反省点 (重要、次セッション AI 向け学習資料)
+再現フロー:
+1. プロジェクト初回オープン: `timelineLanes=[]` → `uuidv4()` で uuid `A` のデフォルトレーン生成
+2. 「+ 新規イベントを作成」→ `event.laneId='A'` → `upsertTimelineEvent` で即時 store 反映
+3. `props.timeline` 変化 → useEffect 再発火 → `lanes` 依然空 → 新 uuid `B` 生成
+4. 表示レーン `B`、`event.laneId='A'` 不一致 → **イベントが画面から消える**
 
-### 経緯
-1. **当初オーダー (本田様)**: タイトル同期 + 単体更新即反映 + フッター = 位置/関係保存役割 (= 案 C)
-2. **AI 提案**: 代替 A (全自動 + フッター削除) / 代替 C (PR-1A だけ) / 二層モデル を比較提示し、案 C で着地
-3. **Codex セカンドオピニオン**: H1 stale overwrite / H2 キャンセル semantics / H3 削除非対称 / H4 history 汚染 の 4 件指摘
-4. **AI の越権 (反省点)**: 「H1-H4 を吸収するなら最終的に A の方が筋」「PR-1A 経由で段階的に A に行こう」と方向転換を誘導 → 案 Y (A 直行 + 3 PR 段階分割) を採用、PR-A1 を「dataSlice 基盤整備、UI 変更なし」スコープに縮小
-5. **PR #176 (PR-A1) マージ**: 基盤は整ったが、caller がないため体感バグ未解消
-6. **本田様の指摘**: 「PR-A2 のスコープにフッター削除が入ってる? それは当初オーダーから外れるよね?」
-7. **AI の越権撤回**: 反論せず初回指摘で認め、当初オーダー (フッター残す) に立ち戻り、PR-A2 のスコープを「caller 追加発火のみ」に縮小
-8. **PR #178 (PR-A2) マージ**: 当初オーダー 3 件達成、Codex H1-H2 は本田様判断で許容
+### 修正内容 (PR #183)
 
-### 反省点と次セッション AI 向けメタ学習
+- `store/dataSlice.ts` (+42 行): `ensureDefaultLane` action 追加。`timelineLanes` 空時のみデフォルトレーンを store に実体作成 (idempotent)、既存孤児 event があれば laneId を採用 (Codex must-fix 対応)、空文字 trap 防止 (silent-failure-hunter HIGH 対応)、`warnOnceInDev` paired signal (CLAUDE.md MUST 規律遵守)
+- `components/TimelineModal.tsx` (+12/-2 行): `uuidv4` import 削除、isOpen 時に `ensureDefaultLane` 呼出 useEffect 追加、フォールバックを空配列に変更
+- `store/dataSlice.ensureDefaultLane.test.ts` (新規, 13 tests): action contract + AC-1/AC-3/AC-7 (孤児救済) + idempotent + guard + markDirty positive pin + 空文字 boundary
+- `components/TimelineModal.lane.test.ts` (新規, 6 tests): grep pin で uuid 再生成パターン復活 + mobile invariant 阻止
 
-| 反省点 | 教訓 |
+合計: 4 ファイル、+342/-2 行、19 tests 追加 (760 → 763 PASS、回帰なし)
+
+## レビュー履歴 (本 PR で取得した judgment material)
+
+| レビュー | 結果 | 反映 |
+|---------|------|------|
+| Codex セカンドオピニオン (根本原因分析) | PASS 92% | - |
+| Codex セカンドオピニオン (実装レビュー) | PARTIAL PASS 88% → must-fix「孤児 event 未復旧」 | ✅ commit `155ded2` で対応 |
+| /code-review low (ローカル diff) | findings: none | - |
+| /safe-refactor (4 ファイル) | HIGH/MEDIUM/LOW 全 0 件 | - |
+| /pr-review-toolkit:review-pr code-reviewer | Critical/Important/Suggestion 0 件 | - |
+| /pr-review-toolkit:review-pr pr-test-analyzer | rating 7 (mobile pin 不在) + rating 6 (markDirty) + rating 5 × 3 | ✅ commit `fed90e0` で対応 |
+| /pr-review-toolkit:review-pr comment-analyzer | グローバル CLAUDE.md 規範抵触 4 件 + 重複コメント 1 件 | ✅ commit `fed90e0` で対応 |
+| /pr-review-toolkit:review-pr silent-failure-hunter | **CRITICAL 1** (paired signal 不在、CLAUDE.md MUST 違反) + HIGH 1 (nullish coalescing trap) | ✅ commit `fed90e0` で対応 |
+
+## 環境変更 (グローバル影響あり、本田様承認済)
+
+- **Playwright MCP を user scope に追加**: `claude mcp add playwright -s user npx @playwright/mcp@latest` 実行 (本田様明示指示で実行)。`~/.claude.json` の `mcpServers.playwright` に追加。**全プロジェクトで自動接続される状態**。本セッションでは現セッション再起動不要 (curl 実機確認で代替) のため未使用、次回 Claude Code 起動時から利用可能。
+
+## Cloud Run デプロイ確認 (PR #183 マージ後)
+
+| 検証 | 結果 |
 |------|------|
-| AI が Codex 指摘 (H1-H4) を「許容不可」と独断判断し、当初オーダーを上書きする方向転換を提案した | **Codex 指摘の「許容するか / しないか」は decision-maker 領分** (AI は指摘内容と影響範囲を提示するだけに留め、許容可否を勝手に判断しない、4 原則 §1) |
-| 「最終形は A の方がメンテコストが低い」と AI が論じて 3 PR 段階分割を提案 | **「最終形どうあるべきか」も decision-maker 領分**。AI が「最適解」を推す姿勢自体が越権 |
-| 本田様の「シンプル設計はどんなアドバイス?」「C で十分?」の問いに、AI が常に複数選択肢で答えるあまり、当初の合意が薄れた | **decision-maker の当初オーダーには常に立ち戻る**。AI 側から「もっと良い案」を提案するのは、明示的にアドバイス求められた時だけ。それも「当初オーダーを変えるべき強い根拠」がない限り、当初オーダーを「現状解」として推す |
-| PR-A2 着手段階で本田様が指摘するまで AI 自身が越権に気づかなかった | **handoff / 計画提示時に「当初オーダーと現スコープの整合性」を毎回明示する**。乖離していれば自分で立ち戻る |
+| GitHub Actions `Deploy to Cloud Run` (run 27758299997) | ✅ success (3m19s) |
+| HTTP 生存 (`GET /`) | ✅ 200 (3.9s, 1718 bytes) |
+| Bundle 反映 (`/assets/index-GvnP8tf0.js`, 1.14 MB) | ✅ `ensureDefaultLane` 関数 2 箇所含有、`'メインストーリー'` リテラル 1 箇所 (store 側に集約)、旧 uuidv4 動的生成パターン不在 |
 
-### 関連グローバル feedback (既存)
-- [feedback_ai_executable_scope_abc.md](../../memory/feedback_ai_executable_scope_abc.md) — A/B/C 分類 (C 案は起点 unclear なら却下候補)
-- [feedback_oq_decision_maker_vs_executor_role_check.md](../../memory/feedback_oq_decision_maker_vs_executor_role_check.md) — OQ 提案時の決裁者/実作業者分離
-- [feedback_global_vs_project_ai_scope.md](../../memory/feedback_global_vs_project_ai_scope.md) — project-scope AI は global 設定への能動提案禁止
+**UI レベル実機確認** (タイムラインモーダル操作 → 新規イベント追加 → 表示維持) は本セッション内では未実施。Playwright MCP の現セッションロード未済のため、次回 Claude Code 起動後または本田様手動確認に委ねる (条件待ち #1)。
 
-本事案で得た学習は、上記既存 feedback の「設計議論中における Codex 指摘の許容可否判断は decision-maker 領分」という側面に追加価値あり。グローバル memory への追加は本セッションでは行わず、handoff 内に記録 (次回類似事案が再発したら追加判断)。
+## Artifact Registry クリーンポリシー (本田様指示で確認)
+
+`asia-northeast1-docker.pkg.dev/novel-writer-dev/novel-writer` の cleanup policy は **既に設定済み + 本番モードで動作中**:
+
+- `keep-latest-2`: `mostRecentVersions.keepCount: 2` (KEEP)
+- `delete-all-others`: `tagState: ANY` (DELETE)
+- `cleanupPolicyDryRun: false` (本番モード)
+
+現存 3 件 (`84237d2`, `d588d3a`, `dc0cd9f`) のうち最古 1 件は次の 24h バッチで自動削除予定。要望は完全に既存設定と一致しており、追加作業なし。
+
+## /doctor 21 件警告について (本セッション末で発覚)
+
+- バージョン: `2.1.181 (Claude Code)` (最新)
+- MCP 認証未済 11 件 (marketing 系、novel-writer 作業外) → 放置可
+- MCP config 不正 2 件 (gmail / google calendar、plugin 側 bug 可能性) → `/plugins` refresh 推奨
+- Plugin cache 不在 7 件 → **読み取り検証で全 cache 実在を確認、`/doctor` の誤報の可能性が高い** (`/doctor` が期待するパスと実際の cache 場所の乖離、v2.1.181 で cache 場所が変わった可能性)
+
+実害なし。次回起動時に `/plugins` を本田様が実行すれば念のため refresh されるが必須ではない。
 
 ## Issue Net 変化
 
-- Close: 0 件
-- 起票: 0 件
-- Net: **0 件** (Issue 起票なし、PR で完結)
+- Close 数: 0 件
+- 起票数: 3 件 (#180, #181, #182)
+- Net: **-3 件**
 
-## 残 Open Issue (前 handoff から不変)
+**Net ≤ 0 だが進捗ゼロではない判定根拠** (CLAUDE.md `feedback_issue_triage.md` triage 基準):
+- #181: 実害あるバグ (基準 #1) + 再現可能 (基準 #2) + decision-maker 明示指示 (基準 #5) → 起票妥当、Phase 1 完了で実害解消済
+- #180: decision-maker 明示指示 (基準 #5) → 起票妥当、Phase 3 で対応予定
+- #182: Codex セカンドオピニオンで発見 (rating ≥ 7 相当、基準 #4) + 既存バグ独立 Issue として triage 基準 #2 → 起票妥当
 
-| Issue | 内容 | 緊急性 |
-|------|------|--------|
-| #137 | promptSafety umbrella (サブ #7 完了、残 #6 / #8) | LOW |
-| #147 | PII path leak | LOW |
-| #152 | update path paired signal | LOW |
-| #155 | AC-3 backward compat test gap | LOW |
-| #156 | callback register-or-forget リスク | LOW |
+3 件すべて triage 基準を満たし、ノイズ起票ではない。Net マイナスは新規実害発見の結果として妥当。
+
+## 残 Open Issue (前 handoff から変化)
+
+| Issue | 内容 | 緊急性 | 状態変化 |
+|------|------|--------|---------|
+| **#180** | プロットボード全自動保存化 | P2 (enhancement) | **本セッション新規起票** |
+| **#181** | タイムライン全自動保存化 (Phase 2/3) + 残バグ | P1 (bug) | **本セッション新規起票、Phase 1 完了** |
+| **#182** | createEventFromPlot 整合性 | P2 (bug) | **本セッション新規起票** |
+| #137 | promptSafety umbrella | LOW | 前 handoff から不変 |
+| #147 | PII path leak | LOW | 前 handoff から不変 |
+| #152 | update path paired signal | LOW | 前 handoff から不変 |
+| #155 | AC-3 backward compat test gap | LOW | 前 handoff から不変 |
+| #156 | callback register-or-forget リスク | LOW | 前 handoff から不変 |
 
 ## 次のアクション (3 分割構造)
 
 ### 即着手タスク
-なし
+
+**なし**
+
+executor 領分で blocker なく動ける項目ゼロ。
 
 ### 条件待ち (明示 trigger 付き)
 
 | # | 項目 | A/B/C | trigger | 充足時タスク |
 |---|------|-------|---------|------------|
-| 1 | **PR-A2 の実機確認** (Cloud Run dev デプロイ完了後、本田様による) | B 検出 | Cloud Run dev デプロイ完了 + 本田様の実機操作 | 本田様: プロットボードでカード title 変更 → CardEditorModal 保存 → フッター押さず閉じる → タイムラインで title 同期確認 + トースト表示確認。問題なければ完走、想定外なら追加調整指示 |
-| 2 | Issue #137 / #147 / #152 / #155 / #156 着手 | B 修正 | decision-maker が「Issue #XXX 着手して」等の番号単位指示 | impl-plan → tdd → safe-refactor → code-review |
-| 3 | 前 handoff の条件待ち 7 件 (description セクション視覚強調 / タイムライン未反映切り分け / prod 構築 / setup-safety-event-metrics / Cloud Logging baseline / 残 Issue 優先順位 / D1〜D5 起票判断) | 各種 | 前 handoff [2026-06-09-pr173-174-chapter-id-migration.md](./2026-06-09-pr173-174-chapter-id-migration.md) 参照 | 同左 |
-| 4 | プロットボード関連の dead code 整理 (`deletePlotItem` / `deleteTimelineEvent` は PR-A1 で追加したが、PR-A2 のスコープ縮小で caller なし → 将来使うなら維持、不要なら別 PR で削除) | A 修正 (housekeeping) | decision-maker の明示指示 | 削除する場合: dataSlice.ts から該当 action 削除 + dataSlice.upsert.test.ts の対応テスト削除。維持する場合: 用途のコメント追加のみ |
+| 1 | **PR #183 UI レベル実機確認** | B 検出 | 本田様による Playwright MCP 経由実機操作 (Claude Code 再起動後に user scope の playwright server が自動接続) または本田様手動確認 | 新規プロジェクトでタイムラインモーダル開く → 「+ 新規イベントを作成」→ イベント表示維持確認、再オープンで保持確認、AC-7 (既存孤児 event) を持つ既存プロジェクトでの復旧確認 |
+| 2 | **Issue #181 Phase 2 着手** | C | decision-maker 明示指示 (「Phase 2 進めて」「#181 Phase 2 着手」等) | `handleSaveLane` / `handleDeleteEvent` / `handleDrop` の即時 store 反映 (`upsertTimelineLane` / `deleteTimelineLane` action 新規追加)、5-6 ファイル、~200 行規模 |
+| 3 | **Issue #180 着手** (プロットボード全自動保存化) | C | decision-maker 明示指示 | `upsertPlotItem` 経由で positions / relations / colors の即時 store 反映、フッター保存ボタン削除、5-10 ファイル規模 |
+| 4 | **Issue #182 着手** (createEventFromPlot 整合性) | C | decision-maker 明示指示 | `timelineLanes[0]?.id || 'default'` フォールバックを `ensureDefaultLane` 経由に統合、~20 行修正 |
+| 5 | **Issue #181 Phase 3 着手** (PB + TL 統合自動保存化) | C | Phase 2 完了 + decision-maker 明示指示 | Issue #180 + Phase 2 完了後の統合 PR、大規模 |
+| 6 | Issue #137 / #147 / #152 / #155 / #156 着手 | B 修正 | decision-maker 番号単位指示 | impl-plan → tdd → safe-refactor → code-review |
+| 7 | 前 handoff の条件待ち項目 (description 視覚強調 / タイムライン未反映切り分け 等) | 各種 | 前 handoff [2026-06-14b-pr178-plotboard-single-save.md](./2026-06-14b-pr178-plotboard-single-save.md) 参照 | 同左 |
+| 8 | Artifact Registry の現存 3 件のうち最古 1 件即削除 (手動 cleanup) | B 修正 | decision-maker 明示指示 | `gcloud artifacts docker images delete` で `dc0cd9f` (最古) を削除。24h で自動削除されるので待っても良い |
+| 9 | `/plugins` refresh (本田様操作) | A | decision-maker 任意実行 | プロンプト欄で `/plugins` 実行 → marketplace refresh、`/doctor` 警告解消の可能性 |
 
 ### 却下候補 (記録のみ、包括指示の対象外)
 
 | # | 項目 | A/B/C | 着手しない理由 |
 |---|------|-------|--------------|
-| 1 | Codex H1 (stale overwrite) / H2 (キャンセル semantics) の追加対応 | C | 本田様判断で許容済。実害発生時に再判断 |
-| 2 | local state 廃止 / フッター保存ボタン削除 (元 PR-A2 案 Y 部分) | C | 当初オーダーから外れる、AI 起点提案は越権 |
-| 3 | プロットボード以外の UI 改善提案 | C | 起点 unclear、4 原則 §1 違反 |
-| 4 | `0002-plotboard-autosync` ADR 起票 | A | 本田様明示指示なし、handoff 内記録で十分 |
-| 5 | グローバル memory への新規 feedback 追加 (本セッションの AI 越権事案) | A | 既存 feedback (ai_executable_scope_abc 等) で当該観点はカバー済、追加価値判定は次回類似事案再発時 |
+| 1 | UI 実機確認以外で本セッションの追加自走 | C | executor 領分の作業ゼロ、handoff へ流れる |
+| 2 | グローバル `~/.claude/` 設定の追加調整 (auto-update fix / cache 整理 等) | A | スコープ厳守 (CLAUDE.md プロジェクト固有 §1)、別 Claude セッション (`cd ~/.claude && claude`) で対応すべき |
+| 3 | プロットボードの「stale overwrite」リスク (Issue #180 で根治予定の PR-A2 残課題) の本 PR 内対応 | C | Phase 3 統合の対応範囲、Phase 1 hotfix のスコープ外 |
+| 4 | Playwright MCP の現セッションでの強制ロード試行 | B | 再起動が正攻法、ToolSearch で hack 的にロードしない |
+| 5 | グローバル memory への新規 feedback 追加 (本セッション学習事項) | A | 既存 feedback (`feedback_silent_fail_paired_signal.md` 等) で当該観点はカバー済、追加価値判定は次回類似事案再発時 |
 
 ## 構造的整合性チェック
 
 | 観点 | 該当性 | 状態 |
 |------|-------|------|
-| 型・共有ロジック・設定ファイル変更 | ❌ 該当なし | ⏭️ スキップ |
+| 型・共有ロジック・設定ファイル変更 | ❌ 該当なし (DataSlice interface への 1 行追加のみ、break なし) | ⏭️ スキップ |
 | 新規テーブル / API 追加 | ❌ 該当なし | ⏭️ スキップ |
-| データフロー実装 | ✅ 該当 (CardEditorModal → upsertPlotItem → setActiveProjectData → markDirty → 2秒 debounce → IndexedDB) | ⚠️ `/trace-dataflow` 未実行。次セッションで本田様の実機確認が「全レイヤー到達」の実証となる、または追加で `/trace-dataflow` を `condition` ベースで実行可能 |
+| データフロー実装 | ✅ 該当 (TimelineModal → ensureDefaultLane → setActiveProjectData → markDirty → 2 秒 debounce → IndexedDB) | ⚠️ `/trace-dataflow` 未実行。条件待ち #1 の本田様実機確認が「全レイヤー到達」の実証となる |
 
 ## グローバル memory scope チェック (§4.5)
 
@@ -129,36 +163,30 @@
 
 ## CI 状態
 
-- PR #178 (PR-A2) マージ後の main の `Deploy to Cloud Run` workflow が handoff 取得時点で `in_progress` (46s 経過)
-- 実機 URL: https://novel-writer-ramnh3ulya-an.a.run.app (Cloud Run dev)
-- デプロイ完了後、本田様の実機確認待ち (条件待ち #1)
+- PR #183 マージ後の `Deploy to Cloud Run` (run 27758299997): ✅ success (3m19s、commit `84237d2` デプロイ済)
+- curl 実機確認 (HTTP 200 + bundle 反映確認) 済
 
 ## 残留プロセス
 
-| プロセス | 所属プロジェクト | 扱い |
-|---------|--------------|------|
-| firebase emulators (`demo-visitcare` project) | visitcare-shift-optimizer | 本プロジェクト外、kill 提案なし (越権回避) |
-| cloud-firestore-emulator-v1.20.2.jar | 同上 | 同上 |
-
-本プロジェクト由来の残留プロセスは ✅ なし。
+✅ なし (本プロジェクト由来の残留プロセスゼロ)
 
 ## 再開可能性判定
 
 | 項目 | 状態 |
 |------|------|
 | Git Status | ✅ clean (本 handoff ブランチを除く) |
-| Open PR | 本 handoff PR のみ |
-| Active Issue | 5 件 (全て LOW + decision-maker 判断待ち、前 handoff から不変) |
-| CI | ⏳ main の Deploy to Cloud Run in_progress (PR #178 由来) |
+| Open PR | 本 handoff PR のみ (見込み) |
+| Active Issue | 8 件 (#180/#181/#182 本セッション新規 + #137/#147/#152/#155/#156 既存 LOW) |
+| CI | ✅ main 最新コミット (`84237d2`) のデプロイ success |
 | 残留プロセス | ✅ なし (本プロジェクト由来) |
 | 即着手タスク | 0 件 |
-| 条件待ち | 4 件 (本田様の実機確認 / Issue 着手 / 前 handoff 7 件 / dead code 整理) |
+| 条件待ち | 9 件 (Phase 2/3/4 着手指示 / 実機確認 / 既存 Issue 着手 等、すべて decision-maker trigger 待ち) |
 
 ## 最終結論
 
-✅ **セッション終了可**
+🛑 **executor 領分の作業ゼロ、即時セッション終了推奨**
 
-- PR #176 + #178 マージ完了、当初オーダー 3 件すべてコード上達成
-- 即着手 0 / 条件待ちはすべて decision-maker trigger 待ち (本田様の実機確認 / Issue 番号指示)
-- 設計議論で AI 側越権あり、handoff 内に反省と教訓を記録 (次セッション AI 向け学習資料として)
-- CI deploy 結果は本田様の実機確認で代替検証されるため、本セッション目的達成は CI 結果に依存しない
+- Issue #181 Phase 1 完了、PR #183 マージ済 + Cloud Run デプロイ成功 (bundle 反映確認済)
+- 即着手 0 / 条件待ち 9 件はすべて decision-maker trigger 待ち (Phase 2/3/4 指示 or 実機確認 or 既存 Issue 着手指示)
+- UI レベル実機確認は Playwright MCP 再起動後または本田様手動確認に委ねる (執行者領分外)
+- 包括指示「優先順にすすめて」「進めて」で動ける即着手タスクなし


### PR DESCRIPTION
## Summary

本セッション (2026-06-18) の handoff を作成。前回 handoff (2026-06-14b) はファイル名付きでアーカイブし、LATEST.md を本セッション内容に更新。

## 本セッション成果

- **PR #183 マージ完了** (Issue #181 Phase 1 hotfix: タイムライン孤児化バグ修正)
- **Issue 3 件起票**: #180 (プロットボード全自動保存化) / #181 (タイムライン全体) / #182 (createEventFromPlot 整合性)
- **Cloud Run デプロイ確認** (curl + bundle 反映確認)
- **Artifact Registry クリーンポリシー状態確認** (既設定済、要望と完全一致)
- **Playwright MCP を user scope に追加** (本田様承認の global 設定変更)

## 次セッション継承

- 即着手タスク: 0 件
- 条件待ち: 9 件 (Phase 2/3/4 着手指示 / 実機 UI 確認 / 既存 Issue 着手指示 等、すべて decision-maker trigger 待ち)
- 却下候補: 5 件

🛑 executor 領分の作業ゼロ、即時セッション終了推奨

## Test plan

- [x] LATEST.md の整合性 (本セッション PR/Issue/Codex/レビュー履歴すべて記録)
- [x] 前 handoff (2026-06-14b) のアーカイブ作成 + 相対リンク有効
- [x] 次のアクション 3 分割構造 (即着手 / 条件待ち / 却下候補)
- [x] Issue Net 変化計測 (Close 0 / 起票 3 / Net -3、triage 基準根拠明記)
- [x] 最終結論 (🛑 executor 領分の作業ゼロ)

Refs #181 (Phase 1 完了報告)

🤖 Generated with [Claude Code](https://claude.com/claude-code)