### PR TITLE
docs(runbook): fix prod-pitr.md PITR drill bash (macOS BSD date + DEST_DB 変数保持)

### DIFF
--- a/docs/runbook/prod-pitr.md
+++ b/docs/runbook/prod-pitr.md
@@ -95,6 +95,8 @@ PITR 有効化だけで復旧できる保証はない。本番インシデント
 
 ### 演習手順 (dev で実施、本番影響なし)
 
+> **注**: 本手順は **同一 shell session** で順次実行する前提。途中で shell を閉じると `DEST_DB` 変数が失われ Step 7 で削除対象が特定できなくなる。新 shell で再開する場合は Step 4 で表示される `DEST_DB` の値をメモして、Step 7 で `DEST_DB=<メモした値>` を再 export してから実行する。
+
 ```bash
 # 1. dev で PITR 有効化 (まだ未有効なら)
 gcloud firestore databases update \
@@ -106,25 +108,39 @@ gcloud firestore databases update \
 #    → IndexedDB に保存 → 通常使用
 
 # 3. 5-10 分待機後、現在時刻を snapshot 候補時刻として記録
-SNAPSHOT_TIME=$(date -u -d '5 minutes ago' +%Y-%m-%dT%H:%M:%SZ)
+#    macOS (BSD date) と Linux (GNU date) で構文が異なるため両対応:
+if date -u -v-5M +%Y-%m-%dT%H:%M:%SZ >/dev/null 2>&1; then
+  # macOS (BSD date)
+  SNAPSHOT_TIME=$(date -u -v-5M +%Y-%m-%dT%H:%M:%SZ)
+else
+  # Linux (GNU date、Cloud Shell 等)
+  SNAPSHOT_TIME=$(date -u -d '5 minutes ago' +%Y-%m-%dT%H:%M:%SZ)
+fi
 echo "Snapshot time: $SNAPSHOT_TIME"
 
-# 4. テストデータを (敢えて) 破壊
+# 4. 演習用 destination database 名を変数保持 (Step 5 / Step 7 共通参照)
+export DEST_DB="drill-restore-$(date +%s)"
+echo "Destination database: $DEST_DB"
+# 注: 同一 shell session で Step 5 / Step 7 まで実行すること。
+#     shell を閉じて再開する場合は上記 echo の値をメモし、
+#     Step 7 実行前に `export DEST_DB=<メモした値>` で再注入する。
+
+# 5. テストデータを (敢えて) 破壊
 #    → Firebase Console で users/<dev uid> ドキュメントを手動削除
 #    → アプリでログイン → users/init で初期化 (旧データ消失確認)
 
-# 5. PITR restore (新規 database 作成)
+# 6. PITR restore (Step 4 で保持した DEST_DB に新規 database 作成)
 gcloud firestore databases restore \
   --source-database=projects/novel-writer-dev/databases/'(default)' \
-  --destination-database=drill-restore-$(date +%s) \
-  --snapshot-time=$SNAPSHOT_TIME \
+  --destination-database="$DEST_DB" \
+  --snapshot-time="$SNAPSHOT_TIME" \
   --project=novel-writer-dev
 
-# 6. 復旧 database の検証 (Firebase Console で確認)
+# 7. 復旧 database の検証 (Firebase Console で確認)
 #    → 破壊前のドキュメントが存在することを確認
 
-# 7. 演習完了後、復旧用 database を削除 (コスト最小化)
-gcloud firestore databases delete drill-restore-<timestamp> \
+# 8. 演習完了後、復旧用 database を削除 (コスト最小化)
+gcloud firestore databases delete "$DEST_DB" \
   --project=novel-writer-dev
 ```
 


### PR DESCRIPTION
## Summary

PR β ([#202](https://github.com/Yukina1116/novel-writer/pull/202)) の code-review (low effort, doc target) で flag された 2 件の bash バグ修正。

### 修正 1: macOS / Linux 両対応の date コマンド

**旧** (`prod-pitr.md:97`):
\`\`\`bash
SNAPSHOT_TIME=\$(date -u -d '5 minutes ago' +%Y-%m-%dT%H:%M:%SZ)
\`\`\`

- GNU date 専用の \`-d '5 minutes ago'\` を使用
- 本田様の owner 環境は macOS (BSD date) → \`date: illegal option -- d\` エラー
- → \`SNAPSHOT_TIME\` が空 → \`gcloud restore --snapshot-time=\` が空引数で失敗

**新**:
\`\`\`bash
if date -u -v-5M +%Y-%m-%dT%H:%M:%SZ >/dev/null 2>&1; then
  # macOS (BSD date)
  SNAPSHOT_TIME=\$(date -u -v-5M +%Y-%m-%dT%H:%M:%SZ)
else
  # Linux (GNU date、Cloud Shell 等)
  SNAPSHOT_TIME=\$(date -u -d '5 minutes ago' +%Y-%m-%dT%H:%M:%SZ)
fi
\`\`\`

### 修正 2: DEST_DB 変数保持で Step 5 / Step 7 整合

**旧** (`prod-pitr.md:104`):
- Step 5: \`--destination-database=drill-restore-\$(date +%s)\` (動的)
- Step 7: \`gcloud firestore databases delete drill-restore-<timestamp>\` (静的プレースホルダ)
- → Step 5 と Step 7 が独立 shell コマンドで \`\$(date +%s)\` の値が変わる → Step 7 で削除対象が特定できない

**新**:
- 新規 Step 4 で \`export DEST_DB="drill-restore-\$(date +%s)"\` を実行
- Step 6 (元 Step 5) / Step 8 (元 Step 7) の両方で \`"\$DEST_DB"\` を参照
- 同一 shell session 前提 + shell 切替時の再 export 手順を冒頭注記

## 影響範囲

- doc only、コード変更なし
- Step 番号がずれた (旧 5/7 → 新 6/8)、新規 Step 4 (DEST_DB export) 挿入
- ADR-0003 / phase4-tasks.md / 他 runbook への影響なし (相互 link で参照する section 名は変更なし)

## Test plan

- [x] \`npm run lint\` PASS (tsc エラー 0)
- [x] \`npm run test\` PASS (836/836)
- [x] bash 構文目視確認 + 両 OS 対応 if 分岐ロジック確認
- [ ] 段階 2 PITR 実機有効化時の演習で実走 (本 PR merge 後、別セッション・別 PR で実施)

設定/ドキュメントのみの PR のため、構文検証 + 段階 2 演習での実走で完了とする (CLAUDE.md Definition of Done §3 該当)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)