### PR TITLE
docs(prod-migration): Phase 4 PR α — phase4-tasks.md 枠組み先行 (タスク + AC + GO 1/2 tracker + Phase 5 GO チェック)

### DIFF
--- a/docs/spec/prod-migration/phase4-tasks.md
+++ b/docs/spec/prod-migration/phase4-tasks.md
@@ -1,0 +1,211 @@
+# Phase 4: 一般公開準備 タスク表
+
+- Status: 🚧 **進行中** (2026-06-20 着手、本 PR α = 枠組み先行)
+- Owner: yasushi-honda
+- Related: [docs/adr/0003-public-launch-operations.md](../../adr/0003-public-launch-operations.md) (PR β で起票、本 PR では未存在)
+- Related runbook: [docs/runbook/prod-pitr.md](../../runbook/prod-pitr.md) / [prod-monitoring.md](../../runbook/prod-monitoring.md) / [prod-slo.md](../../runbook/prod-slo.md) (いずれも PR β で起票)
+- Related: [phase3-tasks.md](./phase3-tasks.md) §Phase 4 GO チェック (本 Phase で答える GO-1〜GO-6)
+- Related ADR: [ADR-0001](../../adr/0001-local-first-architecture.md) §Consequences (緊急対応 + max-instances=2 + 法務確認 MUST) / [ADR-0002](../../adr/0002-dev-prod-deploy-flow.md) (dev → prod 運用フロー、本 Phase でも authoritative)
+
+> **本書の位置付け**: 本ドキュメント・関連 ADR-0003・関連 runbook は AI (Claude Code) が起草した **公開準備の草案** である。最終的な運用判断 (PITR 有効化実行、Logging dashboard 構築実行、SLO 採用、課金クォータ申請、法務確認、公開実行 GO-6) は **decision-maker (owner = 本田様)** に委ねる。AI は executor として手順実行と起草を担当する (AI 駆動開発 4 原則 §1)。
+
+## 背景
+
+Phase 3 (PR #200, 2026-06-20) で dev → prod 運用フロー (ADR-0002 + runbook prod-deploy-flow.md) が完成。続く Phase 4 では **一般公開「直前」まで** の運用基盤を整える。
+
+**Phase 4 完了 ≠ 公開実行**。公開実行 (GO-6 = 本田様の公開告知) は **Phase 5** に分離する。Phase 5 GO チェックは本書末尾に独立 section として置く (Phase 3 で Phase 4 GO チェックを起こしたパターンを踏襲)。
+
+## Phase 分割 (再掲)
+
+| Phase | スコープ | 状態 |
+|---|---|---|
+| Phase 1 | prod インフラ整備 | ✅ 完了 (PR #192/#193/#194) |
+| Phase 2 | CI/CD 二環境化 + 初回 prod デプロイ | ✅ 完了 (PR #195/#197/#199) |
+| Phase 3 | dev → prod 運用フロー確立 | ✅ 完了 (PR #200) |
+| **Phase 4** (本ドキュメント) | 一般公開準備 (GO-3 PITR / GO-4 Logging / GO-5 SLO 文書化 + 法務/課金 tracker) | 🚧 進行中 |
+| Phase 5 | 公開実行 (GO-6 本田様公開告知 + KPI 追跡開始) | ⏳ |
+
+## Codex セカンドオピニオン反映済の修正点 (Phase 4 計画段階)
+
+| 修正 | 内容 | 重要度 |
+|---|---|---|
+| 修正 1 | **PR 分割 2 本** に確定 (PR α = phase4-tasks.md 枠組み先行 / PR β = ADR-0003 + 3 runbook) | M |
+| 修正 2 | **ADR-0003 は ADR-0002 補強** の位置付け、冒頭に「ADR-0002 remains authoritative for dev → prod deploy flow; ADR-0003 adds public-launch readiness controls」明記 | **H** |
+| 修正 3 | **Firestore データ rollback 設計を prod-pitr.md で完結**。ADR-0002 rollback 3→4 段階拡張案を runbook に記載、ADR-0002 本体は本 PR では変更しない (段階 2 PITR 有効化後 or 別 PR で反映) | **H** |
+| 修正 4 | SLO 指標は **`initial draft / to be recalibrated after Phase 5 real traffic`** 注記、99.5% 等は推測値として扱う | M |
+| 修正 5 | incident 通知は **email を最小案、Slack/SMS は future work**、確定は本田様判断 | M |
+| 修正 6 | 法務 status tracker は **phase4-tasks.md 内 section**、独立ファイル化しない。Status は `Not started / In review / Approved / Blocked` 4 値限定、AI は事実更新のみ | M |
+| 修正 7 | 課金クォータ申請 draft は **optional**、`default quota likely sufficient for private testing; public launch quota decision remains owner-approved` 明記 | L |
+| 修正 8 | **Phase 5 GO チェック section を本書末尾に独立**、ADR-0003 内には参照 link のみ | **H** |
+
+## タスク一覧
+
+### PR α: 枠組み先行 (本書のみ、約 350 行)
+
+| # | タスク | 状態 | 担当 | AC |
+|---|--------|------|------|----|
+| T1 | `docs/spec/prod-migration/phase4-tasks.md` (本ドキュメント) 作成 | 🚧 | AI | AC-P4-1 / AC-P4-6 / AC-P4-10 |
+| T2 | lint + test 確認 → PR α 起票 → 番号単位認可 → merge | ⏳ | AI → 本田様 | AC-P4-7 |
+
+### PR β: 詳細設計 (ADR-0003 + 3 runbook、約 750 行、PR α merge 後に起票)
+
+| # | タスク | 状態 | 担当 | AC |
+|---|--------|------|------|----|
+| T3 | `docs/adr/0003-public-launch-operations.md` 新規 (Context / Decision / Consequences + ADR-0002 補強位置付け明示) | ⏳ | AI | AC-P4-2 / AC-P4-11 |
+| T4 | `docs/runbook/prod-pitr.md` 新規 (有効化 / retention 判断 / 復旧演習 / ADR-0002 rollback 4 段階拡張案) | ⏳ | AI | AC-P4-3 |
+| T5 | `docs/runbook/prod-monitoring.md` 新規 (dashboard 構成 / alerting policy / email 最小通知設計) | ⏳ | AI | AC-P4-4 |
+| T6 | `docs/runbook/prod-slo.md` 新規 (initial draft 注記 + 3 指標候補 + incident response 草案) | ⏳ | AI | AC-P4-5 |
+| T7 | lint + test 確認 → PR β 起票 (reviewer checklist で 4 領域分割) → 番号単位認可 → merge | ⏳ | AI → 本田様 | AC-P4-7 |
+
+### 段階 2 (本 Phase 対象外、別セッション・別 PR、番号単位認可必須)
+
+| # | タスク | AC |
+|---|--------|----|
+| - | GO-3 PITR 実機有効化 + 復旧演習 + 証跡を `prod-pitr.md` に追記 | AC-P4-8 |
+| - | GO-4 Logging dashboard / alerting 実機構築 + 通知到達確認 + 証跡を `prod-monitoring.md` に追記 | AC-P4-9 |
+| - | (段階 3) SLO 草案 → Accepted 化 PR、Phase 5 spec 起草 | - |
+
+## Acceptance Criteria
+
+| # | 基準 | 検証方法 |
+|---|------|---------|
+| AC-P4-1 | `phase4-tasks.md` に T1-T7 タスク表 + AC ≥ 10 項目 + GO-1 法務 status tracker + GO-2 課金クォータ申請 draft + Phase 5 GO チェック section が存在 | `grep -c '^| AC-P4-' docs/spec/prod-migration/phase4-tasks.md` ≥ 10 かつ `grep -cE '^## (GO-1\|GO-2\|Phase 5 GO チェック)' docs/spec/prod-migration/phase4-tasks.md` ≥ 3 |
+| AC-P4-2 | ADR-0003 に Context / Decision / Consequences の 3 section + ADR-0002 補強位置付け明示 + 冒頭に「草案、最終判断は decision-maker」 (PR β で検証) | `grep -cE '^## (Context\|Decision\|Consequences)' docs/adr/0003-public-launch-operations.md` = 3 かつ `grep -c 'ADR-0002 remains authoritative' docs/adr/0003-public-launch-operations.md` ≥ 1 |
+| AC-P4-3 | `prod-pitr.md` に「有効化手順」「retention 期間判断」「復旧演習」「ADR-0002 rollback 4 段階拡張案」の 4 section + 関連 ADR link (PR β で検証) | `grep -cE '^## (有効化\|retention\|復旧演習\|ADR-0002 rollback)' docs/runbook/prod-pitr.md` ≥ 4 |
+| AC-P4-4 | `prod-monitoring.md` に「dashboard 構成」「alerting policy」「通知先設計 (email 最小)」の 3 section + Slack/SMS を future work として明示 (PR β で検証) | `grep -cE '^## (dashboard\|alerting\|通知)' docs/runbook/prod-monitoring.md` ≥ 3 かつ `grep -c 'future work\|Future work' docs/runbook/prod-monitoring.md` ≥ 1 |
+| AC-P4-5 | `prod-slo.md` に「SLO 指標 (可用性/エラー率/AI応答失敗率)」「incident response」「通知 channel」の 3 section + initial draft 注記 (PR β で検証) | `grep -cE '^## (SLO 指標\|incident response\|通知)' docs/runbook/prod-slo.md` ≥ 3 かつ `grep -c 'initial draft\|recalibrated after Phase 5' docs/runbook/prod-slo.md` ≥ 1 |
+| AC-P4-6 | `phase4-tasks.md` 内に GO-1 法務 status tracker (4 値 status) + GO-2 課金クォータ申請 draft section | `grep -c 'Not started\|In review\|Approved\|Blocked' docs/spec/prod-migration/phase4-tasks.md` ≥ 4 かつ `grep -c '課金クォータ申請\|owner-approved' docs/spec/prod-migration/phase4-tasks.md` ≥ 1 |
+| AC-P4-7 | `npm run lint` PASS + `npm run test` PASS (本 PR は doc のみだが、規律として実行) | tsc エラー 0 件 + vitest 全 PASS |
+| AC-P4-8 | (段階 2 で別 PR) GO-3 PITR 実機有効化 + 復旧演習 + 証跡が `prod-pitr.md` に追記 | gcloud + grep (段階 2 完了時点で検証) |
+| AC-P4-9 | (段階 2 で別 PR) GO-4 Logging dashboard / alerting 実機構築 + 通知到達確認 + 証跡が `prod-monitoring.md` に追記 | gcloud + grep (段階 2 完了時点で検証) |
+| AC-P4-10 | `phase4-tasks.md` 末尾に「Phase 5 GO チェック」独立 section + Phase 4 完了 ≠ Phase 5 GO 明文化 + GO-1〜GO-6 全項目 trigger 条件記載 | `grep -c '^## Phase 5 GO チェック' docs/spec/prod-migration/phase4-tasks.md` = 1 かつ `awk '/^## Phase 5 GO チェック/,/^## 参考/' docs/spec/prod-migration/phase4-tasks.md \| grep -cE 'GO-1\|GO-2\|GO-3\|GO-4\|GO-5\|GO-6'` ≥ 6 |
+| AC-P4-11 | ADR-0003 冒頭に「ADR-0002 remains authoritative for dev → prod deploy flow; ADR-0003 adds public-launch readiness controls without superseding ADR-0002」が記載 (PR β で検証) | `grep -c 'without superseding ADR-0002' docs/adr/0003-public-launch-operations.md` ≥ 1 |
+
+## Phase 4 スコープ外 (NG リスト、本 Phase に含めない)
+
+| カテゴリ | 項目 | 理由 |
+|---|---|---|
+| Phase 5 領分 | prod 公開告知 traffic 切替 | GO-6 は decision-maker 操作 |
+| Phase 5 領分 | 一般公開後 KPI 追跡 | Phase 5 で別途設計 |
+| 別マイルストーン | M5 (Stripe Tier 2 課金) 実装 | 別軸 |
+| 段階 2 (別 PR) | Firestore PITR の AI 単独実機有効化 | 番号単位認可必須、本 PR は手順記載のみ |
+| 段階 2 (別 PR) | Cloud Logging dashboard / alerting の AI 単独実機構築 | 同上 |
+| decision-maker 領分 | 法務文書 (規約 3 文書) の AI 単独修正 | content は法務、AI は status 更新のみ |
+| decision-maker 領分 | 顧問弁護士との連絡・進捗確認・督促 | 4 原則 §1 |
+| decision-maker 領分 | 課金クォータ申請提出可否判断 | template 起草のみ AI、提出は本田様 |
+| Future work (Phase 5 以降) | Slack / SMS 通知 channel 実装 | email 最小案で Phase 4 完了 |
+| Future work (Phase 5 以降) | SLO 実値ベース再校正 | Phase 5 公開後の real traffic データ必須 |
+| Future work (一般公開後) | secret rotation 方針詳細 | Phase 3 NG リスト維持 |
+| ADR-0002 本体修正 | rollback 3→4 段階拡張の ADR-0002 反映 | 本 PR は prod-pitr.md に拡張案のみ記載、ADR-0002 本体は段階 2 PITR 有効化後 or 別 PR で反映 |
+
+## GO-1: 法務確認 status
+
+> **担当**: 本田様 + 顧問弁護士。AI は事実更新のみ executor 領分 (内容判断は decision-maker)。
+>
+> **Status 4 値**: `Not started` / `In review` / `Approved` / `Blocked`
+>
+> 正本は `public/legal/*.md` (HTML render は `public/legal/*.html`)。本 section は status 追跡のみ。
+
+| 文書 | Status | 最終更新 | 備考 |
+|---|---|---|---|
+| 利用規約 (terms-of-service) | Not started | 2026-06-20 | 現状 `LEGAL_REVIEW_REQUIRED` 警告残置中、顧問弁護士アサイン待ち |
+| プライバシーポリシー (privacy-policy) | Not started | 2026-06-20 | 同上 |
+| 特商法表記 (tokushou) | Not started | 2026-06-20 | 同上 |
+
+### 法務確認の進め方 (本田様への提案)
+
+1. 顧問弁護士に `public/legal/*.md` 3 文書をレビュー依頼
+2. 指摘事項を `public/legal/*.md` に反映 (本田様 or 本田様承認後 AI が編集)
+3. 承認後、`LEGAL_REVIEW_REQUIRED` 警告ヘッダーを削除 (別 PR)
+4. 本 tracker の Status を `Approved` に更新
+
+### Phase 5 GO への影響
+
+GO-1 (3 文書すべて `Approved`) が Phase 5 GO チェックの前提条件。1 つでも `Not started` / `In review` / `Blocked` が残れば Phase 5 着手不可。
+
+## GO-2: 課金クォータ申請 draft (optional)
+
+> **Phase 2 smoke test 結果 (68 文字 / 1 回呼出) からは default quota likely sufficient for private testing; public launch quota decision remains owner-approved.**
+>
+> 本 section は申請が必要になった場合の template 起草。提出可否判断は本田様。
+
+### 現状の quota 利用状況 (Phase 2 時点)
+
+| サービス | quota | 利用率 (推定) | 一般公開後の懸念 |
+|---|---|---|---|
+| Vertex AI (`gemini-2.5-flash`) | region default | < 1% (smoke test 1 call) | ユーザー数 × AI 呼出頻度で増加 |
+| Vertex AI (`Imagen`) | region default | 0% | 1 リクエスト 4 画像生成、コスト重め |
+| Cloud Run | default (1000 req/sec) | 〜 | 公開後の DAU 次第 |
+| Firestore (read/write) | default (10K req/sec) | < 1% | 同上 |
+
+### 申請 template (本田様が Google Cloud Console に転記可能な形)
+
+> **本 template は AI が起草した optional draft**。本田様が「申請が必要」と判断したときに転用してください。
+
+**Vertex AI Quota Increase Request (英文):**
+
+```
+Subject: Quota Increase Request for Vertex AI (gemini-2.5-flash, Imagen) — novel-writer-prod
+
+Project ID: novel-writer-prod
+Region: asia-northeast1
+Current default quota: <現状値、Google Cloud Console で確認>
+Requested quota: <希望値>
+Use case: AI-assisted novel writing SaaS. Each end user invokes
+gemini-2.5-flash for prose generation (~200-2000 input tokens, ~300-1000
+output tokens per call, average ~3 calls/session). Imagen invoked
+opt-in for character portrait generation (~1 call per session).
+Expected DAU at public launch: <本田様見積もり>
+Expected concurrent peak: <本田様見積もり>
+Project status: Pre-launch, private testing complete (Phase 2 smoke
+test successful: 68 chars generated in 1 call).
+Contact: <本田様 email>
+```
+
+**Cloud Run / Firestore quota**: 公開後の実利用データを 1〜2 週間取得してから申請判断。Phase 5 公開後 GO-2 再評価。
+
+### Phase 5 GO への影響
+
+GO-2 は **「default quota で行ける見込み」または「申請 Approved」** のどちらかが必要。本田様の判断項目。
+
+## Phase 5 GO チェック
+
+> **重要**: Phase 4 完了は **Phase 5 (公開実行 = 公開告知 + KPI 追跡開始) の GO ではない**。Phase 4 で文書化 + 起草 + (段階 2 で) PITR/Logging 実機構築が完了しても、それは「公開できる準備が整った」状態であって「公開する」ことではない。一般公開 (Phase 5) には下記すべてが充足され、かつ **decision-maker (本田様) からの明示 GO** が必要である。
+
+### Phase 5 (公開実行) 前に充足すべき項目
+
+| # | 項目 | 担当 | trigger (充足条件) |
+|---|------|------|------------------|
+| GO-1 | 法務確認 (利用規約 / プライバシーポリシー / 特商法表記 全 `Approved`) | 本田様 + 顧問弁護士 | 本書 §GO-1 tracker の 3 文書すべて `Approved` |
+| GO-2 | 課金クォータ (default で行ける見込み or 申請 Approved) | 本田様 | 本書 §GO-2 判断完了 (Phase 2 smoke + 想定 DAU で評価) |
+| GO-3 | Firestore PITR 有効化 + 復旧演習 PASS | AI 実行 (本田様番号単位認可後) | 段階 2 PR merge + `prod-pitr.md` に証跡追記 |
+| GO-4 | Cloud Logging dashboard + alerting 構築 + 通知到達確認 | AI 実行 (本田様番号単位認可後) | 段階 2 PR merge + `prod-monitoring.md` に証跡追記 |
+| GO-5 | SLO Accepted (initial draft 採用、`prod-slo.md` Status 変更) | 本田様レビュー → AI 更新 PR | 段階 3 PR merge |
+| GO-6 | 本田様からの公開告知 GO + Phase 5 spec 着手指示 | 本田様 | 上記 GO-1〜GO-5 すべて ✅ + 明示指示 |
+
+### Phase 5 着手の trigger 条件
+
+- 上記 GO-1〜GO-6 **すべて** が ✅ になる
+- かつ **本田様から「Phase 5 着手 GO」の明示指示** (Phase 4 着手指示と同じパターン)
+- AI は自発的に Phase 5 着手を提案しない (AI 駆動開発 4 原則 §1 越権防止)
+
+### Phase 4 完了 ≠ Phase 5 GO
+
+Phase 4 完了 (本 phase4-tasks.md 全 chk + ADR-0003 + 3 runbook merge + 段階 2 実機構築 + GO-5 SLO Accepted) の意味:
+- ✅ 公開する準備が整った
+- ✅ 公開後に必要な PITR / Logging / SLO 基盤が起動した
+
+Phase 4 完了の意味**ではない**もの:
+- ❌ 公開告知してよい
+- ❌ Phase 5 を自動的に開始してよい
+- ❌ 法務 / 課金 / 公開告知判断を AI が代行してよい
+
+## 参考
+
+- ADR-0001 §Consequences (緊急対応 + max-instances=2 + 月 ¥1,000 予算アラート、Phase 4 でも適用継続)
+- ADR-0002 (dev → prod 運用フロー、本 Phase でも authoritative、ADR-0003 は補強)
+- [phase3-tasks.md](./phase3-tasks.md) §Phase 4 GO チェック (本 Phase が答える GO-1〜GO-6)
+- [runbook prod-deploy-flow.md](../../runbook/prod-deploy-flow.md) (Phase 3 で起草、本 Phase でも適用)
+- ADR-0003 / prod-pitr.md / prod-monitoring.md / prod-slo.md (PR β で起票)
+- `.claude/memory/feedback_env_var_naming_drift.md` (Phase 2 教訓)
+- `.claude/memory/feedback_firebase_auth_setup_gotcha.md` (Phase 1 補完事項)


### PR DESCRIPTION
## Summary

Phase 4 (一般公開準備) の枠組み先行 PR。`phase4-tasks.md` のみ作成。
ADR-0003 + 3 runbook (prod-pitr / prod-monitoring / prod-slo) は **PR β** で別途起票。

- T1-T7 タスク表 (PR α + PR β + 段階 2 + 段階 3 の全体像)
- AC-P4-1〜11 (PR α 範囲は AC-P4-1 / P4-6 / P4-7 / P4-10、それ以外は PR β / 段階 2 で検証)
- GO-1 法務確認 status tracker (3 文書 × 4 値 status、AI は事実更新のみ)
- GO-2 課金クォータ申請 draft (optional、Vertex AI 申請文 template)
- **Phase 5 GO チェック独立 section** (公開実行 = 本田様判断、AI 自発提案禁止)

コード変更なし、文書のみ。

## Codex セカンドオピニオン (plan モード) 反映済

| 重要度 | 指摘 | 反映先 |
|---|---|---|
| H | ADR-0003 は ADR-0002 補強 (supersede しない) | PR β で boilerplate 明記予定 |
| H | Firestore データ rollback 設計は prod-pitr.md で完結、ADR-0002 本体は本 Phase で変更しない | NG リスト + PR β スコープ |
| H | Phase 5 GO チェック独立 section | 本 PR で実装済 |
| M | PR 分割 2 本 (α 枠組み / β 詳細) | 本 PR α + 後続 PR β |
| M | SLO は initial draft、Phase 5 real traffic で再校正 | PR β で実装予定 |
| M | incident 通知は email 最小案、Slack/SMS は future work | PR β で実装予定 |
| M | 法務 tracker は phase4-tasks.md 内、4 値 status 限定 | 本 PR で実装済 |
| L | 課金クォータ申請 draft は optional、断定回避 | 本 PR で実装済 |

## AC 検証 (PR α 範囲)

- ✅ AC-P4-1: AC 11 件 + GO-1 / GO-2 / Phase 5 GO チェック 3 section
- ✅ AC-P4-6: Status 4 値 + 課金クォータ申請 section
- ✅ AC-P4-7: \`npm run lint\` PASS + \`npm run test\` PASS (836/836)
- ✅ AC-P4-10: Phase 5 GO チェック section + GO-1〜6 全項目記載

AC-P4-2〜5 / AC-P4-8〜9 / AC-P4-11 は PR β / 段階 2 で検証。

## Phase 4 完了 ≠ Phase 5 GO

- 本 PR merge では Phase 4 は **完了しない**
- Phase 4 完了は PR β merge + 段階 2 (PITR/Logging 実機構築) + 段階 3 (SLO Accepted) 後
- Phase 5 (公開実行) は別軸の本田様明示 GO 待ち

## Test plan

- [x] \`npm run lint\` PASS (tsc エラー 0)
- [x] \`npm run test\` PASS (836/836)
- [x] AC-P4-1 / P4-6 / P4-10 grep ベースで検証 PASS
- [ ] doc レビュー (本田様の目視確認)

設定/ドキュメントのみの PR のため、構文検証 + 次セッション参照可能性で完了とする (CLAUDE.md Definition of Done §3 該当)。

## NG リスト (本 PR に含めない)

- ADR-0003 / 3 runbook (PR β で別途)
- PITR / Logging 実機有効化 (段階 2 で別 PR、番号単位認可必須)
- 法務文書 (規約 3 文書) の AI 単独修正
- ADR-0002 本体修正 (本 Phase では prod-pitr.md に拡張案のみ)
- 公開告知 traffic 切替 (Phase 5)

詳細は phase4-tasks.md §Phase 4 スコープ外 参照。

🤖 Generated with [Claude Code](https://claude.com/claude-code)