### PR TITLE
fix(prod-pitr): wait for clone-LRO completion before verify

### DIFF
--- a/.github/workflows/dev-pitr-drill.yml
+++ b/.github/workflows/dev-pitr-drill.yml
@@ -88,6 +88,14 @@ jobs:
             --project="$PROJECT_ID"
           echo "Cloned to: $DEST_DB"
 
+      - name: Wait for cloned database to be READY (clone is LRO)
+        # gcloud firestore databases clone は LRO (Long-Running Operation)。
+        # コマンド return 後も database が restoring 状態のため、
+        # FAILED_PRECONDITION (code 9) が返らなくなるまで poll する。
+        env:
+          GCLOUD_PROJECT: ${{ env.PROJECT_ID }}
+        run: npx tsx scripts/pitr-drill.ts wait-ready "${{ steps.clone.outputs.dest_db }}"
+
       - name: Verify cloned doc (must EXIST in cloned db)
         env:
           GCLOUD_PROJECT: ${{ env.PROJECT_ID }}

--- a/scripts/pitr-drill.ts
+++ b/scripts/pitr-drill.ts
@@ -36,6 +36,30 @@ async function main() {
   } else if (action === 'delete') {
     await db.collection(COLLECTION).doc(DOC_ID).delete()
     console.log(`Deleted ${COLLECTION}/${DOC_ID} from (default) database of ${PROJECT_ID}`)
+  } else if (action === 'wait-ready') {
+    // gcloud firestore databases clone は LRO で、コマンド return 後も
+    // database が restoring 状態のことがある (FAILED_PRECONDITION エラー)。
+    // ready になるまで poll する。
+    const dbLabel = restoreDb || '(default)'
+    const maxAttempts = 60
+    const intervalMs = 10_000
+    for (let i = 0; i < maxAttempts; i++) {
+      try {
+        await db.collection(COLLECTION).limit(1).get()
+        console.log(`OK: Database ${dbLabel} is READY (attempt ${i + 1})`)
+        return
+      } catch (e: unknown) {
+        const code = (e as { code?: number }).code
+        if (code === 9 /* FAILED_PRECONDITION = restoring */) {
+          console.log(`Attempt ${i + 1}/${maxAttempts}: not ready yet, waiting ${intervalMs / 1000}s...`)
+          await new Promise(r => setTimeout(r, intervalMs))
+          continue
+        }
+        throw e
+      }
+    }
+    console.error(`NG: Timeout waiting for ${dbLabel} to become READY (${maxAttempts * intervalMs / 1000}s)`)
+    process.exit(2)
   } else if (action === 'verify') {
     const doc = await db.collection(COLLECTION).doc(DOC_ID).get()
     const dbLabel = restoreDb || '(default)'
@@ -47,7 +71,7 @@ async function main() {
       process.exit(2)
     }
   } else {
-    console.error('Usage: tsx scripts/pitr-drill.ts {create|delete|verify} [restore-db-name]')
+    console.error('Usage: tsx scripts/pitr-drill.ts {create|delete|wait-ready|verify} [restore-db-name]')
     process.exit(1)
   }
 }


### PR DESCRIPTION
## Summary

PR #205 で gcloud コマンドを clone に修正したが、dev-pitr-drill run [#27874472054](https://github.com/Yukina1116/novel-writer/actions/runs/27874472054) で再 fail。
clone は **LRO (Long-Running Operation)** で、コマンド return 後も destination database が \"restoring\" 状態のため直後の read で FAILED_PRECONDITION (code 9) が返る。

## 失敗ログ

\`\`\`
Error: 9 FAILED_PRECONDITION: Cannot serve requests when the database is undergoing a restore.
\`\`\`

## 修正

| ファイル | 変更 |
|---|---|
| \`scripts/pitr-drill.ts\` | \`wait-ready\` action 追加 (FAILED_PRECONDITION を polling、最大 60 回 × 10s = 10 分タイムアウト、ready 判定は \`collection().limit(1).get()\` の成否) |
| \`.github/workflows/dev-pitr-drill.yml\` | \"Wait for cloned database to be READY\" step を verify 前に挿入 |

## 反省

PR #205 で clone コマンド名は修正したが、clone が LRO であることを確認せず verify を直後に置いた。Firebase Admin SDK のエラーコード (9 = FAILED_PRECONDITION) で発覚。今後 GCP の database 系操作は同期/非同期と state transition を ground truth で確認する。

runbook \`prod-pitr.md\` の手動演習手順への wait section 追加は本 PR には含めず、**workflow PASS 後の証跡追記 PR で同梱**する (PR を最小に保つため)。

## Test plan

- [x] \`npm run lint\` PASS (tsc エラー 0)
- [x] \`npm run test\` PASS (836/836)
- [ ] 本 PR merge 後、\`gh workflow run dev-pitr-drill.yml --ref main\` を再 run して PASS 確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)