### PR TITLE
feat(workflows): add Firestore PITR drill + enable workflows (Phase 4 stage 2 GO-3)

### DIFF
--- a/.github/workflows/dev-pitr-drill.yml
+++ b/.github/workflows/dev-pitr-drill.yml
@@ -1,0 +1,116 @@
+name: dev PITR drill
+
+# Phase 4 段階 2 GO-3: dev で Firestore PITR 復旧演習を実走
+# 隔離 collection `pitr-drill/test-doc-1` のみ操作、本番データには触れない
+# workflow_dispatch only (誤起動防止)
+# 参考: docs/runbook/prod-pitr.md §復旧演習、docs/adr/0003-public-launch-operations.md §Decision 1
+
+on:
+  workflow_dispatch:
+
+env:
+  PROJECT_ID: novel-writer-dev
+  PROJECT_NUMBER: '446321146441'
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  drill:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - id: auth
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: projects/446321146441/locations/global/workloadIdentityPools/github-pool/providers/github-provider
+          service_account: github-deploy@novel-writer-dev.iam.gserviceaccount.com
+
+      - uses: google-github-actions/setup-gcloud@v3
+
+      - name: Pre-check PITR state
+        run: |
+          gcloud firestore databases describe \
+            --database='(default)' \
+            --project="$PROJECT_ID" \
+            --format='value(pointInTimeRecoveryEnablement,earliestVersionTime,versionRetentionPeriod)'
+
+      - name: Enable PITR (idempotent — no-op if already enabled)
+        run: |
+          gcloud firestore databases update \
+            --database='(default)' \
+            --project="$PROJECT_ID" \
+            --enable-pitr
+
+      - name: Create test doc
+        env:
+          GCLOUD_PROJECT: ${{ env.PROJECT_ID }}
+        run: npx tsx scripts/pitr-drill.ts create
+
+      - name: Wait 60s + record SNAPSHOT_TIME
+        id: snapshot
+        run: |
+          # 60 秒待機: snapshot 時刻が確実に「create 完了後」になるよう余裕を持たせる
+          sleep 60
+          # GNU date (ubuntu-latest): 30 秒前を snapshot として記録
+          SNAPSHOT_TIME=$(date -u -d '-30 seconds' +%Y-%m-%dT%H:%M:%SZ)
+          echo "snapshot_time=$SNAPSHOT_TIME" >> "$GITHUB_OUTPUT"
+          echo "Recorded SNAPSHOT_TIME: $SNAPSHOT_TIME"
+
+      - name: Delete test doc (destroy)
+        env:
+          GCLOUD_PROJECT: ${{ env.PROJECT_ID }}
+        run: npx tsx scripts/pitr-drill.ts delete
+
+      - name: PITR restore to new database
+        id: restore
+        run: |
+          DEST_DB="drill-restore-$(date +%s)"
+          echo "dest_db=$DEST_DB" >> "$GITHUB_OUTPUT"
+          gcloud firestore databases restore \
+            --source-database="projects/$PROJECT_ID/databases/(default)" \
+            --destination-database="$DEST_DB" \
+            --snapshot-time="${{ steps.snapshot.outputs.snapshot_time }}" \
+            --project="$PROJECT_ID"
+          echo "Restored to: $DEST_DB"
+
+      - name: Verify restored doc (must EXIST in restored db)
+        env:
+          GCLOUD_PROJECT: ${{ env.PROJECT_ID }}
+        run: npx tsx scripts/pitr-drill.ts verify "${{ steps.restore.outputs.dest_db }}"
+
+      - name: Cleanup restored database
+        if: always()
+        run: |
+          DEST_DB="${{ steps.restore.outputs.dest_db }}"
+          if [ -n "$DEST_DB" ]; then
+            gcloud firestore databases delete "$DEST_DB" \
+              --project="$PROJECT_ID" \
+              --quiet
+            echo "Cleaned up: $DEST_DB"
+          fi
+
+      - name: Post-check PITR state
+        run: |
+          gcloud firestore databases describe \
+            --database='(default)' \
+            --project="$PROJECT_ID" \
+            --format='value(pointInTimeRecoveryEnablement,earliestVersionTime,versionRetentionPeriod)'
+
+      - name: Cleanup any leftover test docs in (default)
+        if: always()
+        env:
+          GCLOUD_PROJECT: ${{ env.PROJECT_ID }}
+        run: |
+          # 演習で create したが delete されずに残った doc を念のため削除 (best-effort)
+          npx tsx scripts/pitr-drill.ts delete 2>/dev/null || true

--- a/.github/workflows/prod-pitr-enable.yml
+++ b/.github/workflows/prod-pitr-enable.yml
@@ -1,0 +1,66 @@
+name: prod PITR enable
+
+# Phase 4 段階 2 GO-3: prod Firestore PITR を有効化
+# workflow_dispatch only、本田様番号単位明示認可必須
+# 復旧演習は dev-pitr-drill.yml で別途実施 (prod では実演習しない、本番影響回避)
+# 参考: docs/runbook/prod-pitr.md §有効化手順、docs/adr/0003-public-launch-operations.md §Decision 1
+
+on:
+  workflow_dispatch:
+
+env:
+  PROJECT_ID: novel-writer-prod
+  PROJECT_NUMBER: '1026420855688'
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  enable:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+
+      - id: auth
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: projects/1026420855688/locations/global/workloadIdentityPools/github-pool/providers/github-provider
+          service_account: github-deploy@novel-writer-prod.iam.gserviceaccount.com
+
+      - uses: google-github-actions/setup-gcloud@v3
+
+      - name: Pre-check PITR state
+        run: |
+          gcloud firestore databases describe \
+            --database='(default)' \
+            --project="$PROJECT_ID" \
+            --format='value(pointInTimeRecoveryEnablement,earliestVersionTime,versionRetentionPeriod)'
+
+      - name: Enable PITR
+        run: |
+          gcloud firestore databases update \
+            --database='(default)' \
+            --project="$PROJECT_ID" \
+            --enable-pitr
+
+      - name: Post-check PITR state (must be POINT_IN_TIME_RECOVERY_ENABLED)
+        run: |
+          STATE=$(gcloud firestore databases describe \
+            --database='(default)' \
+            --project="$PROJECT_ID" \
+            --format='value(pointInTimeRecoveryEnablement)')
+          echo "PITR state: $STATE"
+          if [ "$STATE" != "POINT_IN_TIME_RECOVERY_ENABLED" ]; then
+            echo "ERROR: Expected POINT_IN_TIME_RECOVERY_ENABLED, got $STATE"
+            exit 1
+          fi
+          echo "OK: prod PITR is now ENABLED"
+
+      - name: Record retention period
+        run: |
+          gcloud firestore databases describe \
+            --database='(default)' \
+            --project="$PROJECT_ID" \
+            --format='value(versionRetentionPeriod,earliestVersionTime,updateTime)'

--- a/scripts/pitr-drill.ts
+++ b/scripts/pitr-drill.ts
@@ -1,0 +1,58 @@
+#!/usr/bin/env tsx
+// Phase 4 段階 2 GO-3: Firestore PITR 復旧演習用 CRUD script
+// 隔離 collection `pitr-drill/test-doc-1` のみを扱う。本番データには触れない。
+// 用途: .github/workflows/dev-pitr-drill.yml から呼ばれる。
+// usage: tsx scripts/pitr-drill.ts {create|delete|verify} [restore-db-name]
+
+import { initializeApp, getApps, applicationDefault } from 'firebase-admin/app'
+import { getFirestore } from 'firebase-admin/firestore'
+
+const PROJECT_ID = process.env.GCLOUD_PROJECT
+if (!PROJECT_ID) {
+  console.error('GCLOUD_PROJECT env var is required')
+  process.exit(1)
+}
+
+const COLLECTION = 'pitr-drill'
+const DOC_ID = 'test-doc-1'
+
+if (!getApps().length) {
+  initializeApp({ credential: applicationDefault(), projectId: PROJECT_ID })
+}
+
+const action = process.argv[2]
+const restoreDb = process.argv[3]
+
+const db = restoreDb ? getFirestore(restoreDb) : getFirestore()
+
+async function main() {
+  if (action === 'create') {
+    await db.collection(COLLECTION).doc(DOC_ID).set({
+      label: 'PITR drill test data',
+      createdAt: new Date().toISOString(),
+      session: 'phase4-stage2-go-3-evidence',
+    })
+    console.log(`Created ${COLLECTION}/${DOC_ID} in (default) database of ${PROJECT_ID}`)
+  } else if (action === 'delete') {
+    await db.collection(COLLECTION).doc(DOC_ID).delete()
+    console.log(`Deleted ${COLLECTION}/${DOC_ID} from (default) database of ${PROJECT_ID}`)
+  } else if (action === 'verify') {
+    const doc = await db.collection(COLLECTION).doc(DOC_ID).get()
+    const dbLabel = restoreDb || '(default)'
+    if (doc.exists) {
+      console.log(`OK: Doc EXISTS in ${dbLabel}: ${COLLECTION}/${DOC_ID}`)
+      console.log('  Data:', JSON.stringify(doc.data(), null, 2))
+    } else {
+      console.error(`NG: Doc does NOT exist in ${dbLabel}: ${COLLECTION}/${DOC_ID}`)
+      process.exit(2)
+    }
+  } else {
+    console.error('Usage: tsx scripts/pitr-drill.ts {create|delete|verify} [restore-db-name]')
+    process.exit(1)
+  }
+}
+
+main().catch(e => {
+  console.error(e)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary

Phase 4 段階 2 GO-3 (Firestore PITR 有効化 + dev 復旧演習) の実機構築 workflow + script を追加。
本 PR は workflow 設置のみで、実機構築 (`workflow_dispatch` 起動) は本 PR merge 後に別タイミングで実行。

- **`.github/workflows/dev-pitr-drill.yml`**: dev で復旧演習 (create → snapshot → delete → restore → verify → cleanup)
- **`.github/workflows/prod-pitr-enable.yml`**: prod PITR 有効化のみ (演習は dev で完結、本番影響回避)
- **`scripts/pitr-drill.ts`**: 隔離 collection `pitr-drill/test-doc-1` への create/delete/verify CRUD

コード変更は workflow + 1 script の追加のみ、既存挙動への影響なし。

## 設計の根拠 (memory 由来)

- `feedback_firestore_prod_admin_via_workflow.md`: 本番 Firestore admin は CI workflow + SA impersonation で実施、ローカル `node -e` 直結は禁止
- `reference_destructive_admin_workflow_pattern.md`: WIF cred + inputs env 経由 + idempotent な enable コマンド
- Phase 1 で構築した WIF Pool (`github-pool/github-provider`) を流用、新規 SA 作成なし
- Phase 3 ADR-0002 § rollback 段階 + PR γ #203 で修正した bash pattern (DEST_DB 変数保持) を踏襲

## ⚠️ 本 PR merge 後の必須前提作業 (本田様実行)

dev / prod の `github-deploy` SA に Firestore admin 権限がない。workflow run の前に以下を実行:

\`\`\`bash
# dev
gcloud projects add-iam-policy-binding novel-writer-dev \\
  --member=serviceAccount:github-deploy@novel-writer-dev.iam.gserviceaccount.com \\
  --role=roles/datastore.owner

# prod
gcloud projects add-iam-policy-binding novel-writer-prod \\
  --member=serviceAccount:github-deploy@novel-writer-prod.iam.gserviceaccount.com \\
  --role=roles/datastore.owner
\`\`\`

### 現状の github-deploy SA roles (dev で確認済)

\`roles/artifactregistry.writer\` + \`roles/run.admin\` のみ。Firestore admin 系権限なし。

### 付与する \`roles/datastore.owner\` の権限範囲

- Firestore database describe / update (\`--enable-pitr\`)
- Firestore database restore (PITR 復旧)
- Firestore document read / write (drill 演習用)
- Firestore database delete (演習用復旧 database の cleanup)

### IAM 変更を AI ではなく本田様にお願いする理由

- 現在 AI の ADC identity は別アカウント (\`yasushi.honda@aozora-cg.com\`)、novel-writer-dev / prod に owner 権限なし
- IAM 変更は destructive、CLAUDE.md 4 原則 §3 で番号単位明示認可 + decision-maker 領分

## 本 PR merge 後の手順 (時系列)

1. 本田様が **上記 IAM 変更を gcloud で実行** (dev / prod 両方)
2. AI が \`gh workflow run dev-pitr-drill.yml --ref main\` を起動 (本田様明示認可必要)
3. dev 演習 PASS を確認 (workflow log)
4. AI が \`gh workflow run prod-pitr-enable.yml --ref main\` を起動 (本田様番号単位明示認可必要、prod 操作)
5. 別 PR で runbook \`prod-pitr.md\` 証跡 table に追記

## 設計の決定事項

| 観点 | 採用 | 理由 |
|---|---|---|
| 演習を dev のみで実施 | ✅ | prod では実演習しない、本番データへの影響回避 |
| github-deploy SA 流用 | ✅ | Phase 1 で構築した WIF を再利用、新 SA 不要 |
| \`roles/datastore.owner\` | ✅ | PITR enable + restore + database delete + doc CRUD すべて含む |
| dev workflow に \`enable-pitr\` step | ✅ | idempotent (既に enabled なら no-op)、初回 dev 演習で同時に有効化可能 |
| 隔離 collection \`pitr-drill/test-doc-1\` | ✅ | 本田様データ (\`users/*\` / \`projects/*\`) と完全隔離 |
| restore database 名 \`drill-restore-<timestamp>\` | ✅ | PR γ #203 で確立した命名規約 |
| \`if: always()\` で cleanup | ✅ | 途中 fail でも restored db が残らない |

## Test plan

- [x] \`npm run lint\` PASS (tsc エラー 0)
- [x] \`npm run test\` PASS (836/836)
- [x] workflow yaml syntax 目視確認
- [ ] dev workflow 実走 (本田様 IAM 変更 + 明示認可後)
- [ ] prod workflow 実走 (本田様番号単位明示認可後)
- [ ] 証跡を runbook prod-pitr.md に追記する別 PR (本 PR merge 後)

## NG リスト (本 PR に含めない)

- IAM 変更の自動化 (decision-maker 領分、本田様手動)
- workflow_dispatch 起動 (本 PR merge 後の別タイミング、番号単位認可必須)
- 本田様データ (\`users/*\` / \`projects/*\`) への一切の操作
- 証跡追記 (別 PR で workflow log を反映)
- runtime SA (\`novel-writer-run\`) の権限変更
- 新規 SA 作成

🤖 Generated with [Claude Code](https://claude.com/claude-code)