### PR TITLE
docs(prod-migration): Phase 4 PR β — ADR-0003 + 3 runbook (PITR / monitoring / SLO)

### DIFF
--- a/docs/adr/0003-public-launch-operations.md
+++ b/docs/adr/0003-public-launch-operations.md
@@ -1,0 +1,138 @@
+# ADR-0003: 一般公開時の運用追補 (PITR / 監視 / SLO / incident response)
+
+- Status: Draft (本書は AI 起草の **草案**。最終的な運用判断は **decision-maker = owner (本田様)** に委ねる)
+- Date: 2026-06-20
+- Decision Drivers: 一般公開 (Phase 5) に向けた可用性 / データ保護 / 監視 / incident response の基盤整備
+- Related: [Phase 4 spec](../spec/prod-migration/phase4-tasks.md), [runbook prod-pitr.md](../runbook/prod-pitr.md), [runbook prod-monitoring.md](../runbook/prod-monitoring.md), [runbook prod-slo.md](../runbook/prod-slo.md)
+- Related ADR: [ADR-0001](./0001-local-first-architecture.md) §Consequences (緊急対応 + max-instances=2 + 法務確認 MUST) / [ADR-0002](./0002-dev-prod-deploy-flow.md) (dev → prod 運用フロー)
+- Supersedes: なし
+- Superseded by: なし
+
+> **ADR-0002 remains authoritative for dev → prod deploy flow (deploy 判断 / tag 戦略 / rollback / データ同期).
+> ADR-0003 adds public-launch readiness controls (PITR / monitoring / SLO / incident response) without superseding ADR-0002.**
+
+> **本書の位置付け**: 本 ADR は Phase 4 (一般公開準備フェーズ) において、AI (Claude Code) が起草した **公開準備の判断基準の草案** である。最終的な運用判断 (PITR 有効化実行、Logging dashboard 構築実行、SLO 採用、incident response 通知 channel 確定、公開実行 GO-6) は **decision-maker (owner = 本田様)** に委ねる。AI は executor として手順実行と起草を担当する (AI 駆動開発 4 原則 §1)。
+
+## Context
+
+### Phase 3 完了時点の状況 (2026-06-20)
+
+- ADR-0002 で dev → prod 運用フローの 4 判断基準 (deploy 判断 / tag / rollback 3 段階 / データ同期) を文書化
+- runbook prod-deploy-flow.md で実務手順を文書化
+- prod は本田様 (owner) 自身の dev test 用稼働中、一般公開は未
+
+### Phase 4 で答える未解決の問い
+
+Phase 3 で **「Phase 4 GO チェック」** として残した 5 つの未決項目 (GO-1 法務 / GO-2 課金 / GO-3 PITR / GO-4 Logging / GO-5 SLO) のうち、本 ADR は GO-3 / GO-4 / GO-5 の **規範** を起草する。GO-1 / GO-2 は decision-maker 領分のため、本 ADR では扱わず phase4-tasks.md 内 status tracker に委ねる。
+
+1. **データ rollback**: ADR-0002 §3 で rollback を 3 段階に縮約し「Firestore データ rollback は Phase 4 で PITR と一体再設計」と予告した宿題への回答
+2. **監視**: 一般公開後に prod の異常を検知する仕組み (現状: 本田様自身が気付くしかない)
+3. **SLO / incident response**: 「何を異常とみなし、どう対応するか」の明文化
+
+### 制約
+
+- prod は現状 owner 1 名のみ利用、一般公開後の DAU は不確実
+- SLO / incident response を「正式採用」する前に real traffic データ (Phase 5 公開後) で再校正する前提
+- 通知 channel (email / Slack / SMS) の確定は decision-maker 判断
+- AI 単独で PITR 有効化 / Logging dashboard 構築 / SLO 採用を実行しない (番号単位明示認可必須)
+
+## Decision
+
+以下 3 つの規範を採用する。各規範は本 ADR (なぜ) と runbook (どう) で対になる。
+
+### 1. Firestore PITR を Phase 4 段階 2 で有効化し、rollback 4 段階目を実装する
+
+**規範**: Firestore Point-In-Time Recovery (PITR) を一般公開前に有効化し、ADR-0002 §3 の rollback 段階を **3 → 4 段階** に拡張する。
+
+| 段階 | 状況 | 操作 | 復旧時間目安 |
+|---|------|------|------------|
+| 段階 1: 公開即遮断 | 既存 (ADR-0002) | `--no-allow-unauthenticated` | 数十秒 |
+| 段階 2: revision 切替 | 既存 (ADR-0002) | `update-traffic --to-revisions` | 数十秒〜数分 |
+| 段階 3: service delete | 既存 (ADR-0002) | `gcloud run services delete` | 数分 |
+| **段階 4: Firestore PITR restore** | **新規 (本 ADR で起草、runbook prod-pitr.md §ADR-0002 rollback 4 段階拡張案 で手順、ADR-0002 本体反映は段階 2 PITR 有効化後 or 別 PR)** | `gcloud firestore databases restore --source-database --snapshot-time` | 数分〜数十分 (データ量依存) |
+
+**理由**:
+- ADR-0002 §3 で「Firestore データ rollback は Phase 4 で PITR と一体再設計」と予告した宿題への回答
+- PITR は最大 7 日間の任意時点に restore 可能 (Firestore default)、データ汚染インシデントの恒久対応として有効
+- ADR-0002 本体への反映は **段階 2 PITR 実機有効化後 or 別 PR** で行い、本 PR では prod-pitr.md に拡張案として記載 (Codex H 指摘 #3 反映、ADR-0002 をいきなり改変しない)
+
+### 2. Cloud Logging monitoring + alerting policy + email 通知を最小案として採用
+
+**規範**: 一般公開前に Cloud Logging dashboard + alerting policy を構築し、**email を最小通知 channel** として採用する。Slack / SMS は future work。
+
+| 監視項目 | alerting 閾値 (initial draft) | 通知 channel |
+|---|---|---|
+| `/api/*` 5xx rate | 5 分平均 > 5% | email |
+| auth fail rate (`verifyIdToken` 401) | 5 分平均 > 50% | email (公開直後の identity 設定漏れ検知) |
+| Vertex AI 429/503/504 rate | 5 分平均 > 10% | email (quota 超過検知) |
+| Cloud Run instance count | `max-instances` (=2) 到達 5 分継続 | email (突発的 traffic 警告) |
+| Firestore ERROR レベル log | 直近 5 分に 1 件以上 | email |
+
+**理由**:
+- owner 1 名運用でも「気付く仕組み」は必要 (現状 = 本田様が UI 異常を見るしかない)
+- email は構築コストが最も低く、Slack / SMS への拡張は通知 channel の追加実装で対応可能
+- 閾値は initial draft、Phase 5 real traffic 取得後に再校正
+
+### 3. SLO を initial draft として採用し、Phase 5 real traffic で再校正
+
+**規範**: SLO 指標を **可用性 / エラー率 / AI 応答失敗率** の 3 軸で initial draft として起草、Phase 5 公開後の real traffic データに基づき再校正する。
+
+| 指標 | initial draft target | 測定窓 | 出典 |
+|---|---|---|---|
+| 可用性 (uptime) | **99.5% monthly** (= 約 3.65 時間 downtime/月) | 月次 | Cloud Run uptime check |
+| 5xx エラー率 | **< 1%** | 24 時間 rolling | `/api/*` request log |
+| AI 応答失敗率 (Vertex AI 429/503/504) | **< 5%** | 24 時間 rolling | Cloud Logging |
+
+**incident response (initial draft)**:
+
+| 重要度 | 状況 | 対応 |
+|---|---|---|
+| P0 | 公開即遮断 trigger (情報漏洩 / 認証バイパス / 課金暴走) | 即時 段階 1 rollback |
+| P1 | SLO 閾値違反継続 (5xx > 5% が 30 分以上等) | 1 時間以内に原因調査 + 段階 2 rollback 判断 |
+| P2 | 単発エラー / 短時間異常 | 24 時間以内に分析 → fix PR |
+
+通知 channel (initial draft): P0 / P1 = email、P2 = log のみ (notification なし)。
+
+**理由**:
+- 99.5% は SaaS 業界一般的な initial target、real traffic 後に上下調整
+- 5xx / Vertex AI 429-504 / 401 fail rate は ADR-0001 §Consequences の課金リスク + Phase 2 で実発覚した bug 2 件と整合
+- P0 / P1 / P2 の 3 段階は incident response の認知負荷を最小化
+
+## Consequences
+
+### 良い影響
+
+- ADR-0002 で残した「Firestore データ rollback」の宿題が Phase 4 で解決路線に乗る (段階 2 で実機有効化、ADR-0002 本体反映は段階 2 後)
+- 一般公開前に「異常検知の仕組み」が email 単一 channel で最低限実装される
+- SLO 数値は initial draft として明示、real traffic 後に再校正する前提が共有される
+- ADR-0002 を supersede せず補強する構造により、deploy 判断 / tag / rollback / データ同期の規範は Phase 4 でも継承される
+
+### 受け入れる制約
+
+- PITR retention は default 7 日 (一般公開後に retention 延長が必要なら別 ADR / 別 PR)
+- 通知 channel が email のみ (公開直後の重大インシデントで本田様の email チェック遅延に依存)
+- SLO 数値が real traffic 前は推測値 (99.5% / 1% / 5% はすべて推定、Phase 5 で再校正)
+- AI 単独での PITR 有効化 / Logging 構築 / SLO 採用は禁止 (番号単位明示認可必須)
+
+### Phase 5 / 一般公開後に再評価する項目 (本 ADR では扱わない)
+
+| 項目 | 再評価時の論点 |
+|---|---|
+| Slack / SMS 通知 | email だけでは検知遅延が大きい場面 (深夜帯のインシデント等) で追加検討 |
+| SLO 数値の本採用 | Phase 5 公開後 1-3 ヶ月の real traffic で再校正 |
+| PITR retention 延長 | 7 日で足りない法務・コンプライアンス要件があれば再評価 |
+| incident response の自動化 | P0 trigger の自動 rollback (`--no-allow-unauthenticated` 自動発火) など |
+| 複数オーナー / 当番制 incident response | 一般公開後にチーム化したときに再設計 |
+
+これら未決項目は [phase4-tasks.md §Phase 5 GO チェック](../spec/prod-migration/phase4-tasks.md#phase-5-go-チェック) で追跡する (本 ADR からは参照のみ、一次定義は phase4-tasks.md)。
+
+## 参考
+
+- [phase4-tasks.md](../spec/prod-migration/phase4-tasks.md) (本 ADR と対の Phase 4 タスク表)
+- [runbook prod-pitr.md](../runbook/prod-pitr.md) (PITR 有効化 + 復旧手順 + ADR-0002 rollback 4 段階拡張案)
+- [runbook prod-monitoring.md](../runbook/prod-monitoring.md) (Cloud Logging dashboard + alerting policy + email 通知)
+- [runbook prod-slo.md](../runbook/prod-slo.md) (SLO initial draft + incident response)
+- [ADR-0002](./0002-dev-prod-deploy-flow.md) (dev → prod 運用フロー、本 ADR でも authoritative)
+- [ADR-0001](./0001-local-first-architecture.md) §Consequences (緊急対応 + max-instances=2 + 法務確認 MUST、本 ADR でも継承)
+- `.claude/memory/feedback_env_var_naming_drift.md` (Phase 2 教訓、alerting 項目の選定根拠)
+- `.claude/memory/feedback_firebase_auth_setup_gotcha.md` (Phase 1 補完事項、auth fail rate alerting の選定根拠)

--- a/docs/runbook/prod-monitoring.md
+++ b/docs/runbook/prod-monitoring.md
@@ -1,0 +1,132 @@
+# Runbook: Cloud Logging dashboard + alerting policy (Phase 4)
+
+- Status: 🚧 Draft (本書は AI 起草の **草案**。dashboard / alerting policy / 通知 channel の実機構築は **decision-maker = owner (本田様)** の番号単位明示認可後に AI が executor として実施する)
+- Last Updated: 2026-06-20
+- Owner: yasushi-honda
+- Related ADR: [ADR-0003](../adr/0003-public-launch-operations.md) §Decision 2 (本書の判断基準を裏付ける規範)
+- Related: [Phase 4 spec](../spec/prod-migration/phase4-tasks.md), [runbook prod-slo.md](./prod-slo.md) (本書 alerting 閾値と SLO 指標を整合)
+
+> **本書の位置付け**: Cloud Logging dashboard + alerting policy + 通知 channel 設計を起草。実機構築 (`gcloud monitoring policies create` 等) は **段階 2 (本 Phase 対象外、別 PR)** で本田様番号単位認可後に AI が実行する。本書は構成記載のみ。
+
+## 用途
+
+- Cloud Logging dashboard の構成設計
+- alerting policy 5 種類の閾値定義
+- 通知 channel 設計 (email を最小案、Slack / SMS は future work)
+- 段階 2 実機構築時の `gcloud` コマンド template
+
+## 前提
+
+- prod = `novel-writer-prod` (Cloud Run + Firestore + Vertex AI @ asia-northeast1)
+- Cloud Logging は GCP project default で有効
+- 通知先 email = 本田様の Gmail (現状 GO-1 法務確認の連絡先と同じ、要本田様確認)
+
+## dashboard 構成
+
+### dashboard name: `novel-writer-prod 監視`
+
+### widget 構成
+
+| # | widget | 表示内容 | 出典 | refresh |
+|---|---|---|---|---|
+| W1 | line chart | `/api/*` request rate (1 分粒度、24h) | Cloud Run request log | 1 分 |
+| W2 | line chart | `/api/*` 5xx error rate (5 分粒度、24h) | Cloud Run request log filter `httpRequest.status >= 500` | 5 分 |
+| W3 | line chart | auth fail rate (`401` rate / total) | Cloud Run request log filter `httpRequest.status = 401` | 5 分 |
+| W4 | line chart | Vertex AI 429 / 503 / 504 rate | server log filter `severity=ERROR AND jsonPayload.statusCode IN (429,503,504)` | 5 分 |
+| W5 | scorecard | Cloud Run instance count (current) | Cloud Run metric `instance_count` | 1 分 |
+| W6 | scorecard | Firestore ERROR レベル log 件数 (直近 5 分) | Firestore log filter `severity=ERROR` | 5 分 |
+| W7 | line chart | Vertex AI quota 利用率 (gemini-2.5-flash) | Vertex AI quota metric | 5 分 |
+| W8 | line chart | usage `reserve` / `commit` / `cancel` 比率 | server log filter `withUsageQuota` | 5 分 |
+
+### dashboard URL の保管
+
+dashboard 作成後の URL を本書末尾「監視 dashboard 履歴」に追記。本田様のブックマーク + 引き継ぎ時の参照用。
+
+## alerting policy
+
+### policy 5 種類 (initial draft、Phase 5 real traffic 後に閾値再校正)
+
+| # | policy name | 条件 | 評価窓 | 通知 channel | 重要度 |
+|---|---|---|---|---|---|
+| A1 | `prod-5xx-rate-high` | `/api/*` 5xx rate > 5% | 5 分平均 | email | P1 |
+| A2 | `prod-auth-fail-rate-high` | `401` rate > 50% | 5 分平均 | email | P1 (公開直後の identity 設定漏れ検知) |
+| A3 | `prod-vertex-ai-quota-error` | Vertex AI 429/503/504 rate > 10% | 5 分平均 | email | P1 (quota 超過検知) |
+| A4 | `prod-instance-saturation` | Cloud Run `instance_count` = `max-instances` (=2) | 5 分継続 | email | P1 (突発 traffic 警告、課金リスク) |
+| A5 | `prod-firestore-error` | Firestore ERROR レベル log | 直近 5 分に 1 件以上 | email | P2 |
+
+### alerting policy template (段階 2 で `gcloud` 実行)
+
+```bash
+# policy A1 example: 5xx rate > 5% for 5 min
+gcloud alpha monitoring policies create \
+  --project=novel-writer-prod \
+  --display-name='prod-5xx-rate-high' \
+  --documentation='Cloud Run 5xx rate exceeded 5% over 5 min window. Investigate via dashboard W2.' \
+  --condition-filter='resource.type="cloud_run_revision" AND metric.type="run.googleapis.com/request_count" AND metric.label."response_code_class"="5xx"' \
+  --condition-threshold-value=0.05 \
+  --condition-threshold-comparison=COMPARISON_GT \
+  --condition-aggregations='alignment-period=300s,per-series-aligner=ALIGN_RATE,cross-series-reducer=REDUCE_MEAN' \
+  --condition-duration=300s \
+  --notification-channels='<email channel ID>'
+```
+
+> **注**: 実際の `gcloud alpha monitoring policies create` の引数仕様は GCP 側変更があり得るため、段階 2 実機構築時に最新ドキュメントを web search で確認すること。
+
+## 通知設計
+
+### email (最小案、本 Phase で構築)
+
+| 項目 | 値 |
+|---|---|
+| notification channel type | `email` |
+| 通知先 | 本田様の Gmail (要本田様確認) |
+| 即時通知 | A1〜A4 (P1) は 1 通/incident、cooldown 30 分 |
+| ダイジェスト | A5 (P2) は 1 日 1 通サマリー (incident なしの日も「異常なし」通知) |
+
+### Slack (future work)
+
+| 項目 | 状態 |
+|---|---|
+| Webhook URL 取得 | ⏳ 未着手 |
+| 通知 channel 名 | `#novel-writer-prod-alerts` (案) |
+| 即時通知 | P0 / P1 即時、P2 は 1 時間ダイジェスト |
+| 検討時期 | 一般公開後 1 ヶ月時点で「email だけでは検知遅延が大きい場面があったか」を本田様判断 |
+
+### SMS / Phone (future work)
+
+| 項目 | 状態 |
+|---|---|
+| 番号登録 | ⏳ 未着手 |
+| 用途 | P0 (公開即遮断 trigger) のみ、深夜帯のインシデント検知 |
+| 検討時期 | 一般公開後 3 ヶ月時点で本田様判断 |
+
+### 通知 channel 確定の決定権
+
+email 通知先 (本田様 Gmail address) の確定は **decision-maker = 本田様** 判断。本書は default で本田様 Gmail を想定するが、実機構築時 (段階 2) に再確認する。
+
+## 段階 2 (本 Phase 対象外) で実施する手順 (preview)
+
+1. 本田様番号単位認可受領 ("PR β merge 後、dashboard / alerting 構築を実行してよい")
+2. email notification channel 作成 (`gcloud alpha monitoring channels create`)
+3. dashboard 作成 (Console UI または `gcloud monitoring dashboards create`)
+4. alerting policy 5 件作成 (上記 template)
+5. 構築完了後、`/api/no-such-endpoint` への curl 等で意図的に 404/500 を発生させ、通知が到達することを確認
+6. 通知到達確認証跡 (alert ID / 通知時刻 / email 受信時刻) を本書末尾「監視構築履歴」に追記
+
+## 関連 ADR / runbook link
+
+- [ADR-0003 §Decision 2](../adr/0003-public-launch-operations.md#2-cloud-logging-monitoring--alerting-policy--email-通知を最小案として採用) (本書の判断基準)
+- [runbook prod-slo.md](./prod-slo.md) (本書 alerting 閾値と SLO 指標を整合)
+- [phase4-tasks.md](../spec/prod-migration/phase4-tasks.md) §Phase 5 GO チェック GO-4
+
+## 監視 dashboard 履歴
+
+| 日時 | 実行者 | dashboard 名 | URL | 備考 |
+|---|---|---|---|---|
+| (段階 2 PR で本田様番号単位認可後に追記) | - | - | - | - |
+
+## 監視構築履歴
+
+| 日時 | policy name | 通知到達確認 | 備考 |
+|---|---|---|---|
+| (段階 2 PR で本田様番号単位認可後に追記) | - | - | - |

--- a/docs/runbook/prod-pitr.md
+++ b/docs/runbook/prod-pitr.md
@@ -1,0 +1,200 @@
+# Runbook: Firestore PITR 有効化と復旧 (Phase 4)
+
+- Status: 🚧 Draft (本書は AI 起草の **草案**。PITR 有効化実行 + retention 期間決定 + 復旧演習実行は **decision-maker = owner (本田様)** の番号単位明示認可後に AI が executor として実施する)
+- Last Updated: 2026-06-20
+- Owner: yasushi-honda
+- Related ADR: [ADR-0003](../adr/0003-public-launch-operations.md) §Decision 1 (本書の判断基準を裏付ける規範)
+- Related: [Phase 4 spec](../spec/prod-migration/phase4-tasks.md), [runbook prod-deploy-flow.md](./prod-deploy-flow.md) (Phase 3 で起草、本書は ADR-0002 rollback 段階を 3→4 段階に拡張する案を起草)
+- Related ADR: [ADR-0002](../adr/0002-dev-prod-deploy-flow.md) §3 rollback (本書 §ADR-0002 rollback 4 段階拡張案 で 4 段階目を起草、本体反映は段階 2 PITR 有効化後 or 別 PR)
+
+> **本書の位置付け**: Firestore Point-In-Time Recovery (PITR) の有効化 + retention 判断 + 復旧手順 + 復旧演習を起草。実機有効化 (`gcloud firestore databases update --enable-pitr`) は **段階 2 (本 Phase 対象外、別 PR)** で本田様番号単位認可後に AI が実行する。本書は手順記載のみ。
+
+## 用途
+
+- Firestore PITR を一般公開 (Phase 5) 前に有効化する手順
+- retention 期間 (default 7 日) の判断
+- データ汚染インシデント発生時の復旧手順
+- 復旧演習 (dev で年 1 回以上) の手順
+- ADR-0002 rollback 3→4 段階拡張の手順起草 (本体反映は別 PR)
+
+## 前提
+
+- prod = `novel-writer-prod` (Cloud Run + Firestore @ asia-northeast1)
+- Firestore database name = `(default)` (Phase 1 で確定)
+- PITR 有効化操作は **destructive ではない** が、本田様番号単位認可下で実行する
+- 復旧 (`gcloud firestore databases restore`) は **新規 database 作成を伴う destructive 操作**、番号単位認可必須
+
+## 有効化手順
+
+### Step 1: 前提確認
+
+```bash
+# 現在の Firestore database 状態確認
+gcloud firestore databases describe \
+  --database='(default)' \
+  --project=novel-writer-prod \
+  --format='value(pointInTimeRecoveryEnablement)'
+# 期待値 (有効化前): POINT_IN_TIME_RECOVERY_DISABLED
+```
+
+### Step 2: PITR 有効化 (本田様番号単位認可後)
+
+```bash
+gcloud firestore databases update \
+  --database='(default)' \
+  --project=novel-writer-prod \
+  --enable-pitr
+# 期待値: Updated database [(default)].
+```
+
+### Step 3: 有効化後の確認
+
+```bash
+gcloud firestore databases describe \
+  --database='(default)' \
+  --project=novel-writer-prod \
+  --format='value(pointInTimeRecoveryEnablement)'
+# 期待値 (有効化後): POINT_IN_TIME_RECOVERY_ENABLED
+
+gcloud firestore databases describe \
+  --database='(default)' \
+  --project=novel-writer-prod \
+  --format='value(earliestVersionTime)'
+# 期待値: 有効化時刻に近い ISO timestamp
+```
+
+### Step 4: 証跡記録
+
+有効化日時 / 実行コマンド / 確認結果を本書末尾「PITR 有効化履歴」table に追記する。
+
+## retention 期間判断
+
+### Firestore PITR の retention 仕様 (2026-06 時点、要 web search 再確認)
+
+| 設定 | retention 期間 |
+|---|---|
+| default (--enable-pitr) | **最大 7 日間** |
+| 延長 (オプション) | 一部リージョンで延長プランあり、要 web search 再確認 + 別 ADR |
+
+### Phase 4 段階での判断
+
+| 観点 | 判断 |
+|---|---|
+| 一般公開直後の想定インシデント検知時間 | 1-3 日以内が現実的 (owner 1 名運用) |
+| 法務 / コンプライアンス要件 | 現状要求なし (Phase 4 範囲、Phase 5 以降で再評価) |
+| コスト | retention 期間によらず PITR 有効化自体が課金される (Firestore 料金体系参照) |
+| **推奨** | **default 7 日で Phase 4 完了、Phase 5 real traffic 観察後に延長判断** |
+
+**理由**: Phase 4 段階では single-tenant 運用で large incident が起きにくく、7 日 retention で十分な可能性が高い。一般公開後に「データ汚染インシデントの検知が 7 日を超えるパターン」があれば retention 延長を別 ADR で再評価する。
+
+## 復旧演習
+
+### 演習の目的
+
+PITR 有効化だけで復旧できる保証はない。本番インシデント前に **dev 環境で復旧手順を一度実行** し、手順書の正確性と所要時間を実測する。
+
+### 演習手順 (dev で実施、本番影響なし)
+
+```bash
+# 1. dev で PITR 有効化 (まだ未有効なら)
+gcloud firestore databases update \
+  --database='(default)' \
+  --project=novel-writer-dev \
+  --enable-pitr
+
+# 2. 演習用テストデータ作成 (本田様の dev アカウントで適当に project 作成)
+#    → IndexedDB に保存 → 通常使用
+
+# 3. 5-10 分待機後、現在時刻を snapshot 候補時刻として記録
+SNAPSHOT_TIME=$(date -u -d '5 minutes ago' +%Y-%m-%dT%H:%M:%SZ)
+echo "Snapshot time: $SNAPSHOT_TIME"
+
+# 4. テストデータを (敢えて) 破壊
+#    → Firebase Console で users/<dev uid> ドキュメントを手動削除
+#    → アプリでログイン → users/init で初期化 (旧データ消失確認)
+
+# 5. PITR restore (新規 database 作成)
+gcloud firestore databases restore \
+  --source-database=projects/novel-writer-dev/databases/'(default)' \
+  --destination-database=drill-restore-$(date +%s) \
+  --snapshot-time=$SNAPSHOT_TIME \
+  --project=novel-writer-dev
+
+# 6. 復旧 database の検証 (Firebase Console で確認)
+#    → 破壊前のドキュメントが存在することを確認
+
+# 7. 演習完了後、復旧用 database を削除 (コスト最小化)
+gcloud firestore databases delete drill-restore-<timestamp> \
+  --project=novel-writer-dev
+```
+
+### 演習実施頻度
+
+- **段階 2 PITR 有効化直後**: 1 回必須 (手順書の正確性確認)
+- **以降**: 年 1 回以上 (Cloud Logging スケジュール or 本田様カレンダー)
+
+### 演習証跡
+
+dev 演習実施日時 / 所要時間 / 課題を本書末尾「復旧演習履歴」table に追記。
+
+## ADR-0002 rollback 4 段階拡張案
+
+> **本 section は ADR-0002 §3 rollback 3 段階の拡張案を起草するもの**。ADR-0002 本体への反映は **段階 2 PITR 実機有効化後 or 別 PR** で行う (Codex H 指摘 #3 反映、本 PR では ADR-0002 本体を変更しない)。
+
+### 現行 ADR-0002 §3 (Phase 3 で起草、3 段階)
+
+| 段階 | 状況 | 操作 | 復旧時間目安 |
+|---|------|------|------------|
+| 段階 1: 公開即遮断 | 情報漏洩 / 認証バイパス / 課金暴走 | `--no-allow-unauthenticated` | 数十秒 |
+| 段階 2: revision 切替 | 通常 rollback | `update-traffic --to-revisions` | 数十秒〜数分 |
+| 段階 3: service delete | 最終手段 | `gcloud run services delete` | 数分 |
+| (Firestore データ rollback) | Phase 3 段階では未設計、Phase 4 で再設計予告 | (本書で起草) | - |
+
+### 拡張案 (ADR-0002 §3 を 4 段階に)
+
+| 段階 | 状況 | 操作 | 復旧時間目安 |
+|---|------|------|------------|
+| 段階 1: 公開即遮断 | 既存、不変 | `--no-allow-unauthenticated` | 数十秒 |
+| 段階 2: revision 切替 | 既存、不変 | `update-traffic --to-revisions` | 数十秒〜数分 |
+| 段階 3: service delete | 既存、不変 | `gcloud run services delete` | 数分 |
+| **段階 4: Firestore PITR restore** | **データ汚染 (誤削除 / 誤上書き / 意図せざる migration)** | **`gcloud firestore databases restore --snapshot-time`** + **新規 database への切替** | **数分〜数十分 (データ量依存) + アプリ database 切替操作** |
+
+### 段階 4 の判断基準
+
+| 状況 | 段階 4 採用判断 |
+|---|---|
+| データ削除インシデント | ✅ 採用 (削除前時刻 snapshot から restore) |
+| データ migration 失敗 | ✅ 採用 (migration 前時刻 snapshot から restore) |
+| アプリ挙動の欠陥 (データは無事) | ❌ 段階 2 (revision 切替) で十分 |
+| service 自体の重大障害 | ❌ 段階 3 (service delete) を優先 |
+
+### 段階 4 実施時の追加考慮事項
+
+- **新規 database 作成**: PITR restore は元の `(default)` database を上書きせず、新規 database を作成する
+- **アプリの database 接続切替**: Firebase Admin SDK の database name 指定を `(default)` → 新規 name に変更 → 再 deploy
+- **旧 database の扱い**: 復旧確認後、旧 `(default)` を削除するか rename して保管するかは本田様判断
+- **PITR retention 限界**: snapshot 時刻が retention (7 日) を超えていると restore 不可、即座の判断が重要
+
+### ADR-0002 本体反映タイミング
+
+- 本 runbook の段階 4 案を ADR-0002 §3 に転記する PR は **段階 2 PITR 有効化完了後** (実機で段階 4 が動くことを確認してから ADR 本体に書く)
+- それまでは本 runbook が ADR-0002 §3 の補強として参照される
+
+## 関連 ADR / runbook link
+
+- [ADR-0003 §Decision 1](../adr/0003-public-launch-operations.md#1-firestore-pitr-を-phase-4-段階-2-で有効化しrollback-4-段階目を実装する) (本書の判断基準)
+- [ADR-0002 §3 rollback](../adr/0002-dev-prod-deploy-flow.md) (Phase 3 起草、3 段階、本書で 4 段階拡張案)
+- [runbook prod-deploy-flow.md](./prod-deploy-flow.md) §rollback (Phase 3 起草、3 段階手順)
+- [phase4-tasks.md](../spec/prod-migration/phase4-tasks.md) §Phase 5 GO チェック GO-3
+
+## PITR 有効化履歴
+
+| 日時 | 実行者 | 操作 | retention 設定 | 確認結果 |
+|---|---|---|---|---|
+| (段階 2 PR で本田様番号単位認可後に追記) | - | - | - | - |
+
+## 復旧演習履歴
+
+| 日時 | 環境 | 演習者 | 所要時間 | 課題 / 改善点 |
+|---|---|---|---|---|
+| (段階 2 PITR 有効化直後の初回演習で追記) | dev | - | - | - |

--- a/docs/runbook/prod-slo.md
+++ b/docs/runbook/prod-slo.md
@@ -1,0 +1,151 @@
+# Runbook: SLO + incident response (Phase 4 initial draft)
+
+- Status: 🚧 **Initial draft**. SLO targets defined here are to be **recalibrated after Phase 5 (public launch) yields real traffic data**. Single-tenant private testing data is insufficient to set authoritative targets.
+- Last Updated: 2026-06-20
+- Owner: yasushi-honda
+- Related ADR: [ADR-0003](../adr/0003-public-launch-operations.md) §Decision 3 (本書の判断基準を裏付ける規範)
+- Related: [Phase 4 spec](../spec/prod-migration/phase4-tasks.md), [runbook prod-monitoring.md](./prod-monitoring.md) (alerting 閾値と本書 SLO 指標を整合)
+
+> **本書の位置付け**: SLO 指標 (可用性 / エラー率 / AI 応答失敗率) と incident response (P0/P1/P2) の **initial draft**。Phase 5 公開後の real traffic データに基づき再校正する前提。最終的な SLO 採用 (Accepted 化) は **decision-maker = owner (本田様)** レビュー後に AI が status 更新 PR で反映する。
+
+## 用途
+
+- SLO 指標の initial draft 定義 (3 軸: 可用性 / 5xx エラー率 / AI 応答失敗率)
+- incident response の重要度分類 (P0 / P1 / P2) と対応手順
+- 通知 channel の重要度別マッピング
+- Phase 5 public launch 後の SLO 再校正の判断基準
+
+## 前提
+
+- prod = `novel-writer-prod` (Cloud Run + Firestore + Vertex AI @ asia-northeast1)
+- alerting policy は `prod-monitoring.md` 参照 (本書と閾値を整合)
+- single-tenant 段階の現状では SLO 違反が起こる場面は限定的
+- Phase 5 公開後の real traffic で initial draft 数値を上下調整する前提
+
+## SLO 指標
+
+### 3 軸 initial draft
+
+| 指標 | initial draft target | 測定窓 | 出典 metric | 違反検知 trigger |
+|---|---|---|---|---|
+| 可用性 (uptime) | **99.5% monthly** (= 約 3.65 時間 downtime/月) | 月次 | Cloud Run uptime check (5 分粒度) | 月次集計で 99.5% 下回り |
+| 5xx エラー率 | **< 1%** | 24 時間 rolling | `/api/*` request log filter `httpRequest.status >= 500` | 24h 平均 ≥ 1% |
+| AI 応答失敗率 (Vertex AI 429/503/504) | **< 5%** | 24 時間 rolling | server log filter `severity=ERROR AND jsonPayload.statusCode IN (429,503,504)` | 24h 平均 ≥ 5% |
+
+### 数値の根拠と注記
+
+- **99.5%**: SaaS 業界一般的な initial target (Google Cloud のような大規模インフラは 99.95%+ だが、single-developer SaaS では 99.5% が現実的初期値)
+- **5xx < 1%**: Cloud Run + Express の安定性指標、Phase 2 smoke test では 0% を維持
+- **Vertex AI < 5%**: Vertex AI の quota / region 障害頻度を考慮、Phase 2 smoke では 0% だが公開後は quota 接近で増加する想定
+
+### 再校正 (recalibration) 条件
+
+| trigger | 対応 |
+|---|---|
+| Phase 5 公開後 **1 ヶ月** の real traffic 取得完了 | 初回再校正、SLO Accepted 化候補 |
+| 公開後 SLO 違反が **3 ヶ月連続** で発生 | 数値を緩める or インフラ強化判断 |
+| 公開後 SLO 違反が **3 ヶ月ゼロ** で推移 | 数値を厳しくする候補 (99.5% → 99.8% 等) |
+| Vertex AI region 障害が **想定外頻度** で発生 | AI 失敗率閾値を緩める or リトライ機構強化 |
+
+## incident response
+
+### 重要度分類 (P0 / P1 / P2)
+
+| 重要度 | 状況 | 例 | 対応 SLA |
+|---|---|---|---|
+| **P0** | 公開即遮断 trigger | 情報漏洩 / 認証バイパス / 課金暴走 / 規約違反データ流出 | 即時 (検知から 15 分以内に段階 1 rollback 発火) |
+| **P1** | SLO 閾値違反継続 | 5xx > 5% が 30 分以上 / auth fail > 50% が 30 分以上 / Vertex AI 429/503/504 > 10% が 30 分以上 / instance saturation 5 分以上 | 1 時間以内 (原因調査 + 段階 2 rollback 判断) |
+| **P2** | 単発エラー / 短時間異常 | Firestore ERROR レベル log 単発 / 5xx スパイク (短時間) | 24 時間以内 (分析 → fix PR) |
+
+### incident response の手順 (重要度別)
+
+#### P0 対応 (15 分以内)
+
+```bash
+# Step 1: 段階 1 rollback (公開即遮断) を即時発火
+gcloud run services update novel-writer \
+  --no-allow-unauthenticated \
+  --region=asia-northeast1 \
+  --project=novel-writer-prod
+
+# Step 2: incident 起票 (GitHub Issue or 本田様 note)
+#   title: "[P0] <症状>"
+#   body: 検知時刻 / 検知元 (alerting policy ID) / 影響範囲 / 暫定遮断完了時刻
+
+# Step 3: 原因調査 → 修正 → 再 deploy → 段階 1 解除 (--allow-unauthenticated 復元)
+#   詳細は runbook prod-deploy-flow.md §rollback 段階 1 参照
+```
+
+#### P1 対応 (1 時間以内)
+
+```
+1. alerting policy の通知 email を受領
+2. dashboard (prod-monitoring.md §dashboard 構成) で原因 widget を確認
+3. 原因によって判断:
+   - 新 revision の欠陥 → 段階 2 rollback (revision 切替)
+   - Vertex AI quota 接近 → quota 申請 trigger を本田様判断
+   - データ整合性問題 → 段階 4 rollback (PITR restore) 検討
+4. 修正完了後、incident note を本書末尾「incident 履歴」table に追記
+```
+
+#### P2 対応 (24 時間以内)
+
+```
+1. ダイジェスト email (1 日 1 通) で受領
+2. dashboard で発生時刻 + 範囲を分析
+3. 必要なら GitHub Issue 起票 (rating ≥ 7 の場合のみ、CLAUDE.md Issue triage rule)
+4. fix PR (dev → prod 通常 fix path、ADR-0002 §1 deploy 判断に従う)
+```
+
+## 通知 channel
+
+### initial draft mapping
+
+| 重要度 | 通知方式 | 詳細 |
+|---|---|---|
+| P0 | email 即時 | 検知 → 1 分以内に alerting policy が email 送信、cooldown なし (incident 発生中は連投許容) |
+| P1 | email 即時 | 検知 → 5 分以内に alerting policy が email 送信、cooldown 30 分 |
+| P2 | email ダイジェスト | 1 日 1 通サマリー (incident なしの日も「異常なし」通知で「監視が止まっている」状態の検知) |
+
+### future work (一般公開後 1 ヶ月時点で再評価)
+
+| 通知方式 | trigger | 検討時期 |
+|---|---|---|
+| Slack | email だけでは検知遅延が大きい場面があったか | 公開後 1 ヶ月時点 |
+| SMS / Phone | P0 の深夜帯検知 (email 未確認) で実害が出たか | 公開後 3 ヶ月時点 |
+| PagerDuty / OpsGenie | チーム化 (複数オーナー / 当番制 incident response) 時 | 公開後 6 ヶ月時点 or チーム化時点 |
+
+## SLO 採用 (Accepted 化) の手順
+
+### Phase 4 段階 3 (SLO Accepted 化 PR)
+
+1. **公開後 1 ヶ月** の real traffic データを Cloud Logging から集計
+2. 本書の initial draft target と実値を比較、本田様レビュー
+3. 本田様の判断で:
+   - **そのまま採用** → 本書 Status を `Accepted` に更新 + alerting policy 閾値を本書と整合
+   - **再校正** → 数値を上下調整、本書 + `prod-monitoring.md` alerting policy 両方を整合修正
+4. SLO Accepted 化 PR を起票 → 本田様番号単位認可 → merge
+
+### Phase 5 GO への影響
+
+GO-5 (SLO Accepted) が Phase 5 公開後の運用 phase 移行 (= Phase 4 完全終了) の前提条件。本書が `Draft` のままだと Phase 4 完了とみなさない。
+
+## 関連 ADR / runbook link
+
+- [ADR-0003 §Decision 3](../adr/0003-public-launch-operations.md#3-slo-を-initial-draft-として採用しphase-5-real-traffic-で再校正) (本書の判断基準)
+- [runbook prod-monitoring.md](./prod-monitoring.md) (alerting 閾値と本書 SLO 指標を整合)
+- [runbook prod-pitr.md](./prod-pitr.md) §ADR-0002 rollback 4 段階拡張案 (P1/P0 で段階 4 採用検討時の参照)
+- [runbook prod-deploy-flow.md](./prod-deploy-flow.md) §rollback (P0/P1 対応で段階 1/2/3 操作の手順)
+- [phase4-tasks.md](../spec/prod-migration/phase4-tasks.md) §Phase 5 GO チェック GO-5
+
+## incident 履歴
+
+| 日時 | 重要度 | 症状 | 対応 | resolved 時刻 | 備考 |
+|---|---|---|---|---|---|
+| (一般公開後の実 incident で追記) | - | - | - | - | - |
+
+## SLO 再校正履歴
+
+| 日時 | 再校正前 target | 再校正後 target | 根拠 | 担当 |
+|---|---|---|---|---|
+| (Phase 4 段階 3 SLO Accepted 化 PR で追記) | - | - | - | - |


### PR DESCRIPTION
## Summary

Phase 4 段階 1 の詳細設計 PR。PR α ([#201](https://github.com/Yukina1116/novel-writer/pull/201)) merge 後の続編。
4 artifact 同梱 (約 620 行)。

- **ADR-0003** (`docs/adr/0003-public-launch-operations.md`): ADR-0002 を **補強する追補** 位置付け、PITR / monitoring / SLO の 3 規範
- **runbook prod-pitr.md**: Firestore PITR 有効化手順 / retention 判断 / 復旧演習 / **ADR-0002 rollback 4 段階拡張案**
- **runbook prod-monitoring.md**: Cloud Logging dashboard 構成 (8 widget) / alerting policy 5 件 / 通知設計 (email 最小、Slack/SMS は future work)
- **runbook prod-slo.md**: SLO **initial draft** (99.5% / 5xx < 1% / Vertex AI 429-504 < 5%) + incident response P0/P1/P2 + 再校正条件

コード変更なし、文書のみ。

## Reviewer checklist (4 領域分割)

### 領域 1: ADR-0003 (補強位置付け)
- [ ] 冒頭 boilerplate「ADR-0002 remains authoritative for dev → prod deploy flow; ADR-0003 adds public-launch readiness controls **without superseding ADR-0002**」明記
- [ ] Context / Decision / Consequences の 3 section が揃う
- [ ] §Decision 1-3 が prod-pitr / prod-monitoring / prod-slo の 3 runbook と一対一対応

### 領域 2: prod-pitr.md (PITR + rollback 4 段階拡張案)
- [ ] 有効化 / retention / 復旧演習 / ADR-0002 rollback 4 段階拡張案の 4 section
- [ ] ADR-0002 本体は本 PR で **変更しない** (拡張案は本 runbook 内に留める、本体反映は段階 2 PITR 有効化後 or 別 PR)
- [ ] 復旧演習手順が dev で実施可能な形 (本番影響なし)

### 領域 3: prod-monitoring.md (dashboard + alerting + 通知)
- [ ] dashboard 8 widget + alerting policy 5 件
- [ ] 通知 channel が email を最小案、Slack / SMS が future work として future work table に明示
- [ ] alerting 閾値が SLO 指標 (prod-slo.md) と整合

### 領域 4: prod-slo.md (initial draft SLO + incident response)
- [ ] 冒頭に **Initial draft** + Phase 5 real traffic 再校正注記
- [ ] SLO 指標 3 軸 (可用性 / 5xx / AI 失敗率) + incident response P0/P1/P2 + 通知 channel mapping の 3 section
- [ ] 再校正条件 (公開後 1 ヶ月時点 / 3 ヶ月連続違反 / 3 ヶ月ゼロ) が明示

## Codex セカンドオピニオン (plan モード) High 指摘 反映状況

| H 指摘 | 反映 |
|---|---|
| H #2: ADR-0003 補強位置付け | ✅ ADR-0003 冒頭 boilerplate 明記 |
| H #3: Firestore データ rollback 設計を prod-pitr.md で完結、ADR-0002 本体は本 Phase で変更しない | ✅ prod-pitr.md §ADR-0002 rollback 4 段階拡張案 で起草、本体反映は段階 2 後 |
| H #8: Phase 5 GO チェック section | ✅ phase4-tasks.md (PR α) で完了、本 PR では参照 link のみ |

## AC 検証 (PR β 範囲)

- ✅ AC-P4-2: ADR-0003 に Context/Decision/Consequences + ADR-0002 補強位置付け
- ✅ AC-P4-3: prod-pitr.md に 4 section
- ✅ AC-P4-4: prod-monitoring.md に 3 section + future work 明示
- ✅ AC-P4-5: prod-slo.md に 3 section + initial draft 注記
- ✅ AC-P4-7: \`npm run lint\` PASS + \`npm run test\` PASS (836/836)
- ✅ AC-P4-11: ADR-0003 冒頭に「without superseding ADR-0002」明記

AC-P4-1 / P4-6 / P4-10 は PR α で検証済。AC-P4-8 / P4-9 は段階 2 (別 PR、本 Phase 対象外、番号単位認可必須) で検証。

## Phase 4 完了状況 (本 PR merge 後)

- ✅ 段階 1 (起草) 完了: phase4-tasks.md + ADR-0003 + 3 runbook
- ⏳ 段階 2 (実機構築) 未着手: PITR 有効化 / Logging dashboard / alerting policy
- ⏳ 段階 3 (SLO Accepted 化) 未着手: Phase 5 real traffic + 1 ヶ月後

Phase 5 (公開実行) GO は phase4-tasks.md §Phase 5 GO チェック GO-1〜GO-6 全充足 + 本田様明示 GO 待ち。

## Test plan

- [x] \`npm run lint\` PASS (tsc エラー 0)
- [x] \`npm run test\` PASS (836/836)
- [x] AC-P4-2〜5 / P4-7 / P4-11 grep ベースで検証 PASS
- [ ] doc レビュー (本田様の目視確認、4 領域 reviewer checklist)

設定/ドキュメントのみの PR のため、構文検証 + 次セッション参照可能性で完了とする (CLAUDE.md Definition of Done §3 該当)。

## NG リスト (本 PR に含めない)

- PITR / Logging 実機有効化 (段階 2 で別 PR、番号単位認可必須)
- ADR-0002 本体修正 (rollback 3→4 段階拡張は prod-pitr.md に拡張案として留め、本体反映は段階 2 後)
- SLO Accepted 化 (段階 3 で別 PR、Phase 5 real traffic + 1 ヶ月後)
- 公開告知 traffic 切替 (Phase 5)
- 法務文書 (規約 3 文書) の AI 単独修正

詳細は phase4-tasks.md §Phase 4 スコープ外 参照。

🤖 Generated with [Claude Code](https://claude.com/claude-code)