### PR TITLE
feat(timeline): lane / event 操作の単体保存化 (Issue #181 Phase 2)

### DIFF
--- a/components/TimelineModal.handlers.test.ts
+++ b/components/TimelineModal.handlers.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// Issue #181 Phase 2: 4 handler (handleSaveLane / handleDeleteLane / handleDeleteEvent / handleDrop) に
+// 対応する store action 呼び出し (upsertTimelineLane / deleteTimelineLane / deleteTimelineEvent /
+// moveTimelineEvent) が存在することを grep で pin する。
+// 将来の refactor で「local state のみ更新」パスに戻ると、フッター保存なしで閉じた時に変更が消える
+// PR-A2 由来の UX バグ family が再発するため、構造的に阻止する。
+
+describe('TimelineModal Phase 2 handler→store wiring (Issue #181 Phase 2)', () => {
+    const source = readFileSync(resolve(__dirname, 'TimelineModal.tsx'), 'utf-8');
+
+    it('4 つの store action を useStore 経由で取得している', () => {
+        expect(source).toMatch(/upsertTimelineLane\s*=\s*useStore\(state\s*=>\s*state\.upsertTimelineLane\)/);
+        expect(source).toMatch(/deleteTimelineLane\s*=\s*useStore\(state\s*=>\s*state\.deleteTimelineLane\)/);
+        expect(source).toMatch(/deleteTimelineEvent\s*=\s*useStore\(state\s*=>\s*state\.deleteTimelineEvent\)/);
+        expect(source).toMatch(/moveTimelineEvent\s*=\s*useStore\(state\s*=>\s*state\.moveTimelineEvent\)/);
+    });
+
+    it('handleSaveLane が upsertTimelineLane を呼ぶ (lane 単体保存)', () => {
+        // handleSaveLane 定義から次の handler までの範囲で upsertTimelineLane の呼び出しを確認
+        const handlerMatch = source.match(/const handleSaveLane[\s\S]*?(?=const handleDeleteLane)/);
+        expect(handlerMatch).toBeTruthy();
+        expect(handlerMatch![0]).toMatch(/upsertTimelineLane\s*\(\s*laneToSave\s*\)/);
+    });
+
+    it('handleDeleteLane が deleteTimelineLane を呼ぶ (lane + cascade + plot link cleanup)', () => {
+        const handlerMatch = source.match(/const handleDeleteLane[\s\S]*?(?=const handleSaveEvent)/);
+        expect(handlerMatch).toBeTruthy();
+        expect(handlerMatch![0]).toMatch(/deleteTimelineLane\s*\(\s*laneId\s*\)/);
+    });
+
+    it('handleDeleteEvent が deleteTimelineEvent を呼ぶ (event + plot link cleanup)', () => {
+        const handlerMatch = source.match(/const handleDeleteEvent[\s\S]*?(?=\/\/ Drag and Drop)/);
+        expect(handlerMatch).toBeTruthy();
+        expect(handlerMatch![0]).toMatch(/deleteTimelineEvent\s*\(\s*eventId\s*\)/);
+    });
+
+    it('handleDrop が moveTimelineEvent を呼ぶ (drag-drop 順序計算ベース)', () => {
+        // handleDrop は最後の handler なので、関数末尾の閉じ括弧まで
+        const handlerMatch = source.match(/const handleDrop\s*=\s*\([^)]*\)\s*=>\s*\{[\s\S]*?handleDragEnd\(\);[\s\S]*?\};/);
+        expect(handlerMatch).toBeTruthy();
+        expect(handlerMatch![0]).toMatch(/moveTimelineEvent\s*\(/);
+    });
+
+    it('Codex 推奨: handleDrop の moveTimelineEvent 呼び出しに insertBeforeEventId 引数が渡されている', () => {
+        // 全置換 setTimeline(newTimeline) ではなく、(eventId, targetLaneId, insertBeforeEventId) の
+        // 3 引数で呼ぶ責務縮小契約を pin。
+        const handlerMatch = source.match(/const handleDrop\s*=\s*\([^)]*\)\s*=>\s*\{[\s\S]*?handleDragEnd\(\);[\s\S]*?\};/);
+        expect(handlerMatch).toBeTruthy();
+        // 引数 3 つを取る call を確認
+        expect(handlerMatch![0]).toMatch(/moveTimelineEvent\s*\(\s*draggedEventId\s*,\s*targetLaneId\s*,\s*insertBeforeEventId\s*\)/);
+    });
+
+    it('Codex 推奨: setTimeline(newTimeline) のような全置換パターンを使用していない', () => {
+        // setTimeline は責務が広すぎるため採用せず moveTimelineEvent に分割した経緯を grep で pin。
+        // 将来「シンプルにするため setTimeline に戻す」refactor を阻止する。
+        expect(source).not.toMatch(/state\.setTimeline\b/);
+        expect(source).not.toMatch(/=\s*useStore\(state\s*=>\s*state\.setTimeline\)/);
+    });
+
+    it('PR-A2 リグレッション防止: handleSaveEvent の upsertTimelineEvent 呼び出しが維持されている', () => {
+        // Phase 2 で他 handler 追加に紛れて誤って消されるのを防ぐ。
+        const handlerMatch = source.match(/const handleSaveEvent[\s\S]*?(?=const handleDeleteEvent)/);
+        expect(handlerMatch).toBeTruthy();
+        expect(handlerMatch![0]).toMatch(/upsertTimelineEvent\s*\(\s*eventToSave\s*\)/);
+    });
+});

--- a/components/TimelineModal.tsx
+++ b/components/TimelineModal.tsx
@@ -40,6 +40,12 @@ export const TimelineModal: React.FC<{
     // タイトル同期 (computeEventTitleSync) と debounce 自動保存をフッター保存待ちなく発火させるため。
     const upsertTimelineEvent = useStore(state => state.upsertTimelineEvent);
     const ensureDefaultLane = useStore(state => state.ensureDefaultLane);
+    // Phase 2: lane / event 操作の単体保存。フッター保存に依存せず未保存閉じでも消えない UX。
+    // Codex セカンドオピニオン PR の指針に従い moveTimelineEvent は順序計算ベース。
+    const upsertTimelineLane = useStore(state => state.upsertTimelineLane);
+    const deleteTimelineLane = useStore(state => state.deleteTimelineLane);
+    const deleteTimelineEvent = useStore(state => state.deleteTimelineEvent);
+    const moveTimelineEvent = useStore(state => state.moveTimelineEvent);
     const eventsContainerRef = useRef<HTMLDivElement>(null);
 
 
@@ -129,6 +135,8 @@ export const TimelineModal: React.FC<{
         } else {
             setLocalLanes([...localLanes, laneToSave]);
         }
+        // Phase 2: 即時 store 反映 (フッター保存待ちで未保存閉じ消失を回避)。
+        upsertTimelineLane(laneToSave);
         setEditingLane(null);
         setIsAddingLane(false);
     };
@@ -137,9 +145,11 @@ export const TimelineModal: React.FC<{
         if (window.confirm('このレーンを削除しますか？レーン内のすべてのイベントも削除されます。')) {
             setLocalLanes(localLanes.filter(l => l.id !== laneId));
             setLocalTimeline(localTimeline.filter(e => e.laneId !== laneId));
+            // Phase 2: store 側で lane + 配下 event + plot.linkedEventId orphan 解除を atomic に実行 (Codex must-fix)。
+            deleteTimelineLane(laneId);
         }
     };
-    
+
     // Event handlers
     const handleSaveEvent = (eventToSave: TimelineEvent) => {
         const exists = localTimeline.some(e => e.id === eventToSave.id);
@@ -155,6 +165,8 @@ export const TimelineModal: React.FC<{
 
     const handleDeleteEvent = (eventId: string) => {
         setLocalTimeline(localTimeline.filter(e => e.id !== eventId));
+        // Phase 2: 即時 store 反映 + plot.linkedEventId orphan 解除 (deleteTimelineEvent 既存契約)。
+        deleteTimelineEvent(eventId);
     };
 
     // Drag and Drop handlers
@@ -208,11 +220,19 @@ export const TimelineModal: React.FC<{
         const newTimeline = localTimeline.filter(event => event.id !== draggedEventId);
         const updatedDraggedEvent = { ...draggedEvent, laneId: targetLaneId };
 
+        // Phase 2: store 側 moveTimelineEvent に渡す insertBeforeEventId を計算 (Codex 推奨の責務分離)。
+        // dragOverInfo.position === 'top' → 当該 event の直前、'bottom' → 直後 (= 次の event の直前)。
+        // dragOverInfo なし時は targetLaneId 内の末尾扱い → insertBeforeEventId = null。
+        let insertBeforeEventId: string | null = null;
         if (dragOverInfo) {
             const targetIndex = newTimeline.findIndex(event => event.id === dragOverInfo.eventId);
             if (targetIndex !== -1) {
                 const insertIndex = dragOverInfo.position === 'top' ? targetIndex : targetIndex + 1;
                 newTimeline.splice(insertIndex, 0, updatedDraggedEvent);
+                // insertIndex が末尾なら null、それ以外なら直後の event ID。
+                insertBeforeEventId = insertIndex < newTimeline.length - 1
+                    ? newTimeline[insertIndex + 1]?.id ?? null
+                    : null;
             } else {
                 newTimeline.push(updatedDraggedEvent);
             }
@@ -224,9 +244,18 @@ export const TimelineModal: React.FC<{
                     break;
                 }
             }
-            newTimeline.splice(lastEventInLaneIndex + 1, 0, updatedDraggedEvent);
+            const insertIndex = lastEventInLaneIndex + 1;
+            newTimeline.splice(insertIndex, 0, updatedDraggedEvent);
+            // /code-review 指摘 (must-fix): else 分岐でも insertBeforeEventId を計算しないと
+            // store 側で配列末尾挿入されてしまい local と不整合になる (lane 末尾 vs 配列末尾)。
+            // 直後の event の id を渡せば store も同じ位置に挿入できる。
+            insertBeforeEventId = insertIndex < newTimeline.length - 1
+                ? newTimeline[insertIndex + 1]?.id ?? null
+                : null;
         }
         setLocalTimeline(newTimeline);
+        // Phase 2: 即時 store 反映 (Codex 推奨: store 現在値から再計算する責務縮小契約)。
+        moveTimelineEvent(draggedEventId, targetLaneId, insertBeforeEventId);
         handleDragEnd(); // Reset dragging state
     };
 

--- a/store/dataSlice.deleteTimelineLane.test.ts
+++ b/store/dataSlice.deleteTimelineLane.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../analysisApi', () => ({
+    analyzeText: vi.fn(),
+}));
+
+import { createDataSlice } from './dataSlice';
+import type { Project, TimelineLane, TimelineEvent, PlotItem } from '../types';
+
+const baseProject = (): Project => ({
+    id: 'p-1',
+    name: 'P',
+    lastModified: new Date(0).toISOString(),
+    settings: [],
+    novelContent: [],
+    chatHistory: [],
+    knowledgeBase: [],
+    plotBoard: [],
+    plotTypeColors: {},
+    plotRelations: [],
+    plotNodePositions: [],
+    timeline: [],
+    timelineLanes: [],
+    characterRelations: [],
+    nodePositions: [],
+    aiSettings: {} as Project['aiSettings'],
+    displaySettings: {} as Project['displaySettings'],
+});
+
+interface FakeStore { state: Record<string, any>; set: (p: any) => void; get: () => Record<string, any>; }
+
+const createFakeStore = (initial: Record<string, any>): FakeStore => {
+    const fake: FakeStore = { state: { ...initial }, set: () => undefined, get: () => fake.state };
+    fake.set = (partial: any) => {
+        const next = typeof partial === 'function' ? partial(fake.state) : partial;
+        fake.state = { ...fake.state, ...next };
+    };
+    fake.get = () => fake.state;
+    return fake;
+};
+
+const mountSlice = (project: Project) => {
+    const fake = createFakeStore({});
+    const slice = createDataSlice(fake.set, fake.get);
+    const openModal = vi.fn();
+    const showToast = vi.fn();
+    const addHistory = vi.fn();
+    const markDirty = vi.fn();
+    fake.state = {
+        ...slice,
+        activeProjectId: 'p-1',
+        allProjectsData: { 'p-1': project },
+        openModal,
+        showToast,
+        addHistory,
+        markDirty,
+        closeModal: vi.fn(),
+    };
+    return { slice, fake, openModal, showToast, addHistory, markDirty };
+};
+
+const lane = (id: string, name = 'L'): TimelineLane => ({ id, name, color: '#000000' });
+const event = (id: string, laneId: string): TimelineEvent => ({
+    id, laneId, title: `event-${id}`, timestamp: '', description: '', lastModified: 0,
+});
+const plot = (id: string, linkedEventId?: string): PlotItem => ({
+    id, title: `plot-${id}`, summary: '', plotType: 'main',
+    linkedEventId, lastModified: 0,
+} as any);
+
+describe('deleteTimelineLane (action) — Issue #181 Phase 2 single-save', () => {
+    beforeEach(() => { vi.useFakeTimers(); vi.setSystemTime(new Date('2026-06-19T00:00:00Z')); });
+    afterEach(() => { vi.useRealTimers(); });
+
+    it('AC-2a: 該当 lane を timelineLanes から filter する', () => {
+        const project: Project = {
+            ...baseProject(),
+            timelineLanes: [lane('keep-1'), lane('remove'), lane('keep-2')],
+        };
+        const { fake } = mountSlice(project);
+
+        fake.state.deleteTimelineLane('remove');
+
+        const updated = fake.state.allProjectsData['p-1'];
+        expect(updated.timelineLanes.map((l: TimelineLane) => l.id)).toEqual(['keep-1', 'keep-2']);
+    });
+
+    it('AC-2b: 該当 lane に紐づく events を timeline から cascade 削除する', () => {
+        const project: Project = {
+            ...baseProject(),
+            timelineLanes: [lane('remove'), lane('keep')],
+            timeline: [event('e1', 'remove'), event('e2', 'keep'), event('e3', 'remove')],
+        };
+        const { fake } = mountSlice(project);
+
+        fake.state.deleteTimelineLane('remove');
+
+        const updated = fake.state.allProjectsData['p-1'];
+        expect(updated.timeline.map((e: TimelineEvent) => e.id)).toEqual(['e2']);
+    });
+
+    it('AC-2c (Codex must-fix): cascade 削除された event を指す plotBoard.linkedEventId を undefined に解除する', () => {
+        // Codex セカンドオピニオン指摘:
+        // lane 削除 → 配下 event filter → 削除済 event を指す plot.linkedEventId が orphan に残る。
+        // 既存 handleSaveTimeline (フッター保存) との link cleanup 責務の非対称を回避する。
+        const project: Project = {
+            ...baseProject(),
+            timelineLanes: [lane('remove')],
+            timeline: [event('e1', 'remove'), event('e2', 'remove')],
+            plotBoard: [
+                plot('p1', 'e1'),
+                plot('p2', 'e2'),
+                plot('p3', 'unrelated'),  // 削除対象外
+                plot('p4'),                // link なし
+            ],
+        };
+        const { fake } = mountSlice(project);
+
+        fake.state.deleteTimelineLane('remove');
+
+        const updated = fake.state.allProjectsData['p-1'];
+        const plotById = new Map<string, PlotItem>(
+            updated.plotBoard.map((p: PlotItem) => [p.id, p])
+        );
+        expect(plotById.get('p1')!.linkedEventId).toBeUndefined();
+        expect(plotById.get('p2')!.linkedEventId).toBeUndefined();
+        expect(plotById.get('p3')!.linkedEventId).toBe('unrelated');  // 無関係 link は維持
+        expect(plotById.get('p4')!.linkedEventId).toBeUndefined();    // 元々 null
+    });
+
+    it('AC-2c: cascade 削除された plot 側の lastModified は更新される (link 解除も変更扱い)', () => {
+        const project: Project = {
+            ...baseProject(),
+            timelineLanes: [lane('remove')],
+            timeline: [event('e1', 'remove')],
+            plotBoard: [plot('p1', 'e1')],
+        };
+        (project.plotBoard[0] as any).lastModified = 100;
+        const { fake } = mountSlice(project);
+
+        fake.state.deleteTimelineLane('remove');
+
+        const updated = fake.state.allProjectsData['p-1'];
+        expect((updated.plotBoard[0] as PlotItem).lastModified).toBeGreaterThan(100);
+    });
+
+    it('該当 lane が存在しない場合は no-op (例外を投げない、timelineLanes / timeline / plotBoard 不変)', () => {
+        const project: Project = {
+            ...baseProject(),
+            timelineLanes: [lane('keep')],
+            timeline: [event('e1', 'keep')],
+            plotBoard: [plot('p1', 'e1')],
+        };
+        const { fake, markDirty } = mountSlice(project);
+        const beforeTimelineLanes = project.timelineLanes;
+        const beforeTimeline = project.timeline;
+        const beforePlotBoard = project.plotBoard;
+
+        expect(() => fake.state.deleteTimelineLane('non-existent')).not.toThrow();
+
+        const updated = fake.state.allProjectsData['p-1'];
+        expect(updated.timelineLanes).toEqual(beforeTimelineLanes);
+        expect(updated.timeline).toEqual(beforeTimeline);
+        expect(updated.plotBoard).toEqual(beforePlotBoard);
+        expect(markDirty).not.toHaveBeenCalled();
+    });
+
+    it('cascade events ゼロでも lane 単独削除は成功 (event 連鎖なし lane の削除)', () => {
+        const project: Project = {
+            ...baseProject(),
+            timelineLanes: [lane('lonely')],
+            timeline: [],
+            plotBoard: [],
+        };
+        const { fake, markDirty } = mountSlice(project);
+
+        fake.state.deleteTimelineLane('lonely');
+
+        const updated = fake.state.allProjectsData['p-1'];
+        expect(updated.timelineLanes).toEqual([]);
+        expect(markDirty).toHaveBeenCalledTimes(1);
+    });
+
+    it('lastModified が更新される (markDirty 経由で自動保存トリガー)', () => {
+        const project: Project = {
+            ...baseProject(),
+            timelineLanes: [lane('x')],
+        };
+        const { fake } = mountSlice(project);
+        const before = fake.state.allProjectsData['p-1'].lastModified;
+
+        fake.state.deleteTimelineLane('x');
+
+        const updated = fake.state.allProjectsData['p-1'];
+        expect(updated.lastModified).not.toBe(before);
+    });
+
+    it('成功時に markDirty が 1 回呼ばれる (auto-save signal positive pin)', () => {
+        const project: Project = {
+            ...baseProject(),
+            timelineLanes: [lane('x')],
+        };
+        const { fake, markDirty } = mountSlice(project);
+
+        fake.state.deleteTimelineLane('x');
+
+        expect(markDirty).toHaveBeenCalledTimes(1);
+    });
+
+    it('history を積まない (addHistory が呼ばれない、PR-A1/A2 規約に準拠)', () => {
+        const project: Project = {
+            ...baseProject(),
+            timelineLanes: [lane('x')],
+        };
+        const { fake, addHistory } = mountSlice(project);
+
+        fake.state.deleteTimelineLane('x');
+
+        expect(addHistory).not.toHaveBeenCalled();
+    });
+
+    it('activeProjectId が null の場合は no-op (例外を投げない)', () => {
+        const project: Project = { ...baseProject(), timelineLanes: [lane('x')] };
+        const { fake } = mountSlice(project);
+        fake.state.activeProjectId = null;
+
+        expect(() => fake.state.deleteTimelineLane('x')).not.toThrow();
+        expect(fake.state.allProjectsData['p-1'].timelineLanes).toHaveLength(1);
+    });
+
+    it('activeProjectId に対応する project が存在しない場合は no-op (例外を投げない)', () => {
+        const project: Project = { ...baseProject() };
+        const { fake } = mountSlice(project);
+        fake.state.activeProjectId = 'non-existent';
+
+        expect(() => fake.state.deleteTimelineLane('x')).not.toThrow();
+    });
+});

--- a/store/dataSlice.moveTimelineEvent.test.ts
+++ b/store/dataSlice.moveTimelineEvent.test.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../analysisApi', () => ({
+    analyzeText: vi.fn(),
+}));
+
+import { createDataSlice } from './dataSlice';
+import type { Project, TimelineEvent, PlotItem } from '../types';
+
+const baseProject = (): Project => ({
+    id: 'p-1',
+    name: 'P',
+    lastModified: new Date(0).toISOString(),
+    settings: [],
+    novelContent: [],
+    chatHistory: [],
+    knowledgeBase: [],
+    plotBoard: [],
+    plotTypeColors: {},
+    plotRelations: [],
+    plotNodePositions: [],
+    timeline: [],
+    timelineLanes: [],
+    characterRelations: [],
+    nodePositions: [],
+    aiSettings: {} as Project['aiSettings'],
+    displaySettings: {} as Project['displaySettings'],
+});
+
+interface FakeStore { state: Record<string, any>; set: (p: any) => void; get: () => Record<string, any>; }
+
+const createFakeStore = (initial: Record<string, any>): FakeStore => {
+    const fake: FakeStore = { state: { ...initial }, set: () => undefined, get: () => fake.state };
+    fake.set = (partial: any) => {
+        const next = typeof partial === 'function' ? partial(fake.state) : partial;
+        fake.state = { ...fake.state, ...next };
+    };
+    fake.get = () => fake.state;
+    return fake;
+};
+
+const mountSlice = (project: Project) => {
+    const fake = createFakeStore({});
+    const slice = createDataSlice(fake.set, fake.get);
+    const openModal = vi.fn();
+    const showToast = vi.fn();
+    const addHistory = vi.fn();
+    const markDirty = vi.fn();
+    fake.state = {
+        ...slice,
+        activeProjectId: 'p-1',
+        allProjectsData: { 'p-1': project },
+        openModal,
+        showToast,
+        addHistory,
+        markDirty,
+        closeModal: vi.fn(),
+    };
+    return { slice, fake, openModal, showToast, addHistory, markDirty };
+};
+
+const event = (id: string, laneId: string, title = `event-${id}`): TimelineEvent => ({
+    id, laneId, title, timestamp: '', description: '', lastModified: 0,
+});
+
+describe('moveTimelineEvent (action) — Issue #181 Phase 2 single-save (drag-drop)', () => {
+    beforeEach(() => { vi.useFakeTimers(); vi.setSystemTime(new Date('2026-06-19T00:00:00Z')); });
+    afterEach(() => { vi.useRealTimers(); });
+
+    it('AC-3e (/code-review must-fix): targetLane の最後の event の id を insertBeforeEventId に渡すと、その直前=lane 末尾位置に挿入される', () => {
+        // 回帰防止: handler 側の else 分岐 (dragOverInfo===null) で store と local の挿入位置が
+        // 不一致になる bug の規律 pin。handler が「lane 末尾」を狙うときは、配列末尾でなく
+        // 「次の lane の最初の event の id」を insertBeforeEventId として渡す契約。
+        const project: Project = {
+            ...baseProject(),
+            timeline: [
+                event('a1', 'laneA'),
+                event('a2', 'laneA'),
+                event('b1', 'laneB'),  // ← laneA の末尾は a2 / 配列末尾は b1
+                event('c1', 'laneC'),
+            ],
+        };
+        const { fake } = mountSlice(project);
+
+        // c1 を laneA の末尾 (a2 と b1 の間) に挿入する → insertBeforeEventId='b1'
+        fake.state.moveTimelineEvent('c1', 'laneA', 'b1');
+
+        const updated = fake.state.allProjectsData['p-1'];
+        expect(updated.timeline.map((e: TimelineEvent) => e.id)).toEqual(['a1', 'a2', 'c1', 'b1']);
+        const moved = updated.timeline.find((e: TimelineEvent) => e.id === 'c1');
+        expect(moved.laneId).toBe('laneA');
+    });
+
+    it('AC-3a: lane 間移動 — eventId の laneId が targetLaneId に更新される', () => {
+        const project: Project = {
+            ...baseProject(),
+            timeline: [event('e1', 'lane-A'), event('e2', 'lane-B')],
+        };
+        const { fake } = mountSlice(project);
+
+        fake.state.moveTimelineEvent('e1', 'lane-B', null);
+
+        const updated = fake.state.allProjectsData['p-1'];
+        const moved = updated.timeline.find((e: TimelineEvent) => e.id === 'e1');
+        expect(moved.laneId).toBe('lane-B');
+    });
+
+    it('AC-3b: insertBeforeEventId=null は配列末尾に挿入', () => {
+        const project: Project = {
+            ...baseProject(),
+            timeline: [event('e1', 'lane-A'), event('e2', 'lane-A'), event('e3', 'lane-A')],
+        };
+        const { fake } = mountSlice(project);
+
+        fake.state.moveTimelineEvent('e1', 'lane-A', null);
+
+        const updated = fake.state.allProjectsData['p-1'];
+        expect(updated.timeline.map((e: TimelineEvent) => e.id)).toEqual(['e2', 'e3', 'e1']);
+    });
+
+    it('AC-3c: insertBeforeEventId 指定で当該 event の直前に挿入', () => {
+        const project: Project = {
+            ...baseProject(),
+            timeline: [event('e1', 'lane-A'), event('e2', 'lane-A'), event('e3', 'lane-A')],
+        };
+        const { fake } = mountSlice(project);
+
+        // e3 を e2 の直前に動かす
+        fake.state.moveTimelineEvent('e3', 'lane-A', 'e2');
+
+        const updated = fake.state.allProjectsData['p-1'];
+        expect(updated.timeline.map((e: TimelineEvent) => e.id)).toEqual(['e1', 'e3', 'e2']);
+    });
+
+    it('AC-3d: 同一 event を同一 lane の同一位置に動かす — 順序維持 (no-op 相当)', () => {
+        const project: Project = {
+            ...baseProject(),
+            timeline: [event('e1', 'lane-A'), event('e2', 'lane-A')],
+        };
+        const { fake } = mountSlice(project);
+
+        // e1 を e2 の前に動かす = 既に e2 の前にいる → 順序維持
+        fake.state.moveTimelineEvent('e1', 'lane-A', 'e2');
+
+        const updated = fake.state.allProjectsData['p-1'];
+        expect(updated.timeline.map((e: TimelineEvent) => e.id)).toEqual(['e1', 'e2']);
+    });
+
+    it('存在しない eventId は no-op (例外を投げない、timeline 不変)', () => {
+        const project: Project = {
+            ...baseProject(),
+            timeline: [event('e1', 'lane-A')],
+        };
+        const { fake, markDirty } = mountSlice(project);
+        const beforeTimeline = project.timeline;
+
+        expect(() => fake.state.moveTimelineEvent('non-existent', 'lane-A', null)).not.toThrow();
+        expect(fake.state.allProjectsData['p-1'].timeline).toEqual(beforeTimeline);
+        expect(markDirty).not.toHaveBeenCalled();
+    });
+
+    it('insertBeforeEventId が存在しない event の ID の場合は末尾挿入 (fallback)', () => {
+        const project: Project = {
+            ...baseProject(),
+            timeline: [event('e1', 'lane-A'), event('e2', 'lane-A')],
+        };
+        const { fake } = mountSlice(project);
+
+        fake.state.moveTimelineEvent('e1', 'lane-A', 'non-existent');
+
+        const updated = fake.state.allProjectsData['p-1'];
+        expect(updated.timeline.map((e: TimelineEvent) => e.id)).toEqual(['e2', 'e1']);
+    });
+
+    it('Codex 指摘: plotBoard を変更しない (link cleanup は責務外、handleSaveTimeline / deleteTimelineEvent の責務)', () => {
+        const project: Project = {
+            ...baseProject(),
+            timeline: [event('e1', 'lane-A')],
+            plotBoard: [{ id: 'p1', title: 'P', summary: '', plotType: 'main', linkedEventId: 'e1', lastModified: 100 } as unknown as PlotItem],
+        };
+        const beforePlotBoard = project.plotBoard;
+        const { fake } = mountSlice(project);
+
+        fake.state.moveTimelineEvent('e1', 'lane-B', null);
+
+        const updated = fake.state.allProjectsData['p-1'];
+        expect(updated.plotBoard).toEqual(beforePlotBoard);
+    });
+
+    it('Codex 指摘: title sync を発火しない (computePlotTitleSync は呼ばれない)', () => {
+        // moveTimelineEvent は title を変更しない契約。
+        // 万一 title 変更ロジックが混入したら plotBoard 側の title が変わってしまうため、
+        // event.title 不変を確認することで間接的に title sync 不発火を pin する。
+        const project: Project = {
+            ...baseProject(),
+            timeline: [event('e1', 'lane-A', '元タイトル')],
+            plotBoard: [{ id: 'p1', title: '他タイトル', summary: '', plotType: 'main', linkedEventId: 'e1', lastModified: 100 } as unknown as PlotItem],
+        };
+        const { fake } = mountSlice(project);
+
+        fake.state.moveTimelineEvent('e1', 'lane-B', null);
+
+        const updated = fake.state.allProjectsData['p-1'];
+        const moved = updated.timeline.find((e: TimelineEvent) => e.id === 'e1');
+        expect(moved.title).toBe('元タイトル');
+        expect((updated.plotBoard[0] as PlotItem).title).toBe('他タイトル');
+    });
+
+    it('lastModified が更新される (markDirty 経由で自動保存トリガー)', () => {
+        const project: Project = {
+            ...baseProject(),
+            timeline: [event('e1', 'lane-A')],
+        };
+        const { fake } = mountSlice(project);
+        const before = fake.state.allProjectsData['p-1'].lastModified;
+
+        fake.state.moveTimelineEvent('e1', 'lane-B', null);
+
+        const updated = fake.state.allProjectsData['p-1'];
+        expect(updated.lastModified).not.toBe(before);
+    });
+
+    it('成功時に markDirty が 1 回呼ばれる (auto-save signal positive pin)', () => {
+        const project: Project = {
+            ...baseProject(),
+            timeline: [event('e1', 'lane-A')],
+        };
+        const { fake, markDirty } = mountSlice(project);
+
+        fake.state.moveTimelineEvent('e1', 'lane-B', null);
+
+        expect(markDirty).toHaveBeenCalledTimes(1);
+    });
+
+    it('history を積まない (addHistory が呼ばれない、PR-A1/A2 規約に準拠)', () => {
+        const project: Project = {
+            ...baseProject(),
+            timeline: [event('e1', 'lane-A')],
+        };
+        const { fake, addHistory } = mountSlice(project);
+
+        fake.state.moveTimelineEvent('e1', 'lane-B', null);
+
+        expect(addHistory).not.toHaveBeenCalled();
+    });
+
+    it('activeProjectId が null の場合は no-op (例外を投げない)', () => {
+        const project: Project = { ...baseProject(), timeline: [event('e1', 'lane-A')] };
+        const { fake } = mountSlice(project);
+        fake.state.activeProjectId = null;
+
+        expect(() => fake.state.moveTimelineEvent('e1', 'lane-B', null)).not.toThrow();
+        expect(fake.state.allProjectsData['p-1'].timeline[0].laneId).toBe('lane-A');
+    });
+});

--- a/store/dataSlice.ts
+++ b/store/dataSlice.ts
@@ -33,6 +33,17 @@ export interface DataSlice {
     deletePlotItem: (id: string) => void;
     upsertTimelineEvent: (event: TimelineEvent) => void;
     deleteTimelineEvent: (id: string) => void;
+    // Phase 2: レーンの単体追加・更新 (PR-A2 の upsertTimelineEvent と対称)。
+    // フッター保存を待たず即時 store 反映 + markDirty で IndexedDB debounce 発火させる。
+    upsertTimelineLane: (lane: TimelineLane) => void;
+    // Phase 2: レーン削除 + 配下 event cascade + plot.linkedEventId orphan 解除を
+    // 1 つの setActiveProjectData updater に集約する (Codex 指摘: 別 transaction 連打だと
+    // debounced save / 別操作が挟まった時に壊れた中間状態が保存される)。
+    deleteTimelineLane: (id: string) => void;
+    // Phase 2: drag-drop 用の単一 event 移動 action。
+    // store の現在値を起点に再計算するため、local snapshot 上書きリスクを構造的に排除する。
+    // 責務縮小契約 (Codex 指摘): title sync しない / plot link cleanup しない / history 積まない。
+    moveTimelineEvent: (eventId: string, targetLaneId: string, insertBeforeEventId: string | null) => void;
     // timelineLanes が空の時のみデフォルトレーンを store に実体作成する (idempotent)。
     // useEffect 側で uuid を動的生成すると props 変化で再発火するたびに新 ID になり
     // event.laneId が孤児化するため、ID 発行を store 側に集約している。
@@ -416,6 +427,84 @@ export const createDataSlice = (set, get): DataSlice => ({
             ),
             lastModified: new Date().toISOString(),
         }));
+    },
+    upsertTimelineLane: (lane: TimelineLane) => {
+        const { activeProjectId, allProjectsData, setActiveProjectData } = get();
+        if (!activeProjectId) return;
+        const project = allProjectsData[activeProjectId];
+        if (!project) return;
+
+        setActiveProjectData(d => {
+            const lanes = d.timelineLanes || [];
+            const exists = lanes.some(l => l.id === lane.id);
+            const newLanes = exists
+                ? lanes.map(l => l.id === lane.id ? lane : l)
+                : [...lanes, lane];
+            return {
+                ...d,
+                timelineLanes: newLanes,
+                lastModified: new Date().toISOString(),
+            };
+        });
+    },
+    deleteTimelineLane: (id: string) => {
+        const { activeProjectId, allProjectsData, setActiveProjectData } = get();
+        if (!activeProjectId) return;
+        const project = allProjectsData[activeProjectId];
+        if (!project) return;
+        // 該当 lane が存在しない場合は markDirty を発火させない (no-op)
+        if (!(project.timelineLanes || []).some(l => l.id === id)) return;
+
+        // Codex must-fix: lane 削除 → 配下 event filter → plot.linkedEventId orphan 解除を
+        // 同一 updater 内で atomic に行う。removedEventIds は updater 引数 d から再計算して
+        // setActiveProjectData の前提と一致させる (TOCTOU 回避)。
+        setActiveProjectData(d => {
+            const removedEventIds = new Set(
+                (d.timeline || []).filter(e => e.laneId === id).map(e => e.id)
+            );
+            const nowMs = Date.now();
+            return {
+                ...d,
+                timelineLanes: (d.timelineLanes || []).filter(l => l.id !== id),
+                timeline: (d.timeline || []).filter(e => e.laneId !== id),
+                plotBoard: (d.plotBoard || []).map(p =>
+                    p.linkedEventId !== undefined && removedEventIds.has(p.linkedEventId)
+                        ? { ...p, linkedEventId: undefined, lastModified: nowMs }
+                        : p
+                ),
+                lastModified: new Date().toISOString(),
+            };
+        });
+    },
+    moveTimelineEvent: (eventId: string, targetLaneId: string, insertBeforeEventId: string | null) => {
+        const { activeProjectId, allProjectsData, setActiveProjectData } = get();
+        if (!activeProjectId) return;
+        const project = allProjectsData[activeProjectId];
+        if (!project) return;
+        // 該当 event が存在しない場合は markDirty を発火させない (no-op)
+        if (!(project.timeline || []).some(e => e.id === eventId)) return;
+
+        setActiveProjectData(d => {
+            const timeline = d.timeline || [];
+            const target = timeline.find(e => e.id === eventId);
+            if (!target) return d;
+            const movedEvent: TimelineEvent = target.laneId === targetLaneId
+                ? target
+                : { ...target, laneId: targetLaneId };
+            const without = timeline.filter(e => e.id !== eventId);
+            // insertBeforeEventId が指定されてかつ存在すれば直前挿入、それ以外は末尾挿入。
+            const insertIndex = insertBeforeEventId
+                ? without.findIndex(e => e.id === insertBeforeEventId)
+                : -1;
+            const newTimeline = insertIndex >= 0
+                ? [...without.slice(0, insertIndex), movedEvent, ...without.slice(insertIndex)]
+                : [...without, movedEvent];
+            return {
+                ...d,
+                timeline: newTimeline,
+                lastModified: new Date().toISOString(),
+            };
+        });
     },
     ensureDefaultLane: () => {
         const { allProjectsData, activeProjectId, setActiveProjectData } = get();

--- a/store/dataSlice.upsertTimelineLane.test.ts
+++ b/store/dataSlice.upsertTimelineLane.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../analysisApi', () => ({
+    analyzeText: vi.fn(),
+}));
+
+import { createDataSlice } from './dataSlice';
+import type { Project, TimelineLane } from '../types';
+
+const baseProject = (): Project => ({
+    id: 'p-1',
+    name: 'P',
+    lastModified: new Date(0).toISOString(),
+    settings: [],
+    novelContent: [],
+    chatHistory: [],
+    knowledgeBase: [],
+    plotBoard: [],
+    plotTypeColors: {},
+    plotRelations: [],
+    plotNodePositions: [],
+    timeline: [],
+    timelineLanes: [],
+    characterRelations: [],
+    nodePositions: [],
+    aiSettings: {} as Project['aiSettings'],
+    displaySettings: {} as Project['displaySettings'],
+});
+
+interface FakeStore { state: Record<string, any>; set: (p: any) => void; get: () => Record<string, any>; }
+
+const createFakeStore = (initial: Record<string, any>): FakeStore => {
+    const fake: FakeStore = { state: { ...initial }, set: () => undefined, get: () => fake.state };
+    fake.set = (partial: any) => {
+        const next = typeof partial === 'function' ? partial(fake.state) : partial;
+        fake.state = { ...fake.state, ...next };
+    };
+    fake.get = () => fake.state;
+    return fake;
+};
+
+const mountSlice = (project: Project) => {
+    const fake = createFakeStore({});
+    const slice = createDataSlice(fake.set, fake.get);
+    const openModal = vi.fn();
+    const showToast = vi.fn();
+    const addHistory = vi.fn();
+    const markDirty = vi.fn();
+    fake.state = {
+        ...slice,
+        activeProjectId: 'p-1',
+        allProjectsData: { 'p-1': project },
+        openModal,
+        showToast,
+        addHistory,
+        markDirty,
+        closeModal: vi.fn(),
+    };
+    return { slice, fake, openModal, showToast, addHistory, markDirty };
+};
+
+describe('upsertTimelineLane (action) — Issue #181 Phase 2 single-save', () => {
+    beforeEach(() => { vi.useFakeTimers(); vi.setSystemTime(new Date('2026-06-19T00:00:00Z')); });
+    afterEach(() => { vi.useRealTimers(); });
+
+    it('AC-1a: 既存に同 ID が無ければ末尾に追加 (push)', () => {
+        const existing: TimelineLane = { id: 'lane-1', name: '既存', color: '#111111' };
+        const project: Project = { ...baseProject(), timelineLanes: [existing] };
+        const { fake } = mountSlice(project);
+
+        const incoming: TimelineLane = { id: 'lane-2', name: '新規', color: '#222222' };
+        fake.state.upsertTimelineLane(incoming);
+
+        const updated = fake.state.allProjectsData['p-1'];
+        expect(updated.timelineLanes).toEqual([existing, incoming]);
+    });
+
+    it('AC-1b: 既存に同 ID があれば in-place 更新 (map、順序維持)', () => {
+        const laneA: TimelineLane = { id: 'a', name: 'A', color: '#aaaaaa' };
+        const laneB: TimelineLane = { id: 'b', name: 'B', color: '#bbbbbb' };
+        const project: Project = { ...baseProject(), timelineLanes: [laneA, laneB] };
+        const { fake } = mountSlice(project);
+
+        const patched: TimelineLane = { id: 'a', name: 'A-renamed', color: '#cccccc' };
+        fake.state.upsertTimelineLane(patched);
+
+        const updated = fake.state.allProjectsData['p-1'];
+        expect(updated.timelineLanes).toHaveLength(2);
+        expect(updated.timelineLanes[0]).toEqual(patched);
+        expect(updated.timelineLanes[1]).toEqual(laneB);
+    });
+
+    it('lastModified が更新される (markDirty 経由で自動保存トリガー)', () => {
+        const project: Project = { ...baseProject() };
+        const { fake } = mountSlice(project);
+        const before = fake.state.allProjectsData['p-1'].lastModified;
+
+        fake.state.upsertTimelineLane({ id: 'new', name: 'N', color: '#000000' });
+
+        const updated = fake.state.allProjectsData['p-1'];
+        expect(updated.lastModified).not.toBe(before);
+    });
+
+    it('成功時に markDirty が 1 回呼ばれる (auto-save signal positive pin)', () => {
+        const project: Project = { ...baseProject() };
+        const { fake, markDirty } = mountSlice(project);
+
+        fake.state.upsertTimelineLane({ id: 'new', name: 'N', color: '#000000' });
+
+        expect(markDirty).toHaveBeenCalledTimes(1);
+    });
+
+    it('history を積まない (addHistory が呼ばれない、PR-A1/A2 規約に準拠)', () => {
+        const project: Project = { ...baseProject() };
+        const { fake, addHistory } = mountSlice(project);
+
+        fake.state.upsertTimelineLane({ id: 'new', name: 'N', color: '#000000' });
+
+        expect(addHistory).not.toHaveBeenCalled();
+    });
+
+    it('既存 timeline / plotBoard / 他フィールドを破壊しない', () => {
+        const project: Project = {
+            ...baseProject(),
+            timeline: [{ id: 'e1', title: 'E', timestamp: '', description: '', laneId: 'lane-1', lastModified: 0 }],
+            plotBoard: [{ id: 'p1', title: 'P', summary: '', plotType: 'main', linkedEventId: 'e1', lastModified: 0 } as any],
+        };
+        const { fake } = mountSlice(project);
+        const beforeTimeline = project.timeline;
+        const beforePlotBoard = project.plotBoard;
+
+        fake.state.upsertTimelineLane({ id: 'lane-1', name: 'L', color: '#000000' });
+
+        const updated = fake.state.allProjectsData['p-1'];
+        expect(updated.timeline).toEqual(beforeTimeline);
+        expect(updated.plotBoard).toEqual(beforePlotBoard);
+    });
+
+    it('activeProjectId が null の場合は no-op (例外を投げない)', () => {
+        const project: Project = { ...baseProject() };
+        const { fake } = mountSlice(project);
+        fake.state.activeProjectId = null;
+
+        expect(() => fake.state.upsertTimelineLane({ id: 'x', name: 'X', color: '#000' })).not.toThrow();
+        expect(fake.state.allProjectsData['p-1'].timelineLanes).toEqual([]);
+    });
+
+    it('activeProjectId に対応する project が存在しない場合は no-op (例外を投げない)', () => {
+        const project: Project = { ...baseProject() };
+        const { fake } = mountSlice(project);
+        fake.state.activeProjectId = 'non-existent';
+
+        expect(() => fake.state.upsertTimelineLane({ id: 'x', name: 'X', color: '#000' })).not.toThrow();
+    });
+});


### PR DESCRIPTION
## Summary

PR #183 Phase 1 (ensureDefaultLane + 孤児 event 救済) に続く Phase 2。
タイムラインモーダルの **lane 追加・編集・削除 / event 削除 / drag-drop 並び替え** を即時 store 反映化し、フッター保存を待たず「未保存で閉じても消えない」UX を実現。

Refs #181 (Phase 2)

## 設計レビュー履歴

| 段階 | 結果 |
|------|------|
| Codex セカンドオピニオン (PR 設計時) | NEEDS REVISION (確信度 86%) → 指摘反映 → PASS |
| `/safe-refactor` | HIGH/MEDIUM 0、LOW 3 (すべて保留推奨) |
| `/code-review medium` | CRITICAL 1 件発見 → 修正適用 + 回帰防止 test 追加 |

## 変更内容

### 新規 store actions (`store/dataSlice.ts` +85 行)

1. **`upsertTimelineLane(lane: TimelineLane)`**
   - 既存 `upsertTimelineEvent` と対称、push / map で upsert
   - history は積まない (PR-A1/A2 規約)

2. **`deleteTimelineLane(id: string)`** ← Codex must-fix
   - 同一 `setActiveProjectData` updater 内で 3 層 atomic cascade
   - 1) `timelineLanes` から filter
   - 2) 配下 event を `timeline` から filter
   - 3) `plot.linkedEventId` orphan を undefined に解除 + `plot.lastModified` 更新

3. **`moveTimelineEvent(eventId, targetLaneId, insertBeforeEventId)`** ← Codex 推奨
   - drag-drop 専用、責務縮小契約 (title sync しない / plot link cleanup しない / history 積まない)
   - store 現在値から再計算するため local snapshot 上書きリスクを構造的に排除

### TimelineModal handler 修正 (`components/TimelineModal.tsx` +25/-5 行)

| handler | 追加 store action |
|---------|------------------|
| `handleSaveLane` | `upsertTimelineLane(laneToSave)` |
| `handleDeleteLane` | `deleteTimelineLane(laneId)` (window.confirm 後) |
| `handleDeleteEvent` | `deleteTimelineEvent(eventId)` |
| `handleDrop` | `moveTimelineEvent(draggedEventId, targetLaneId, insertBeforeEventId)` |

### `/code-review medium` 指摘の must-fix 適用

handleDrop の else 分岐 (`dragOverInfo === null`、lane 空白部分ドロップ) で `insertBeforeEventId` を計算しないと、store 側で配列末尾挿入されて local の「lane 末尾」と不整合になる bug を修正。

```ts
// 修正前 (バグ)
} else {
    // ... lastEventInLaneIndex 計算 ...
    newTimeline.splice(lastEventInLaneIndex + 1, 0, updatedDraggedEvent);
    // insertBeforeEventId が null のまま → store 側で配列末尾挿入
}

// 修正後
} else {
    // ... lastEventInLaneIndex 計算 ...
    const insertIndex = lastEventInLaneIndex + 1;
    newTimeline.splice(insertIndex, 0, updatedDraggedEvent);
    insertBeforeEventId = insertIndex < newTimeline.length - 1
        ? newTimeline[insertIndex + 1]?.id ?? null
        : null;
}
```

### テスト追加 (+40 tests、合計 803 PASS)

- `store/dataSlice.upsertTimelineLane.test.ts` (8 tests): upsert contract + markDirty + history なし
- `store/dataSlice.deleteTimelineLane.test.ts` (11 tests): cascade + plot link cleanup + no-op
- `store/dataSlice.moveTimelineEvent.test.ts` (13 tests): 順序計算 + plot 不変 + title 不変 + `/code-review` 回帰防止
- `components/TimelineModal.handlers.test.ts` (8 tests): handler→store grep pin (setTimeline 全置換パターン排除も pin)

## Acceptance Criteria

- [x] AC-1a/b: `upsertTimelineLane` push / in-place 更新 (test PASS)
- [x] AC-2a/b/c: `deleteTimelineLane` lane filter + event cascade + plot link cleanup (test PASS)
- [x] AC-3a〜e: `moveTimelineEvent` lane 移動 / insertBeforeEventId 直前挿入 / 末尾 fallback / `/code-review` 回帰防止 (test PASS)
- [x] AC-4: handler → store 呼び出しの grep pin (test PASS)
- [x] AC-5: PR #183 / PR-A2 既存テスト regression なし (803 全 PASS)
- [x] AC-6: `npm run lint` (tsc --noEmit) PASS
- [x] AC-7: `npm run test` 803 tests PASS (Phase 1 完了時 760 → +43)

## Test plan (実機、Cloud Run dev デプロイ後)

### シナリオ A: lane 単体保存 (handleSaveLane)
- [ ] TL モーダル「+ 新しいレーン追加」→ 保存ボタン押下 → フッター「保存」を押さずに モーダル閉じ → 再オープン → レーン残存 ✅
- [ ] 既存レーンを編集 (名前 / 色) → フッター「保存」を押さずに モーダル閉じ → 再オープン → 編集内容残存 ✅

### シナリオ B: lane 削除 cascade (handleDeleteLane)
- [ ] lane に event を 2 件作成 → lane 削除 (window.confirm OK) → フッター「保存」を押さずに モーダル閉じ → 再オープン → lane + 配下 events 削除済 ✅
- [ ] 削除 lane 配下の event が linkedEventId を持つ plot がある場合 → プロットボードで該当 plot の linkedEventId が解除されている ✅

### シナリオ C: event 削除 (handleDeleteEvent)
- [ ] event 削除 → フッター「保存」を押さずに モーダル閉じ → 再オープン → event 復活しない ✅

### シナリオ D: drag-drop lane 移動 (handleDrop)
- [ ] event を別 lane の event の上にドラッグ → フッター「保存」を押さずに モーダル閉じ → 再オープン → laneId 変更維持 ✅

### シナリオ E: drag-drop 同 lane 内並び替え
- [ ] 同 lane 内で event 順序入れ替え → フッター「保存」を押さずに モーダル閉じ → 再オープン → 順序維持 ✅

### シナリオ F: lane 空白ドロップ (/code-review 回帰防止)
- [ ] event を別 lane の **空白部分** にドラッグ (dragOverInfo=null) → フッター「保存」を押さずに モーダル閉じ → 再オープン → **lane 末尾** に挿入されている (配列末尾でない) ✅

### シナリオ G: IndexedDB 到達確認 (reload 後維持)
- [ ] シナリオ A〜F の操作後、フッター「保存」を押さずに モーダル閉じる → 2 秒以上待機 (debounce flush) → ブラウザリロード → 全変更が IndexedDB から復元される ✅

## スコープ外 (別 Issue / Phase)

- handleDeleteLane の `window.confirm` → ConfirmDialog 統一 (UI 整合性のみ、機能無関係)
- Phase 3 (Issue #180 + #181): フッター保存ボタン削除 (全自動保存化)
- Issue #182: `createEventFromPlot` の laneId フォールバック整合性

🤖 Generated with [Claude Code](https://claude.com/claude-code)