### PR TITLE
fix(timeline): createEventFromPlot で ensureDefaultLane を呼んで laneId 整合 (Issue #182)

### DIFF
--- a/store/dataSlice.createEventFromPlot.test.ts
+++ b/store/dataSlice.createEventFromPlot.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../analysisApi', () => ({
+    analyzeText: vi.fn(),
+}));
+
+import { createDataSlice } from './dataSlice';
+import type { Project, TimelineLane, TimelineEvent, PlotItem } from '../types';
+
+const plotFixture = (overrides: Partial<PlotItem> = {}): PlotItem => ({
+    id: 'plot-1',
+    title: 'プロットタイトル',
+    summary: '要約',
+    type: '章のまとめ',
+    lastModified: 100,
+    ...overrides,
+});
+
+const eventFixture = (overrides: Partial<TimelineEvent> = {}): TimelineEvent => ({
+    id: 'event-1',
+    title: 'event',
+    timestamp: '2026-01-01',
+    description: '',
+    laneId: 'lane-x',
+    lastModified: 100,
+    ...overrides,
+});
+
+const baseProject = (): Project => ({
+    id: 'p-1',
+    name: 'P',
+    lastModified: new Date(0).toISOString(),
+    settings: [],
+    novelContent: [],
+    chatHistory: [],
+    knowledgeBase: [],
+    plotBoard: [],
+    plotTypeColors: {},
+    plotRelations: [],
+    plotNodePositions: [],
+    timeline: [],
+    timelineLanes: [],
+    characterRelations: [],
+    nodePositions: [],
+    aiSettings: {} as Project['aiSettings'],
+    displaySettings: {} as Project['displaySettings'],
+});
+
+interface FakeStore { state: Record<string, any>; set: (p: any) => void; get: () => Record<string, any>; }
+
+const createFakeStore = (initial: Record<string, any>): FakeStore => {
+    const fake: FakeStore = { state: { ...initial }, set: () => undefined, get: () => fake.state };
+    fake.set = (partial: any) => {
+        const next = typeof partial === 'function' ? partial(fake.state) : partial;
+        fake.state = { ...fake.state, ...next };
+    };
+    fake.get = () => fake.state;
+    return fake;
+};
+
+const mountSlice = (project: Project) => {
+    const fake = createFakeStore({});
+    const slice = createDataSlice(fake.set, fake.get);
+    const openModal = vi.fn();
+    const showToast = vi.fn();
+    const addHistory = vi.fn();
+    const markDirty = vi.fn();
+    fake.state = {
+        ...slice,
+        activeProjectId: 'p-1',
+        allProjectsData: { 'p-1': project },
+        openModal,
+        showToast,
+        addHistory,
+        markDirty,
+        closeModal: vi.fn(),
+    };
+    return { slice, fake, openModal, showToast, addHistory, markDirty };
+};
+
+describe('createEventFromPlot (action) — Issue #182 既存バグ修正', () => {
+    beforeEach(() => { vi.useFakeTimers(); vi.setSystemTime(new Date('2026-06-19T00:00:00Z')); });
+    afterEach(() => { vi.useRealTimers(); });
+
+    it('AC-1: timelineLanes 空時、生成 event の laneId が ensureDefaultLane が作成した lane の id と一致する (孤児化しない)', () => {
+        const plot = plotFixture();
+        const project: Project = { ...baseProject(), plotBoard: [plot] };
+        const { fake } = mountSlice(project);
+
+        fake.state.createEventFromPlot('plot-1');
+
+        const updated = fake.state.allProjectsData['p-1'];
+        expect(updated.timelineLanes).toHaveLength(1);
+        expect(updated.timeline).toHaveLength(1);
+        expect(updated.timeline[0].laneId).toBe(updated.timelineLanes[0].id);
+        expect(updated.timeline[0].laneId).not.toBe('default');
+    });
+
+    it('AC-2: 既存 lane が 1 つある場合、その lane id を使う (既存挙動維持)', () => {
+        const lane: TimelineLane = { id: 'existing-lane', name: 'メイン', color: '#aaaaaa' };
+        const plot = plotFixture();
+        const project: Project = { ...baseProject(), plotBoard: [plot], timelineLanes: [lane] };
+        const { fake } = mountSlice(project);
+
+        fake.state.createEventFromPlot('plot-1');
+
+        const updated = fake.state.allProjectsData['p-1'];
+        expect(updated.timelineLanes).toEqual([lane]);
+        expect(updated.timeline[0].laneId).toBe('existing-lane');
+    });
+
+    it('AC-3: 既存 lane が複数ある場合、[0] の id を使う (既存挙動維持)', () => {
+        const laneA: TimelineLane = { id: 'lane-A', name: 'A', color: '#111' };
+        const laneB: TimelineLane = { id: 'lane-B', name: 'B', color: '#222' };
+        const plot = plotFixture();
+        const project: Project = { ...baseProject(), plotBoard: [plot], timelineLanes: [laneA, laneB] };
+        const { fake } = mountSlice(project);
+
+        fake.state.createEventFromPlot('plot-1');
+
+        const updated = fake.state.allProjectsData['p-1'];
+        expect(updated.timelineLanes).toEqual([laneA, laneB]);
+        expect(updated.timeline[0].laneId).toBe('lane-A');
+    });
+
+    it('AC-4: plot.linkedEventId が既存の場合は no-op + toast info (既存挙動維持)', () => {
+        const plot = plotFixture({ linkedEventId: 'event-existing' });
+        const project: Project = { ...baseProject(), plotBoard: [plot] };
+        const { fake, showToast } = mountSlice(project);
+
+        fake.state.createEventFromPlot('plot-1');
+
+        const updated = fake.state.allProjectsData['p-1'];
+        expect(updated.timeline).toEqual([]);
+        expect(updated.timelineLanes).toEqual([]);
+        expect(showToast).toHaveBeenCalledWith('このプロットはすでにリンクされています', 'info');
+    });
+
+    it('AC-5: plotId が存在しない場合は no-op (timelineLanes も増えない)', () => {
+        const plot = plotFixture();
+        const project: Project = { ...baseProject(), plotBoard: [plot] };
+        const { fake, showToast } = mountSlice(project);
+
+        fake.state.createEventFromPlot('non-existent');
+
+        const updated = fake.state.allProjectsData['p-1'];
+        expect(updated.timeline).toEqual([]);
+        expect(updated.timelineLanes).toEqual([]);
+        expect(showToast).not.toHaveBeenCalled();
+    });
+
+    it('AC-6: activeProjectId に対応する project が無い場合は no-op (例外を投げない)', () => {
+        const plot = plotFixture();
+        const project: Project = { ...baseProject(), plotBoard: [plot] };
+        const { fake } = mountSlice(project);
+        fake.state.activeProjectId = 'non-existent';
+
+        expect(() => fake.state.createEventFromPlot('plot-1')).not.toThrow();
+    });
+
+    it('AC-7: timelineLanes 空 + 既存孤児 event がある場合、ensureDefaultLane 経由で孤児 event の laneId を採用 → 新規 event も同じ id で作られ全 event 救済', () => {
+        const orphan = eventFixture({ id: 'orphan', laneId: 'pre-existing-uuid' });
+        const plot = plotFixture();
+        const project: Project = { ...baseProject(), plotBoard: [plot], timeline: [orphan] };
+        const { fake } = mountSlice(project);
+
+        fake.state.createEventFromPlot('plot-1');
+
+        const updated = fake.state.allProjectsData['p-1'];
+        expect(updated.timelineLanes).toHaveLength(1);
+        expect(updated.timelineLanes[0].id).toBe('pre-existing-uuid');
+        expect(updated.timeline).toHaveLength(2);
+        expect(updated.timeline[0]).toEqual(orphan);
+        expect(updated.timeline[1].laneId).toBe('pre-existing-uuid');
+    });
+
+    it('AC-8: currentPlotData が渡された場合、その items の plot を使用し、relations/positions/colors も上書きする (既存挙動維持)', () => {
+        const persistedPlot = plotFixture({ id: 'plot-1', title: '旧タイトル' });
+        const draftPlot = plotFixture({ id: 'plot-1', title: '新タイトル' });
+        const project: Project = { ...baseProject(), plotBoard: [persistedPlot] };
+        const { fake } = mountSlice(project);
+
+        fake.state.createEventFromPlot('plot-1', {
+            items: [draftPlot],
+            relations: [{ id: 'r-1', from: 'a', to: 'b', label: '' } as any],
+            positions: [{ plotId: 'plot-1', x: 10, y: 20 }],
+            colors: { '章のまとめ': '#ff0000' },
+        });
+
+        const updated = fake.state.allProjectsData['p-1'];
+        expect(updated.timeline[0].title).toBe('新タイトル');
+        expect(updated.plotBoard[0].title).toBe('新タイトル');
+        expect(updated.plotBoard[0].linkedEventId).toBe(updated.timeline[0].id);
+        expect(updated.plotRelations).toHaveLength(1);
+        expect(updated.plotNodePositions).toEqual([{ plotId: 'plot-1', x: 10, y: 20 }]);
+        expect(updated.plotTypeColors).toEqual({ '章のまとめ': '#ff0000' });
+    });
+
+    it('AC-9: 成功時は showToast success + addHistory + markDirty が呼ばれる (auto-save signal pin)', () => {
+        const plot = plotFixture();
+        const project: Project = { ...baseProject(), plotBoard: [plot] };
+        const { fake, showToast, addHistory, markDirty } = mountSlice(project);
+
+        fake.state.createEventFromPlot('plot-1');
+
+        expect(showToast).toHaveBeenCalledWith('タイムラインにイベントを追加しました', 'success');
+        expect(addHistory).toHaveBeenCalledTimes(1);
+        expect(addHistory.mock.calls[0][1]).toEqual({ type: 'timeline', label: 'プロットからイベント「プロットタイトル」を作成' });
+        // ensureDefaultLane の markDirty (1 回) + setActiveProjectData の markDirty (1 回) で計 2 回
+        expect(markDirty).toHaveBeenCalledTimes(2);
+    });
+});

--- a/store/dataSlice.ts
+++ b/store/dataSlice.ts
@@ -841,24 +841,31 @@ export const createDataSlice = (set, get): DataSlice => ({
         set({ highlightedEventId: eventId });
     },
     createEventFromPlot: (plotId: string, currentPlotData?: { items: PlotItem[], relations: PlotRelation[], positions: PlotNodePosition[], colors: { [key: string]: string } }) => {
-        const { setActiveProjectData, allProjectsData, activeProjectId, showToast } = get();
+        const { setActiveProjectData, allProjectsData, activeProjectId, showToast, ensureDefaultLane } = get();
         const project = allProjectsData[activeProjectId];
         if (!project) return;
-        
+
         const plotBoard = currentPlotData ? currentPlotData.items : project.plotBoard;
         const plot = plotBoard.find(p => p.id === plotId);
         if (!plot) return;
-        
+
         if (plot.linkedEventId) {
             showToast('このプロットはすでにリンクされています', 'info');
             return;
         }
+        // Issue #182: timelineLanes が空の場合、旧実装は laneId='default' でフォールバックしていたが
+        // TimelineModal が useEffect で uuid 動的生成するレーン id と一致せず event が孤児化していた。
+        // ensureDefaultLane を呼んで store にデフォルトレーンを実体作成し、両者の laneId を整合させる。
+        ensureDefaultLane();
+        const refreshedProject = get().allProjectsData[activeProjectId];
+        const laneId = refreshedProject?.timelineLanes[0]?.id;
+        if (!laneId) return; // ensureDefaultLane no-op 経路 (activeProjectId null 等) — 防衛
         const newEvent: TimelineEvent = {
             id: uuidv4(),
             title: plot.title,
             description: plot.summary,
             timestamp: '未設定',
-            laneId: project.timelineLanes[0]?.id || 'default',
+            laneId,
             linkedPlotId: plot.id,
             lastModified: Date.now(),
         };


### PR DESCRIPTION
## Summary

- `store/dataSlice.ts` の `createEventFromPlot` で Phase 1 (PR #183) 導入の `ensureDefaultLane` を冒頭で呼び、`timelineLanes[0]?.id` を採用する形へ修正
- 旧実装の `laneId='default'` フォールバックは TimelineModal の uuid 動的生成レーンと一致せず、生成 event が画面から消える孤児化バグの原因だった
- 既存孤児 event がある場合は `ensureDefaultLane` 経路で同じ lane に統合され救済される

## Test plan

- [x] `npm run lint` PASS (tsc --noEmit エラーなし)
- [x] `npm run test` PASS (812 → 821 全 PASS、+9 件 createEventFromPlot 契約テスト)
- [x] AC-1 再現テスト: timelineLanes 空 + createEventFromPlot → event.laneId が新 default lane と一致 (旧実装では `'default'` で孤児化)
- [x] AC-2/3 既存挙動維持: 既存 lane あり → その先頭 id を使う
- [x] AC-4/5/6 ガード: linkedEventId 既存 / plotId 不在 / activeProjectId 不整合 で no-op
- [x] AC-7 孤児救済: 既存孤児 event の laneId が ensureDefaultLane で採用され、新規 event もそれに紐付く
- [x] AC-8 currentPlotData 経路: PlotBoardModal からの draft data 上書きが回帰しない
- [x] AC-9 auto-save signal pin: `addHistory` 1 回 + `markDirty` 2 回 (ensureDefaultLane + setActiveProjectData)
- [ ] 実機確認: 新規プロジェクト (timelineLanes 空) でプロットボードから「タイムラインへ送る」→ タイムラインモーダルを開く → イベントが正しく表示される (次セッション以降で目視)

Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)