### PR TITLE
docs(prod-migration): Phase 1 完了 runbook + tasks 文書化 (PR-B)

### DIFF
--- a/docs/runbook/prod-infrastructure-setup.md
+++ b/docs/runbook/prod-infrastructure-setup.md
@@ -1,0 +1,301 @@
+# Runbook: novel-writer-prod インフラ整備 (Phase 1)
+
+- Status: ✅ **完了** (2026-06-20)
+- Owner: yasushi-honda
+- Executor: AI (Claude Opus 4.7)
+- Related: [docs/spec/prod-migration/phase1-tasks.md](../spec/prod-migration/phase1-tasks.md) (タスク表 + AC 検証結果)
+
+## 用途
+
+novel-writer-prod 環境のインフラ整備の実行手順 + 証跡記録。再現性と監査証跡のため `gcloud` / `firebase` / `gh` コマンドをそのまま記載する。
+
+## 前提
+
+- 実行ユーザー: 本田様の GCP / Firebase / GitHub アカウント (`hy.unimail.11@gmail.com` / `yasushi-honda`)
+- 課金: 請求先アカウント `01EAA2-26BD24-E69348` を novel-writer-prod に紐付け
+- 既存 dev 環境 (`novel-writer-dev`) は不変、本 runbook は prod のみ対象
+
+## 危険操作の注意
+
+- **`firebase deploy` は必ず `--project prod` を明示**。引数なしだと `.firebaserc` の `default: novel-writer-dev` が選ばれるため、prod に対する操作時は明示指定必須 (Codex 修正 R6)
+- WIF Provider の attribute condition は `refs/heads/main` 制約付き。feature ブランチからの prod デプロイは GitHub Actions レベルで構造的にブロック
+- 予算アラート (¥1,000/月) を 100% / 120% 超過した場合は速やかに原因調査 (Cloud Run の `max-instances=2` で上限はあるが Vertex AI 暴走時は別)
+
+## 実行手順 (時系列、2026-06-20)
+
+### T1: 課金有効化
+
+```bash
+gcloud billing projects link novel-writer-prod \
+  --billing-account=01EAA2-26BD24-E69348
+# → billingEnabled: true
+```
+
+**注**: Firebase のお支払い (`01817F-AFD15C-E57676`) は 10 project 紐付け済で quota 上限到達のため、請求先アカウント (別 billing) に切替。
+
+### T2: GCP API 9 種有効化
+
+```bash
+gcloud services enable \
+  run.googleapis.com \
+  aiplatform.googleapis.com \
+  artifactregistry.googleapis.com \
+  firestore.googleapis.com \
+  cloudbuild.googleapis.com \
+  iamcredentials.googleapis.com \
+  firebase.googleapis.com \
+  firebaserules.googleapis.com \
+  identitytoolkit.googleapis.com \
+  --project=novel-writer-prod
+```
+
+**Codex 修正反映**: 当初計画の 6 種から Firebase 関連 3 種 (firebase / firebaserules / identitytoolkit) を追加。
+
+### T3: Artifact Registry repository
+
+```bash
+gcloud artifacts repositories create novel-writer \
+  --repository-format=docker \
+  --location=asia-northeast1 \
+  --description="Cloud Run container images for novel-writer prod" \
+  --project=novel-writer-prod
+```
+
+### T4: Service Account 2 種
+
+```bash
+gcloud iam service-accounts create github-deploy \
+  --display-name="GitHub Actions Deploy SA" \
+  --project=novel-writer-prod
+
+gcloud iam service-accounts create novel-writer-run \
+  --display-name="Cloud Run Runtime SA" \
+  --project=novel-writer-prod
+```
+
+### T5: SA 権限付与
+
+#### Build-time SA (`github-deploy`)
+
+```bash
+PROJECT_ID=novel-writer-prod
+DEPLOY_SA=github-deploy@${PROJECT_ID}.iam.gserviceaccount.com
+
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+  --member=serviceAccount:${DEPLOY_SA} \
+  --role=roles/run.admin --condition=None
+
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+  --member=serviceAccount:${DEPLOY_SA} \
+  --role=roles/artifactregistry.writer --condition=None
+
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+  --member=serviceAccount:${DEPLOY_SA} \
+  --role=roles/iam.serviceAccountUser --condition=None
+```
+
+#### Runtime SA (`novel-writer-run`)
+
+```bash
+RUNTIME_SA=novel-writer-run@${PROJECT_ID}.iam.gserviceaccount.com
+
+# Codex 修正反映: Firebase Admin SDK は Security Rules を bypass するため
+# Firestore 書込みには IAM 側 datastore.user が必須
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+  --member=serviceAccount:${RUNTIME_SA} \
+  --role=roles/datastore.user --condition=None
+
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+  --member=serviceAccount:${RUNTIME_SA} \
+  --role=roles/aiplatform.user --condition=None
+```
+
+### T6: WIF Pool + Provider (branch 制約付き)
+
+```bash
+gcloud iam workload-identity-pools create github-pool \
+  --location=global \
+  --display-name="GitHub Actions Pool" \
+  --project=novel-writer-prod
+
+# Codex 修正反映: repo + refs/heads/main の双方を attribute condition で縛る
+gcloud iam workload-identity-pools providers create-oidc github-provider \
+  --project=novel-writer-prod \
+  --location=global \
+  --workload-identity-pool=github-pool \
+  --display-name="GitHub Actions Provider" \
+  --issuer-uri="https://token.actions.githubusercontent.com/" \
+  --attribute-mapping="google.subject=assertion.sub,attribute.repository=assertion.repository,attribute.ref=assertion.ref,attribute.repository_owner=assertion.repository_owner" \
+  --attribute-condition="assertion.repository=='yasushi-honda/novel-writer' && assertion.ref=='refs/heads/main'"
+```
+
+### T7: github-deploy SA に WIF impersonation 権限
+
+```bash
+PROJECT_NUMBER=1026420855688
+
+gcloud iam service-accounts add-iam-policy-binding \
+  github-deploy@novel-writer-prod.iam.gserviceaccount.com \
+  --project=novel-writer-prod \
+  --role=roles/iam.workloadIdentityUser \
+  --member="principalSet://iam.googleapis.com/projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/github-pool/attribute.repository/yasushi-honda/novel-writer"
+```
+
+### T8: Firestore Native 初期化
+
+```bash
+gcloud firestore databases create \
+  --database='(default)' \
+  --location=asia-northeast1 \
+  --type=firestore-native \
+  --project=novel-writer-prod
+# → type: FIRESTORE_NATIVE, locationId: asia-northeast1
+```
+
+### T9: .firebaserc prod alias 追加 + rules deploy
+
+#### Step 1: PR-A (`.firebaserc` 変更)
+
+```bash
+# feature branch + PR (PR #192)
+git checkout -b feat/prod-migration-phase1-firebaserc
+# .firebaserc 編集 (prod alias 追加)
+git commit -m "chore(prod): .firebaserc に prod alias 追加 (Phase 1 PR-A)"
+git push -u origin feat/prod-migration-phase1-firebaserc
+gh pr create ...
+# PR #192 として番号単位認可後にマージ
+gh pr merge 192 --squash --delete-branch
+```
+
+#### Step 2: main 同期 + rules deploy (本 runbook で実施)
+
+```bash
+git checkout main && git reset --hard origin/main
+firebase deploy --only firestore:rules --project prod
+# → released rules firestore.rules to cloud.firestore
+# → Project Console: https://console.firebase.google.com/project/novel-writer-prod/overview
+```
+
+### T10: Firebase Web App 登録
+
+```bash
+firebase projects:addfirebase novel-writer-prod
+# → GCP project に Firebase resources を追加
+
+firebase apps:create WEB novel-writer --project novel-writer-prod
+# → App ID: 1:1026420855688:web:4afee11ab993a15e2ae03d
+
+firebase apps:sdkconfig WEB 1:1026420855688:web:4afee11ab993a15e2ae03d \
+  --project novel-writer-prod
+```
+
+取得した 6 値 (apiKey / authDomain / projectId / storageBucket / messagingSenderId / appId) を T11 で Secrets 登録。
+
+### T11: GitHub Secrets 登録
+
+```bash
+REPO=Yukina1116/novel-writer
+
+gh secret set PROD_VITE_FIREBASE_API_KEY --body "<apiKey>" --repo $REPO
+gh secret set PROD_VITE_FIREBASE_AUTH_DOMAIN --body "novel-writer-prod.firebaseapp.com" --repo $REPO
+gh secret set PROD_VITE_FIREBASE_PROJECT_ID --body "novel-writer-prod" --repo $REPO
+gh secret set PROD_VITE_FIREBASE_STORAGE_BUCKET --body "novel-writer-prod.firebasestorage.app" --repo $REPO
+gh secret set PROD_VITE_FIREBASE_MESSAGING_SENDER_ID --body "1026420855688" --repo $REPO
+gh secret set PROD_VITE_FIREBASE_APP_ID --body "1:1026420855688:web:4afee11ab993a15e2ae03d" --repo $REPO
+
+# 確認
+gh api repos/$REPO/actions/secrets --jq '.secrets[].name' | grep "^PROD_VITE_FIREBASE"
+# → 6 件確認
+```
+
+**注**: `<apiKey>` は機密扱い。本 runbook には記載せず、Firebase Console (`https://console.firebase.google.com/project/novel-writer-prod/settings/general`) で確認可能。
+
+### T12: 予算アラート
+
+```bash
+gcloud billing budgets create \
+  --billing-account=01EAA2-26BD24-E69348 \
+  --display-name="novel-writer-prod monthly budget" \
+  --budget-amount=1000JPY \
+  --threshold-rule=percent=0.5 \
+  --threshold-rule=percent=0.8 \
+  --threshold-rule=percent=1.0 \
+  --threshold-rule=percent=1.2 \
+  --filter-projects=projects/1026420855688
+# → Budget ID: 1f17fe3e-13d2-46f3-b906-2942a984ec6d
+```
+
+通知先: billing account 管理者 (`hy.unimail.11@gmail.com`) に自動通知。
+
+### T13: Vertex AI quota / region 確認
+
+- `aiplatform.googleapis.com` 有効化済 (T2)
+- region: asia-northeast1 (dev と同 region で稼働実績あり)
+- default quota: gemini-2.5-flash / Imagen の通常利用範囲では十分
+- ¥1,000/月 cap の範囲内では default quota が制約にならない (Imagen 10 回 = ¥100 でも quota は余裕)
+
+実 quota 数値の正確な確認は Phase 2 の smoke test に持ち越し:
+- https://console.cloud.google.com/iam-admin/quotas?project=novel-writer-prod&service=aiplatform.googleapis.com
+
+## 検証コマンド集 (再現性のため)
+
+```bash
+# AC-1 課金
+gcloud billing projects describe novel-writer-prod --format="value(billingEnabled)"
+
+# AC-2 API
+gcloud services list --enabled --project novel-writer-prod --format="value(config.name)" \
+  | grep -E "^(run|aiplatform|artifactregistry|firestore|cloudbuild|iamcredentials|firebase|firebaserules|identitytoolkit)\."
+
+# AC-3 Artifact Registry
+gcloud artifacts repositories describe novel-writer \
+  --location=asia-northeast1 --project=novel-writer-prod
+
+# AC-4 SA
+gcloud iam service-accounts list --project novel-writer-prod
+
+# AC-5 WIF condition
+gcloud iam workload-identity-pools providers describe github-provider \
+  --location=global --workload-identity-pool=github-pool \
+  --project=novel-writer-prod --format="value(attributeCondition)"
+
+# AC-6 WIF impersonation
+gcloud iam service-accounts get-iam-policy \
+  github-deploy@novel-writer-prod.iam.gserviceaccount.com \
+  --project=novel-writer-prod
+
+# AC-7 Firestore
+gcloud firestore databases describe --database='(default)' \
+  --project=novel-writer-prod --format="value(type,locationId)"
+
+# AC-9 Secrets
+gh api repos/Yukina1116/novel-writer/actions/secrets \
+  --jq '.secrets[].name' | grep "^PROD_VITE_FIREBASE" | wc -l
+
+# AC-10 Budget
+gcloud billing budgets list --billing-account=01EAA2-26BD24-E69348 \
+  --format="table(displayName,amount.specifiedAmount.units,amount.specifiedAmount.currencyCode)"
+```
+
+## ロールバック手順 (もし Phase 1 で問題発覚した場合)
+
+Phase 1 はインフラ整備のみで本番ユーザーへの影響はゼロ。問題発覚時は以下を逆順に実行:
+
+1. `gh secret delete PROD_VITE_FIREBASE_*` 6 件
+2. `firebase apps:delete WEB <appId> --project novel-writer-prod`
+3. `gcloud billing budgets delete 1f17fe3e-13d2-46f3-b906-2942a984ec6d --billing-account=01EAA2-26BD24-E69348`
+4. `gcloud iam workload-identity-pools providers delete github-provider --location=global --workload-identity-pool=github-pool --project=novel-writer-prod`
+5. `gcloud iam workload-identity-pools delete github-pool --location=global --project=novel-writer-prod`
+6. `gcloud iam service-accounts delete <SA email> --project=novel-writer-prod` × 2
+7. `gcloud artifacts repositories delete novel-writer --location=asia-northeast1 --project=novel-writer-prod`
+8. `gcloud firestore databases delete '(default)' --project=novel-writer-prod` (削除可能だが慎重に)
+9. `gcloud billing projects unlink novel-writer-prod`
+
+Firestore は once-only 設定が多いため、再構築時は新規 project 作成も検討。
+
+## Phase 2 への引き継ぎ事項
+
+- すべての値・SA email・WIF provider ID は `docs/spec/prod-migration/phase1-tasks.md` 「Phase 2 への引き継ぎ事項」セクション参照
+- Phase 2 では `.github/workflows/deploy-prod.yml` を新規作成 (workflow_dispatch trigger)
+- 初回デプロイ後に AC-13 (未認証 401) / AC-14 (静的 UI 到達) を Playwright MCP で実機検証
+- Vertex AI 実呼び出し smoke test で actual quota 確認

--- a/docs/spec/prod-migration/phase1-tasks.md
+++ b/docs/spec/prod-migration/phase1-tasks.md
@@ -1,0 +1,119 @@
+# Phase 1: novel-writer-prod インフラ整備 タスク表
+
+- Status: ✅ **完了** (2026-06-20)
+- Owner: yasushi-honda
+- Related: [docs/runbook/prod-infrastructure-setup.md](../../runbook/prod-infrastructure-setup.md) (実行手順 + 証跡)
+- Related ADR: [ADR-0001](../../adr/0001-local-first-architecture.md) §M0 / §M3 / §M7
+
+## 背景
+
+2026-06-08 (handoff `2026-06-08-pr162-163-and-prod-roadmap.md`) で本田様と合意した prod 移行方針に基づき、bugfix 一巡完了 (PR #190、2026-06-20) を trigger に Phase 1 (prod インフラ整備) を実施。
+
+Phase 1 では prod 環境のリソースのみ整備し、実デプロイは Phase 2 で行う。
+
+## Phase 分割
+
+| Phase | スコープ | 状態 |
+|---|---|---|
+| **Phase 1** (本ドキュメント) | prod インフラ整備 (デプロイなし) | ✅ 完了 |
+| Phase 2 | CI/CD 二環境化 + 初回 prod デプロイ | ⏳ 次着手 |
+| Phase 3 | dev → prod 運用フロー確立 (workflow_dispatch 駆動) | ⏳ |
+| Phase 4 | 一般公開 (法務確認 + 課金クォータ完了が前提) | ⏳ |
+
+## Codex セカンドオピニオン反映済の修正点 (Phase 1 計画段階)
+
+| 修正 | 内容 |
+|---|---|
+| 修正 1 | API リストを 6 → **9** 種に拡張 (Firebase 関連 +3: firebase / firebaserules / identitytoolkit) |
+| 修正 2 | Runtime SA に **`roles/datastore.user`** を必須として明示追加 (Firebase Admin SDK は rules bypass、別途権限必要) |
+| 修正 3 | WIF Provider attribute condition に **`refs/heads/main` 制約**追加 (feature ブランチからの誤デプロイ防止) |
+| 修正 4 | Vertex AI quota 確認を「並行進行」から Phase 1 AC に格上げ |
+| 修正 5 | AC に「未認証 401 (AC-13)」「静的 UI 到達 (AC-14)」を追加 (Phase 2 検証として文書化) |
+| 修正 6 | 予算アラートを「事前承認タスク扱い」に明示 |
+| 修正 7 | PR-A は `.firebaserc` 変更のみ、実 rules deploy は runbook 証跡化 |
+
+## タスク一覧と達成状況
+
+| # | タスク | 状態 | 担当 | AC |
+|---|--------|------|------|----|
+| T1 | novel-writer-prod 課金有効化 (請求先アカウント `01EAA2-26BD24-E69348`) | ✅ | 本田様承認 → AI 実行 | AC-1 |
+| T2 | GCP API 9 種有効化 | ✅ | AI | AC-2 |
+| T3 | Artifact Registry `novel-writer` @ asia-northeast1 (DOCKER) | ✅ | AI | AC-3 |
+| T4 | Service Account 2 種 (`github-deploy` / `novel-writer-run`) | ✅ | AI | AC-4 |
+| T5 | SA 権限付与 (datastore.user 必須含む、Codex 修正反映) | ✅ | AI | - |
+| T6 | WIF Pool + Provider (branch 制約付き、Codex 修正反映) | ✅ | AI | AC-5 |
+| T7 | `github-deploy` SA に WIF impersonation 権限 | ✅ | AI | AC-6 |
+| T8 | Firestore Native mode 初期化 (asia-northeast1) | ✅ | AI | AC-7 |
+| T9 | `.firebaserc` prod alias 追加 (PR #192) + rules deploy | ✅ | AI (PR-A) | AC-8 |
+| T10 | Firebase Web App 登録 (`firebase apps:create WEB`) | ✅ | AI | AC-9 (前段) |
+| T11 | GitHub Secrets に PROD_VITE_FIREBASE_* 6 件登録 | ✅ | AI (gh CLI) | AC-9 |
+| T12 | 予算アラート (¥1,000/月、50/80/100/120% 閾値) | ✅ | AI (本田様承認後) | AC-10 |
+| T13 | Vertex AI quota / region 確認 (asia-northeast1 default quota) | ✅ | AI | AC-11 |
+| T14 | runbook + tasks 文書化 (本 PR) | 🚧 進行中 | AI (PR-B) | AC-12 |
+
+## Acceptance Criteria 検証結果
+
+| # | 基準 | 検証 |
+|---|------|------|
+| AC-1 | 課金が有効化 | `gcloud billing projects describe novel-writer-prod --format="value(billingEnabled)"` → `True` ✅ |
+| AC-2 | 必要 9 API が ENABLED | `gcloud services list --enabled` で 9 種確認 ✅ |
+| AC-3 | Artifact Registry repository 存在 | `gcloud artifacts repositories describe novel-writer --location=asia-northeast1` ✅ |
+| AC-4 | SA 2 種存在 | `gcloud iam service-accounts list --project novel-writer-prod` ✅ |
+| AC-5 | WIF Provider に repo + branch 制約 | `assertion.repository=='yasushi-honda/novel-writer' && assertion.ref=='refs/heads/main'` ✅ |
+| AC-6 | WIF impersonation 権限付与 | `roles/iam.workloadIdentityUser` + principalSet ✅ |
+| AC-7 | Firestore Native, asia-northeast1 | `FIRESTORE_NATIVE` / `asia-northeast1` ✅ |
+| AC-8 | firestore.rules prod 反映 | `firebase deploy --only firestore:rules --project prod` 成功 ✅ |
+| AC-9 | Firebase Web App + Secrets | `apps:sdkconfig` 6 値取得 → `gh secret list` で 6/6 登録 ✅ |
+| AC-10 | 予算アラート | budget ID `1f17fe3e-13d2-46f3-b906-2942a984ec6d` ¥1,000 JPY 設定済 ✅ |
+| AC-11 | Vertex AI quota 確認 | aiplatform.googleapis.com 有効 + default quota (dev 同 region 稼働実績あり) ✅ |
+| AC-12 | runbook + tasks 文書 | 本 PR でマージ予定 🚧 |
+| AC-13 | 未認証 `/api/*` が 401 | **Phase 2 deploy 後検証** (Phase 1 では文書化のみ) 📋 |
+| AC-14 | 静的 UI (`/`) 未認証到達 | **Phase 2 deploy 後検証** (Phase 1 では文書化のみ) 📋 |
+
+## Phase 2 への引き継ぎ事項
+
+### Phase 2 で参照する値
+
+| 項目 | 値 |
+|---|---|
+| Project ID | `novel-writer-prod` |
+| Project Number | `1026420855688` |
+| Region | `asia-northeast1` |
+| Artifact Registry | `asia-northeast1-docker.pkg.dev/novel-writer-prod/novel-writer/novel-writer` |
+| Build-time SA | `github-deploy@novel-writer-prod.iam.gserviceaccount.com` |
+| Runtime SA | `novel-writer-run@novel-writer-prod.iam.gserviceaccount.com` |
+| WIF Provider | `projects/1026420855688/locations/global/workloadIdentityPools/github-pool/providers/github-provider` |
+| Firebase Web App ID | `1:1026420855688:web:4afee11ab993a15e2ae03d` |
+| GitHub Secrets prefix | `PROD_VITE_FIREBASE_*` (6 件) |
+| Budget ID | `1f17fe3e-13d2-46f3-b906-2942a984ec6d` (¥1,000/月、50/80/100/120%) |
+
+### Phase 2 で必ず検証すべき項目
+
+- AC-13: 未認証 `/api/*` リクエストが 401 を返すこと (BE `verifyIdToken` middleware 動作確認)
+- AC-14: 静的 UI (`/`) が未認証で到達可能であること
+- Vertex AI 実呼び出し (`/api/ai/novel/generate` 等) で smoke test 通過すること
+
+### Phase 2 で作成する deploy-prod.yml の要点
+
+- `on.workflow_dispatch` (手動 trigger、main push 自動デプロイは dev のみ)
+- WIF Provider は prod 用 (上記)
+- Build-arg は `PROD_VITE_FIREBASE_*` を参照
+- Cloud Run flags: dev と同等 (`--memory=512Mi --timeout=300 --max-instances=2 --allow-unauthenticated --service-account=novel-writer-run@novel-writer-prod...`)
+- env-vars: `GCP_PROJECT=novel-writer-prod, GCP_LOCATION=asia-northeast1, USE_VERTEX_AI=true, NODE_ENV=production`
+
+## Phase 4 (一般公開) への前提条件
+
+| 前提 | 状態 |
+|---|---|
+| 法務確認 (顧問弁護士による規約 3 文書承認) | ⏳ 別軸進行 |
+| 課金クォータ (Vertex AI 通常利用範囲で必要なら申請) | ⏳ 必要時申請 |
+| Phase 2 (初回 deploy + smoke test) | ⏳ 次着手 |
+| Phase 3 (dev → prod 運用フロー文書化) | ⏳ |
+
+## 参考
+
+- ADR-0001 §M0 (緊急対応 + `max-instances=2` + 予算アラート)
+- ADR-0001 §M3 (Cloud Run public 化 + verifyIdToken 設計)
+- ADR-0001 §M7 (法務確認 MUST、Phase 4 前提条件)
+- Codex セカンドオピニオン (本セッション、19 件の指摘から 7 件修正反映)
+- PR #192 (T9 PR-A、`.firebaserc` prod alias)


### PR DESCRIPTION
## Summary

- Phase 1 (novel-writer-prod インフラ整備) 全タスク完了 + 文書化
- 2 文書 (runbook 1 + tasks 1) を新規追加、合計 +420 行
- Phase 2 (CI/CD 二環境化) 着手に必要な値・SA email・WIF provider ID を引き継ぎ事項に明記

## Phase 1 完了サマリ

| AC | 状態 |
|----|------|
| AC-1 課金 | ✅ |
| AC-2 API 9 種 | ✅ |
| AC-3 Artifact Registry @ asia-northeast1 | ✅ |
| AC-4 SA 2 種 (github-deploy / novel-writer-run) | ✅ |
| AC-5 WIF condition (repo + refs/heads/main 制約) | ✅ |
| AC-6 WIF impersonation | ✅ |
| AC-7 Firestore Native @ asia-northeast1 | ✅ |
| AC-8 firestore.rules prod 反映 | ✅ |
| AC-9 Firebase Web App + Secrets 6 件 | ✅ |
| AC-10 予算アラート ¥1,000/月 (50/80/100/120%) | ✅ |
| AC-11 Vertex AI quota | ✅ default quota、Phase 2 で smoke test |
| AC-12 runbook + tasks 文書 | 🚧 本 PR で達成 |
| AC-13 未認証 401 | 📋 Phase 2 検証 |
| AC-14 静的 UI 到達 | 📋 Phase 2 検証 |

## Codex セカンドオピニオン反映済 7 修正

1. API リスト 6 → 9 種 (Firebase 関連 +3)
2. Runtime SA に `roles/datastore.user` 必須追加 (Firebase Admin SDK は rules bypass)
3. WIF condition に `refs/heads/main` 制約 (誤デプロイ防止)
4. Vertex AI quota 確認を Phase 1 AC に格上げ
5. AC-13/AC-14 追加 (Phase 2 検証として文書化)
6. 予算アラートを「事前承認タスク扱い」に明示
7. PR-A は `.firebaserc` のみ、実 rules deploy は runbook 証跡化

## 関連リソース (本 PR で文書化)

| 項目 | 値 |
|---|---|
| Project Number | 1026420855688 |
| Region | asia-northeast1 |
| Build-time SA | github-deploy@novel-writer-prod.iam.gserviceaccount.com |
| Runtime SA | novel-writer-run@novel-writer-prod.iam.gserviceaccount.com |
| WIF Provider | projects/1026420855688/locations/global/workloadIdentityPools/github-pool/providers/github-provider |
| Firebase Web App ID | 1:1026420855688:web:4afee11ab993a15e2ae03d |
| Budget ID | 1f17fe3e-13d2-46f3-b906-2942a984ec6d |

## Test plan

- [x] `npm run lint` (tsc --noEmit) pass
- [x] 全 CLI コマンドが実機で実行成功 (runbook 内に出力記録)
- [x] `firebase deploy --only firestore:rules --project prod` 成功確認
- [x] AC-1 〜 AC-11 機械的検証完了
- [ ] merge 後: Phase 2 (deploy-prod.yml 新規作成) 着手

## 関連 PR / Issue

- PR #192 (T9 PR-A、`.firebaserc` prod alias) merged
- ADR-0001 §M0 / §M3 / §M7
- Codex セカンドオピニオン (本セッション)

🤖 Generated with [Claude Code](https://claude.com/claude-code)