### PR TITLE
feat(monitoring): add prod monitoring YAML + setup workflow (Phase 4 stage 2 GO-4)

### DIFF
--- a/.github/workflows/prod-monitoring-setup.yml
+++ b/.github/workflows/prod-monitoring-setup.yml
@@ -1,0 +1,169 @@
+name: prod monitoring setup
+
+# Phase 4 段階 2 GO-4: prod Cloud Monitoring 構築
+# - email notification channel 作成
+# - 5 alerting policy (A1-A5) 作成
+# - dashboard 作成 (8 widget)
+# workflow_dispatch only (誤起動防止)
+# 参考: docs/runbook/prod-monitoring.md、docs/adr/0003-public-launch-operations.md §Decision 2
+#
+# 必須前提作業 (本田様実行、本 PR merge 後・workflow run 前):
+#   gcloud projects add-iam-policy-binding novel-writer-prod \
+#     --member=serviceAccount:github-deploy@novel-writer-prod.iam.gserviceaccount.com \
+#     --role=roles/monitoring.editor
+#
+# 既知の制約:
+#   - alerting policy の filter は絶対 rate (件/秒) で起草、ratio (X%) は段階 2/3 で MQL refactor
+#   - W7 (Vertex AI quota) / W8 (usage reserve-commit-cancel) は placeholder filter、段階 2/3 で実際の metric/log-based metric に refactor
+
+on:
+  workflow_dispatch:
+    inputs:
+      email_address:
+        description: 'Email address to receive alerts (e.g. owner@example.com)'
+        required: true
+        type: string
+
+env:
+  PROJECT_ID: novel-writer-prod
+  PROJECT_NUMBER: '1026420855688'
+  CHANNEL_DISPLAY_NAME: prod-email-channel
+  DASHBOARD_DISPLAY_NAME: 'novel-writer-prod 監視'
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v5
+
+      - id: auth
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: projects/1026420855688/locations/global/workloadIdentityPools/github-pool/providers/github-provider
+          service_account: github-deploy@novel-writer-prod.iam.gserviceaccount.com
+
+      - uses: google-github-actions/setup-gcloud@v3
+
+      - name: Pre-check IAM (require roles/monitoring.editor)
+        run: |
+          # github-deploy SA に roles/monitoring.editor が付与されているか確認
+          # 不足していたら明示エラー (本田様の IAM 変更 step が抜けていないか chk)
+          ROLES=$(gcloud projects get-iam-policy "$PROJECT_ID" \
+            --flatten=bindings \
+            --format='value(bindings.role)' \
+            --filter='bindings.members:github-deploy@novel-writer-prod.iam.gserviceaccount.com')
+          echo "Current roles for github-deploy SA:"
+          echo "$ROLES"
+          if ! echo "$ROLES" | grep -q 'roles/monitoring.editor'; then
+            echo ""
+            echo "ERROR: github-deploy@novel-writer-prod に roles/monitoring.editor が付与されていません。"
+            echo "本田様に以下のコマンドを実行いただいてから再 run してください:"
+            echo "  gcloud projects add-iam-policy-binding novel-writer-prod \\"
+            echo "    --member=serviceAccount:github-deploy@novel-writer-prod.iam.gserviceaccount.com \\"
+            echo "    --role=roles/monitoring.editor"
+            exit 1
+          fi
+          echo "OK: roles/monitoring.editor 確認済"
+
+      - name: Create or get email notification channel
+        id: channel
+        run: |
+          # idempotent: 既存 channel があれば ID 取得、なければ作成
+          EMAIL='${{ inputs.email_address }}'
+          CHANNEL_ID=$(gcloud monitoring channels list \
+            --filter="displayName=\"$CHANNEL_DISPLAY_NAME\"" \
+            --format='value(name)' \
+            --project="$PROJECT_ID" | head -1)
+          if [ -z "$CHANNEL_ID" ]; then
+            echo "Channel not found, creating..."
+            CHANNEL_ID=$(gcloud monitoring channels create \
+              --display-name="$CHANNEL_DISPLAY_NAME" \
+              --type=email \
+              --channel-labels="email_address=$EMAIL" \
+              --project="$PROJECT_ID" \
+              --format='value(name)')
+            echo "Created channel: $CHANNEL_ID"
+          else
+            echo "Existing channel found: $CHANNEL_ID"
+            # email_address が変わっている可能性、update
+            gcloud monitoring channels update "$CHANNEL_ID" \
+              --update-channel-labels="email_address=$EMAIL" \
+              --project="$PROJECT_ID"
+            echo "Updated channel email_address to: $EMAIL"
+          fi
+          echo "channel_id=$CHANNEL_ID" >> "$GITHUB_OUTPUT"
+
+      - name: Create or replace alerting policies (A1-A5)
+        env:
+          CHANNEL_ID: ${{ steps.channel.outputs.channel_id }}
+        run: |
+          # idempotent: 既存同名 policy は delete してから create
+          for policy_file in monitoring/policies/*.yaml; do
+            display_name=$(grep '^displayName:' "$policy_file" | awk '{$1=""; print $0}' | sed 's/^ //')
+            echo "=== Processing policy: $display_name ($policy_file) ==="
+            EXISTING=$(gcloud monitoring policies list \
+              --filter="displayName=\"$display_name\"" \
+              --format='value(name)' \
+              --project="$PROJECT_ID" | head -1)
+            if [ -n "$EXISTING" ]; then
+              echo "Existing policy found, deleting: $EXISTING"
+              gcloud monitoring policies delete "$EXISTING" \
+                --quiet \
+                --project="$PROJECT_ID"
+            fi
+            gcloud monitoring policies create \
+              --policy-from-file="$policy_file" \
+              --notification-channels="$CHANNEL_ID" \
+              --project="$PROJECT_ID"
+            echo "Created: $display_name"
+          done
+
+      - name: Create or replace dashboard
+        run: |
+          # idempotent: 既存同名 dashboard は delete してから create
+          EXISTING=$(gcloud monitoring dashboards list \
+            --filter="displayName=\"$DASHBOARD_DISPLAY_NAME\"" \
+            --format='value(name)' \
+            --project="$PROJECT_ID" | head -1)
+          if [ -n "$EXISTING" ]; then
+            echo "Existing dashboard found, deleting: $EXISTING"
+            gcloud monitoring dashboards delete "$EXISTING" \
+              --quiet \
+              --project="$PROJECT_ID"
+          fi
+          gcloud monitoring dashboards create \
+            --config-from-file=monitoring/dashboard.yaml \
+            --project="$PROJECT_ID"
+          echo "Created dashboard: $DASHBOARD_DISPLAY_NAME"
+
+      - name: Verify created resources
+        run: |
+          echo "=== Notification channels ==="
+          gcloud monitoring channels list \
+            --filter="displayName=\"$CHANNEL_DISPLAY_NAME\"" \
+            --format='table(name,displayName,type,labels.email_address)' \
+            --project="$PROJECT_ID"
+          echo ""
+          echo "=== Alerting policies ==="
+          gcloud monitoring policies list \
+            --format='table(displayName,enabled)' \
+            --project="$PROJECT_ID"
+          echo ""
+          echo "=== Dashboards ==="
+          gcloud monitoring dashboards list \
+            --filter="displayName=\"$DASHBOARD_DISPLAY_NAME\"" \
+            --format='table(name,displayName)' \
+            --project="$PROJECT_ID"
+          echo ""
+          echo "==========================================="
+          echo "Setup completed. Dashboard URL:"
+          DASH_ID=$(gcloud monitoring dashboards list \
+            --filter="displayName=\"$DASHBOARD_DISPLAY_NAME\"" \
+            --format='value(name)' \
+            --project="$PROJECT_ID" | head -1 | awk -F'/' '{print $NF}')
+          echo "  https://console.cloud.google.com/monitoring/dashboards/builder/$DASH_ID?project=$PROJECT_ID"

--- a/monitoring/dashboard.yaml
+++ b/monitoring/dashboard.yaml
@@ -1,0 +1,188 @@
+# Phase 4 段階 2 GO-4: prod Cloud Monitoring Dashboard
+# 8 widget (W1-W8) で prod 監視全体像を 1 画面に集約
+# 起草: docs/runbook/prod-monitoring.md §dashboard 構成
+# Format reference: https://cloud.google.com/monitoring/api/ref_v3/rest/v1/projects.dashboards
+#
+# 実装メモ:
+# - mosaicLayout (12 列グリッド) を採用
+# - W7 (Vertex AI quota) / W8 (usage reserve-commit-cancel) は log-based metric が必要、
+#   PR α では placeholder filter (5xx 系で代替) で起草、段階 2/3 で正確な metric に refactor
+# - widget サイズは 6 columns × 4 rows (line chart) / 3 × 3 (scorecard) を基本に
+displayName: novel-writer-prod 監視
+mosaicLayout:
+  columns: 12
+  tiles:
+    # W1: /api/* request rate (1 分粒度、24h、line chart)
+    - width: 6
+      height: 4
+      xPos: 0
+      yPos: 0
+      widget:
+        title: W1 / /api/* request rate
+        xyChart:
+          dataSets:
+            - timeSeriesQuery:
+                timeSeriesFilter:
+                  filter: 'metric.type="run.googleapis.com/request_count" resource.type="cloud_run_revision" resource.label."service_name"="novel-writer"'
+                  aggregation:
+                    alignmentPeriod: 60s
+                    perSeriesAligner: ALIGN_RATE
+                    crossSeriesReducer: REDUCE_SUM
+              plotType: LINE
+          timeshiftDuration: 0s
+          yAxis:
+            label: req/sec
+            scale: LINEAR
+
+    # W2: 5xx error rate (5 分粒度、24h、line chart)
+    - width: 6
+      height: 4
+      xPos: 6
+      yPos: 0
+      widget:
+        title: W2 / 5xx error rate (A1 alerting source)
+        xyChart:
+          dataSets:
+            - timeSeriesQuery:
+                timeSeriesFilter:
+                  filter: 'metric.type="run.googleapis.com/request_count" resource.type="cloud_run_revision" metric.label."response_code_class"="5xx" resource.label."service_name"="novel-writer"'
+                  aggregation:
+                    alignmentPeriod: 300s
+                    perSeriesAligner: ALIGN_RATE
+                    crossSeriesReducer: REDUCE_SUM
+              plotType: LINE
+          timeshiftDuration: 0s
+          yAxis:
+            label: 5xx/sec
+            scale: LINEAR
+
+    # W3: auth fail rate (401 rate) (line chart)
+    - width: 6
+      height: 4
+      xPos: 0
+      yPos: 4
+      widget:
+        title: W3 / auth fail rate (401, A2 alerting source)
+        xyChart:
+          dataSets:
+            - timeSeriesQuery:
+                timeSeriesFilter:
+                  filter: 'metric.type="run.googleapis.com/request_count" resource.type="cloud_run_revision" metric.label."response_code"="401" resource.label."service_name"="novel-writer"'
+                  aggregation:
+                    alignmentPeriod: 300s
+                    perSeriesAligner: ALIGN_RATE
+                    crossSeriesReducer: REDUCE_SUM
+              plotType: LINE
+          timeshiftDuration: 0s
+          yAxis:
+            label: 401/sec
+            scale: LINEAR
+
+    # W4: Vertex AI 429/503/504 rate (line chart、A3 alerting source)
+    - width: 6
+      height: 4
+      xPos: 6
+      yPos: 4
+      widget:
+        title: W4 / Vertex AI 429/503/504 rate (A3 alerting source)
+        xyChart:
+          dataSets:
+            - timeSeriesQuery:
+                timeSeriesFilter:
+                  filter: 'metric.type="run.googleapis.com/request_count" resource.type="cloud_run_revision" metric.label."response_code"=monitoring.regex.full_match("(429|503|504)") resource.label."service_name"="novel-writer"'
+                  aggregation:
+                    alignmentPeriod: 300s
+                    perSeriesAligner: ALIGN_RATE
+                    crossSeriesReducer: REDUCE_SUM
+              plotType: LINE
+          timeshiftDuration: 0s
+          yAxis:
+            label: 4xx-5xx/sec
+            scale: LINEAR
+
+    # W5: Cloud Run instance count (scorecard、A4 alerting source)
+    - width: 3
+      height: 3
+      xPos: 0
+      yPos: 8
+      widget:
+        title: W5 / instance count (A4 alerting source)
+        scorecard:
+          timeSeriesQuery:
+            timeSeriesFilter:
+              filter: 'metric.type="run.googleapis.com/container/instance_count" resource.type="cloud_run_revision" resource.label."service_name"="novel-writer"'
+              aggregation:
+                alignmentPeriod: 60s
+                perSeriesAligner: ALIGN_MAX
+                crossSeriesReducer: REDUCE_MAX
+          thresholds:
+            - value: 2
+              color: RED
+
+    # W6: Firestore ERROR レベル log 件数 (scorecard、A5 alerting source)
+    - width: 3
+      height: 3
+      xPos: 3
+      yPos: 8
+      widget:
+        title: W6 / Cloud Run ERROR log count (A5 alerting source)
+        scorecard:
+          timeSeriesQuery:
+            timeSeriesFilter:
+              filter: 'metric.type="logging.googleapis.com/log_entry_count" resource.type="cloud_run_revision" metric.label."severity"="ERROR" resource.label."service_name"="novel-writer"'
+              aggregation:
+                alignmentPeriod: 300s
+                perSeriesAligner: ALIGN_COUNT
+                crossSeriesReducer: REDUCE_SUM
+          thresholds:
+            - value: 1
+              color: YELLOW
+
+    # W7: Vertex AI quota 利用率 (line chart、段階 2/3 で正確な metric に refactor 予定)
+    - width: 6
+      height: 4
+      xPos: 0
+      yPos: 11
+      widget:
+        title: 'W7 / Vertex AI quota (placeholder、段階 2/3 で gemini-2.5-flash quota metric に refactor)'
+        xyChart:
+          dataSets:
+            - timeSeriesQuery:
+                timeSeriesFilter:
+                  filter: 'metric.type="serviceruntime.googleapis.com/quota/rate/net_usage" resource.type="consumer_quota"'
+                  aggregation:
+                    alignmentPeriod: 300s
+                    perSeriesAligner: ALIGN_RATE
+                    crossSeriesReducer: REDUCE_SUM
+              plotType: LINE
+          timeshiftDuration: 0s
+          yAxis:
+            label: quota usage
+            scale: LINEAR
+
+    # W8: usage reserve/commit/cancel 比率 (placeholder、log-based metric 必要)
+    - width: 6
+      height: 4
+      xPos: 6
+      yPos: 11
+      widget:
+        title: 'W8 / usage reserve/commit/cancel (placeholder、log-based metric は段階 2/3 で追加)'
+        xyChart:
+          dataSets:
+            - timeSeriesQuery:
+                timeSeriesFilter:
+                  filter: 'metric.type="logging.googleapis.com/log_entry_count" resource.type="cloud_run_revision" resource.label."service_name"="novel-writer"'
+                  aggregation:
+                    alignmentPeriod: 300s
+                    perSeriesAligner: ALIGN_RATE
+                    crossSeriesReducer: REDUCE_SUM
+              plotType: LINE
+          timeshiftDuration: 0s
+          yAxis:
+            label: log entries/sec
+            scale: LINEAR
+
+dashboardFilters: []
+labels:
+  environment: prod
+  phase: phase4-stage2-go4

--- a/monitoring/policies/A1-prod-5xx-rate.yaml
+++ b/monitoring/policies/A1-prod-5xx-rate.yaml
@@ -1,0 +1,45 @@
+# Phase 4 段階 2 GO-4: Alerting policy A1
+# 目的: prod Cloud Run 5xx エラーが急増したら検知
+# 起草意図 (runbook prod-monitoring.md §A1): /api/* 5xx rate > 5% (5 分平均)
+# 実装メモ: Cloud Monitoring の AlertPolicy では ratio (X%) を直接表現できないため、
+#           Phase 4 段階 1 PR α (本ファイル) では 5xx の絶対 rate (件/秒) で threshold を
+#           設定する。MQL refactor は段階 2/3 で実施 (TODO)。
+#           Phase 2 smoke 結果 (60 req → 0 件 5xx) ベースで rate を保守的に設定。
+#
+# Format reference: https://cloud.google.com/monitoring/api/ref_v3/rest/v3/projects.alertPolicies
+displayName: prod-5xx-rate-high
+combiner: OR
+enabled: true
+conditions:
+  - displayName: Cloud Run 5xx rate exceeds threshold
+    conditionThreshold:
+      filter: 'metric.type="run.googleapis.com/request_count" AND resource.type="cloud_run_revision" AND metric.label."response_code_class"="5xx" AND resource.label."service_name"="novel-writer"'
+      comparison: COMPARISON_GT
+      # 5xx rate 閾値: 0.5 件/秒 = 30 件/分 = 150 件/5分
+      # Phase 2 smoke では 0 件、一般公開時の想定 DAU で再校正 (Phase 5 段階 3)
+      thresholdValue: 0.5
+      duration: 300s
+      aggregations:
+        - alignmentPeriod: 60s
+          perSeriesAligner: ALIGN_RATE
+          crossSeriesReducer: REDUCE_SUM
+      trigger:
+        count: 1
+documentation:
+  mimeType: text/markdown
+  content: |
+    # prod-5xx-rate-high (P1)
+
+    Cloud Run service `novel-writer` の 5xx エラー rate が閾値を超過。
+
+    **起草意図 (runbook prod-monitoring.md §A1)**: 5xx rate > 5% (5 分平均)
+    **現実装**: 絶対 rate (件/秒) で代用、MQL refactor は段階 2/3 で予定
+
+    ## 確認手順
+    1. dashboard W2 (5xx error rate) で時刻 + 範囲を確認
+    2. Cloud Logging で `severity>=ERROR AND resource.type=cloud_run_revision` を直近 5 分で grep
+    3. 原因が deploy 後の欠陥なら ADR-0002 §3 段階 2 (revision 切替) を検討
+
+    ## 関連 ADR / runbook
+    - ADR-0003 §Decision 2 (本 policy の規範)
+    - runbook prod-deploy-flow.md §rollback (修復手順)

--- a/monitoring/policies/A2-prod-auth-fail-rate.yaml
+++ b/monitoring/policies/A2-prod-auth-fail-rate.yaml
@@ -1,0 +1,50 @@
+# Phase 4 段階 2 GO-4: Alerting policy A2
+# 目的: 認証エラー (401) の急増を検知
+# 起草意図 (runbook prod-monitoring.md §A2): /api/* 401 rate > 50% (5 分平均)
+# 実装メモ: ratio は MQL 必須、PR α では絶対 rate (件/秒) で代用 (段階 2/3 で MQL refactor)
+#           Phase 2 で env_var_drift bug 発生時に全 token reject の事例あり、
+#           本 policy はその種の構造的 fail-open を 5 分以内に検知する設計。
+#
+# Format reference: https://cloud.google.com/monitoring/api/ref_v3/rest/v3/projects.alertPolicies
+displayName: prod-auth-fail-rate-high
+combiner: OR
+enabled: true
+conditions:
+  - displayName: Cloud Run 401 rate exceeds threshold
+    conditionThreshold:
+      filter: 'metric.type="run.googleapis.com/request_count" AND resource.type="cloud_run_revision" AND metric.label."response_code"="401" AND resource.label."service_name"="novel-writer"'
+      comparison: COMPARISON_GT
+      # 401 rate 閾値: 1.0 件/秒 = 60 件/分 = 300 件/5分
+      # 公開直後の identity 設定漏れ (Phase 1 Firebase Auth 設定漏れの教訓) を 5 分で検知
+      thresholdValue: 1.0
+      duration: 300s
+      aggregations:
+        - alignmentPeriod: 60s
+          perSeriesAligner: ALIGN_RATE
+          crossSeriesReducer: REDUCE_SUM
+      trigger:
+        count: 1
+documentation:
+  mimeType: text/markdown
+  content: |
+    # prod-auth-fail-rate-high (P1)
+
+    Cloud Run `novel-writer` の 401 (認証 fail) rate が閾値を超過。
+
+    **起草意図 (runbook prod-monitoring.md §A2)**: 401 rate > 50% (5 分平均)
+    **現実装**: 絶対 rate で代用、MQL refactor は段階 2/3 で予定
+
+    ## 想定原因
+    - Phase 1 Firebase Auth 設定漏れ (authorizedDomains, sign-in provider)
+    - Phase 2 env_var_drift (GCLOUD_PROJECT 未設定 → 全 token reject)
+    - Firebase project key の rotation
+    - 攻撃 (brute force など)
+
+    ## 確認手順
+    1. dashboard W3 で発生時刻 + 範囲を確認
+    2. Cloud Logging で 401 の jsonPayload を grep、特に `Firebase ID token has incorrect "aud" claim` 等を確認
+    3. 原因が deploy 後の env_var なら ADR-0002 §3 段階 1 (公開即遮断) → 修正 → 再 deploy
+
+    ## 関連 memory
+    - .claude/memory/feedback_env_var_naming_drift.md (Phase 2 教訓)
+    - .claude/memory/feedback_firebase_auth_setup_gotcha.md (Phase 1 補完事項)

--- a/monitoring/policies/A3-prod-vertex-ai-errors.yaml
+++ b/monitoring/policies/A3-prod-vertex-ai-errors.yaml
@@ -1,0 +1,47 @@
+# Phase 4 段階 2 GO-4: Alerting policy A3
+# 目的: Vertex AI quota 超過 / 503 / 504 を検知
+# 起草意図 (runbook prod-monitoring.md §A3): Vertex AI 429/503/504 rate > 10% (5 分平均)
+# 実装メモ: ratio は MQL 必須、PR α では Cloud Run 5xx + log-based ベース simplifier
+#           Vertex AI の直接 quota metric (aiplatform.googleapis.com/quota) はあるが、
+#           policy としては「server endpoint からの 5xx 系」で検知する方が確実。
+#           より正確な検知は log-based metric (custom metric) で段階 2/3 に refactor 想定。
+#
+# Format reference: https://cloud.google.com/monitoring/api/ref_v3/rest/v3/projects.alertPolicies
+displayName: prod-vertex-ai-quota-error
+combiner: OR
+enabled: true
+conditions:
+  - displayName: Vertex AI quota / 503 / 504 errors via Cloud Run 5xx
+    conditionThreshold:
+      filter: 'metric.type="run.googleapis.com/request_count" AND resource.type="cloud_run_revision" AND metric.label."response_code"=monitoring.regex.full_match("(429|503|504)") AND resource.label."service_name"="novel-writer"'
+      comparison: COMPARISON_GT
+      # 429/503/504 rate 閾値: 0.3 件/秒 = 90 件/5分
+      # Vertex AI quota 接近 + region 障害を 5 分で検知
+      thresholdValue: 0.3
+      duration: 300s
+      aggregations:
+        - alignmentPeriod: 60s
+          perSeriesAligner: ALIGN_RATE
+          crossSeriesReducer: REDUCE_SUM
+      trigger:
+        count: 1
+documentation:
+  mimeType: text/markdown
+  content: |
+    # prod-vertex-ai-quota-error (P1)
+
+    Cloud Run `novel-writer` で 429/503/504 (Vertex AI 経由が主因) が閾値を超過。
+
+    **起草意図 (runbook prod-monitoring.md §A3)**: Vertex AI 429/503/504 rate > 10% (5 分平均)
+    **現実装**: Cloud Run 5xx の log-based proxy、log-based metric refactor は段階 2/3 で予定
+
+    ## 想定原因
+    - Vertex AI quota 接近 / 超過 (429)
+    - Vertex AI region 障害 (503)
+    - Cloud Run cold start 中の Vertex AI timeout (504)
+
+    ## 確認手順
+    1. dashboard W4 で発生時刻 + 範囲を確認
+    2. Cloud Logging で `severity=ERROR AND jsonPayload.statusCode IN (429,503,504)` を grep
+    3. quota 接近なら本田様に申請 trigger 報告 (phase4-tasks.md §GO-2 課金クォータ申請 draft)
+    4. region 障害なら GCP status page 確認 + 短時間なら待機、長時間なら ADR-0002 §3 段階 1 検討

--- a/monitoring/policies/A4-prod-instance-saturation.yaml
+++ b/monitoring/policies/A4-prod-instance-saturation.yaml
@@ -1,0 +1,42 @@
+# Phase 4 段階 2 GO-4: Alerting policy A4
+# 目的: Cloud Run instance count が max-instances (=2) で 5 分継続 → 課金リスクの兆候
+# 起草意図 (runbook prod-monitoring.md §A4): instance_count = max-instances を 5 分継続
+# 実装メモ: 比較対象は固定値 2 (Phase 1 で max-instances=2 設定済、ADR-0001 §Consequences §4)
+#
+# Format reference: https://cloud.google.com/monitoring/api/ref_v3/rest/v3/projects.alertPolicies
+displayName: prod-instance-saturation
+combiner: OR
+enabled: true
+conditions:
+  - displayName: Cloud Run instance count saturates max-instances
+    conditionThreshold:
+      filter: 'metric.type="run.googleapis.com/container/instance_count" AND resource.type="cloud_run_revision" AND resource.label."service_name"="novel-writer"'
+      comparison: COMPARISON_GTE
+      # max-instances=2 に張り付き (Phase 1 で max-instances=2 設定)
+      thresholdValue: 2
+      duration: 300s
+      aggregations:
+        - alignmentPeriod: 60s
+          perSeriesAligner: ALIGN_MAX
+          crossSeriesReducer: REDUCE_MAX
+      trigger:
+        count: 1
+documentation:
+  mimeType: text/markdown
+  content: |
+    # prod-instance-saturation (P1)
+
+    Cloud Run `novel-writer` の instance count が max-instances (=2) に 5 分継続で張り付き。
+
+    **起草意図**: 突発 traffic 警告 + 課金リスクの早期検知
+    **背景**: ADR-0001 §Consequences §4 で「緊急対応 max-instances=2 + 月 ¥1,000 予算アラート」
+
+    ## 確認手順
+    1. dashboard W5 で発生時刻 + 持続時間を確認
+    2. dashboard W1 (request rate) で traffic spike を確認
+    3. 想定範囲なら本田様判断で max-instances を 5 or 10 に拡張 (`gcloud run services update --max-instances`)
+    4. 想定外なら ADR-0002 §3 段階 1 (公開即遮断) で課金暴走を止血
+
+    ## 関連
+    - ADR-0001 §Consequences §4 (max-instances=2 設計根拠)
+    - GO-2 課金クォータ申請 draft (phase4-tasks.md)

--- a/monitoring/policies/A5-prod-firestore-error.yaml
+++ b/monitoring/policies/A5-prod-firestore-error.yaml
@@ -1,0 +1,45 @@
+# Phase 4 段階 2 GO-4: Alerting policy A5
+# 目的: Firestore ERROR レベル log を検知 (P2、ダイジェスト)
+# 起草意図 (runbook prod-monitoring.md §A5): Firestore ERROR レベル log 直近 5 分に 1 件以上
+# 実装メモ: Firestore の ERROR は log-based metric が必要。GA log-based metric
+#           "logging.googleapis.com/user/<NAME>" は別途作成が必要。
+#           PR α では Cloud Run の Firestore admin SDK error を server log (severity=ERROR) で
+#           間接検知する形で起草、log-based metric refactor は段階 2/3 で予定。
+#
+# Format reference: https://cloud.google.com/monitoring/api/ref_v3/rest/v3/projects.alertPolicies
+displayName: prod-firestore-error
+combiner: OR
+enabled: true
+conditions:
+  - displayName: Cloud Run server log severity=ERROR (Firestore admin SDK 経由含む)
+    conditionThreshold:
+      filter: 'metric.type="logging.googleapis.com/log_entry_count" AND resource.type="cloud_run_revision" AND metric.label."severity"="ERROR" AND resource.label."service_name"="novel-writer"'
+      comparison: COMPARISON_GT
+      # ERROR log 直近 5 分に 1 件以上 (P2、ダイジェスト)
+      thresholdValue: 0
+      duration: 300s
+      aggregations:
+        - alignmentPeriod: 60s
+          perSeriesAligner: ALIGN_COUNT
+          crossSeriesReducer: REDUCE_SUM
+      trigger:
+        count: 1
+documentation:
+  mimeType: text/markdown
+  content: |
+    # prod-firestore-error (P2)
+
+    Cloud Run `novel-writer` の server log で severity=ERROR が直近 5 分に 1 件以上発生。
+
+    **起草意図 (runbook prod-monitoring.md §A5)**: Firestore ERROR レベル log を検知
+    **現実装**: Cloud Run の全 ERROR log を検知 (Firestore + その他)、Firestore 専用化は段階 2/3 で予定
+
+    ## P2 の意味
+    P2 = 24 時間以内に分析、即時対応不要。ダイジェスト email で受信。
+    既に発生時刻に問題は終わっていることが多いが、再発防止のため log analysis を残す。
+
+    ## 確認手順
+    1. dashboard W6 で発生時刻 + 範囲を確認
+    2. Cloud Logging で `severity=ERROR AND resource.type=cloud_run_revision` を直近 5 分で grep
+    3. Firestore admin SDK error なら ADR-0002 / ADR-0003 の rollback 検討対象 (P1 escalation)
+    4. それ以外の単発エラーなら GitHub Issue 起票検討 (CLAUDE.md Issue triage rule)


### PR DESCRIPTION
## Summary

Phase 4 段階 2 GO-4 の **段階 1 (起草)** PR α。本 PR は YAML + workflow 設置のみで、実機構築 (\`workflow_dispatch\` 起動) は本 PR merge 後・別セッションで実行。

- **5 alerting policy YAML** (A1-A5): Cloud Run 5xx / 401 / 429-503-504 / instance saturation / ERROR log
- **dashboard YAML** (8 widget mosaicLayout): W1 request rate / W2 5xx / W3 401 / W4 Vertex AI errors / W5 instance / W6 ERROR / W7 quota / W8 usage
- **setup workflow**: \`workflow_dispatch\` only, email_address input, IAM precheck, idempotent

## 設計の根拠 (GO-3 教訓を反映)

GO-3 では gcloud spec の ground truth 確認漏れで **5 PR 連続** の修正が発生。本 GO-4 では事前確認を強化:

| 項目 | 確認方法 |
|---|---|
| AlertPolicy YAML spec | Cloud Monitoring 公式 docs (\`projects.alertPolicies\`) で確認、displayName / combiner / conditions / notificationChannels / documentation / enabled の構造 |
| Dashboard YAML spec | Cloud Monitoring 公式 docs (\`projects.dashboards\`) で確認、mosaicLayout (12 列) + tiles + widget の構造 |
| gcloud monitoring policies create | \`--help\` で flag 確認 (\`--policy-from-file\` + \`--notification-channels\` 併用可) |
| LRO 性質 | monitoring API は同期、LRO ではない (clone と異なる) |
| Idempotent | 既存 channel/policy/dashboard は delete 後 recreate |
| IAM 事前 check | workflow 内に Pre-check step、roles/monitoring.editor 不足を明示エラー化 |

## ratio (X%) の表現について

runbook §A1-A5 で起草した「X% rate」(5%/50%/10%) は AlertPolicy で **直接表現不可** (Cloud Monitoring の標準 threshold は絶対値のみ、ratio は MQL/PromQL が必要)。

- **PR α (本 PR)**: 絶対 rate (件/秒) で threshold 設定、ratio refactor は段階 2/3 で MQL/PromQL に変換予定
- 各 policy YAML の冒頭コメント + documentation field に「現実装は絶対 rate、段階 2/3 で MQL refactor 予定」を明記

## ⚠️ 本 PR merge 後の必須前提作業 (本田様実行)

prod の \`github-deploy\` SA に **\`roles/monitoring.editor\`** がない (現状は \`artifactregistry.writer\` + \`run.admin\` + \`datastore.owner\` のみ)。workflow run の前に以下を実行:

\`\`\`bash
gcloud projects add-iam-policy-binding novel-writer-prod \\
  --member=serviceAccount:github-deploy@novel-writer-prod.iam.gserviceaccount.com \\
  --role=roles/monitoring.editor
\`\`\`

workflow には Pre-check step を入れてあるので、IAM 未付与で起動すると **明示エラー** で停止して desire の差を表示します。

## 本 PR merge 後の手順 (時系列、別セッション)

1. 本田様 IAM 変更 (上記 gcloud コマンド)
2. AI が \`gh workflow run prod-monitoring-setup.yml --ref main -f email_address=<本田様確定 address>\` で起動 (番号単位明示認可必須)
3. 5 policy + dashboard + email channel 作成
4. email 通知到達確認 (workflow 内では確認しない、本田様が後日実機 trigger を起こして確認)
5. 証跡 PR: runbook prod-monitoring.md に dashboard URL + 構築日時 + IAM 変更コマンド + 確認結果を追記、phase4-tasks.md AC-P4-9 を完了に更新

## Test plan

- [x] \`npm run lint\` PASS (tsc エラー 0)
- [x] \`npm run test\` PASS (836/836)
- [x] AlertPolicy / Dashboard YAML 構造を公式 spec と照合
- [x] gcloud コマンド flag を \`--help\` で確認
- [ ] dev workflow 実走 (※本 PR には dev workflow を含めない、prod のみ。dev で先行検証する場合は別 PR)
- [ ] prod workflow 実走 (本 PR merge + 本田様 IAM 変更 + 本田様番号単位認可後)

設定/インフラ向け PR のため、実機構築は別セッションで本田様番号単位認可後に実施 (CLAUDE.md Definition of Done §3 該当)。

## NG リスト (本 PR に含めない)

- IAM 変更の自動化 (decision-maker 領分、本田様手動)
- workflow_dispatch 起動 (本 PR merge 後の別タイミング、番号単位認可必須)
- dev environment への monitoring 構築 (本 GO-4 のスコープは prod のみ、ADR-0003 §Decision 2)
- SLO Accepted 化 (段階 3)
- Slack/SMS 通知 (future work)
- log-based metric の事前作成 (W7/W8 は placeholder、段階 2/3 で正確な metric に refactor)
- MQL/PromQL への ratio 書き直し (段階 2/3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)