### PR TITLE
fix(prod-monitoring): replace IAM precheck with Monitoring API access probe

### DIFF
--- a/.github/workflows/prod-monitoring-setup.yml
+++ b/.github/workflows/prod-monitoring-setup.yml
@@ -49,26 +49,30 @@ jobs:
 
       - uses: google-github-actions/setup-gcloud@v3
 
-      - name: Pre-check IAM (require roles/monitoring.editor)
+      - name: Pre-check Monitoring API access
         run: |
-          # github-deploy SA に roles/monitoring.editor が付与されているか確認
-          # 不足していたら明示エラー (本田様の IAM 変更 step が抜けていないか chk)
-          ROLES=$(gcloud projects get-iam-policy "$PROJECT_ID" \
-            --flatten=bindings \
-            --format='value(bindings.role)' \
-            --filter='bindings.members:github-deploy@novel-writer-prod.iam.gserviceaccount.com')
-          echo "Current roles for github-deploy SA:"
-          echo "$ROLES"
-          if ! echo "$ROLES" | grep -q 'roles/monitoring.editor'; then
+          # github-deploy SA が Monitoring API に対し editor 権限を持つか試行ベースで確認。
+          # gcloud projects get-iam-policy は resourcemanager.projects.getIamPolicy 権限を要求し
+          # roles/monitoring.editor の範囲外であるため、IAM 直接確認は catch-22 で使えない。
+          # 代わりに monitoring.notificationChannels.list を試行し、permission denied なら
+          # 不足ロールガイダンスを出して fail する。
+          if ! gcloud monitoring channels list \
+                --project="$PROJECT_ID" \
+                --limit=1 \
+                --format='value(name)' >/dev/null 2>monitoring-precheck.err; then
+            echo "ERROR: Monitoring API へのアクセスに失敗しました。"
+            echo "--- gcloud stderr ---"
+            cat monitoring-precheck.err
+            echo "---------------------"
             echo ""
-            echo "ERROR: github-deploy@novel-writer-prod に roles/monitoring.editor が付与されていません。"
+            echo "github-deploy@novel-writer-prod に roles/monitoring.editor が付与されていない可能性があります。"
             echo "本田様に以下のコマンドを実行いただいてから再 run してください:"
             echo "  gcloud projects add-iam-policy-binding novel-writer-prod \\"
             echo "    --member=serviceAccount:github-deploy@novel-writer-prod.iam.gserviceaccount.com \\"
             echo "    --role=roles/monitoring.editor"
             exit 1
           fi
-          echo "OK: roles/monitoring.editor 確認済"
+          echo "OK: Monitoring API アクセス確認済 (notificationChannels.list 成功)"
 
       - name: Create or get email notification channel
         id: channel


### PR DESCRIPTION
## Summary

- Phase 4 段階 2 GO-4 で初回 workflow run (#27876520913) が `Pre-check IAM` step で fail。原因は **catch-22**: `gcloud projects get-iam-policy` が `resourcemanager.projects.getIamPolicy` 権限を要求するが、これは `roles/monitoring.editor` の範囲外。IAM 付与済でも check 自体が permission denied で fail する設計欠陥。
- 修正: Pre-check を「`gcloud monitoring channels list --limit=1` を試行して Monitoring API へのアクセス権を試行ベースで確認」に置換。必要権限が後続 step (channels create / policies create / dashboards create) と完全一致するため、本物の権限不足シグナルになる。
- 失敗時ガイダンス文言 (`roles/monitoring.editor` 付与コマンド) と stderr 詳細出力は保持。

## Context

- PR #208 (Phase 4 段階 2 GO-4 PR α) で起草、merge 済み。
- prod IAM 変更 (`roles/monitoring.editor` 付与) は本 PR と独立に AI 実行済 (本田様包括認可下、handoff #209 条件待ち #3 トリガー充足)。
- 本 fix PR merge 後に再度 workflow run することで Phase 4 段階 2 GO-4 完了予定。

## Why this approach (not the alternative)

| 案 | 採用可否 |
|----|----------|
| **採用**: Monitoring API 試行 (channels list) | 必要権限が後続 step と一致、最小権限の原則を維持 |
| 不採用: SA に `roles/iam.securityReviewer` 追加 | 監査・読み取り権限が増え、最小権限から逸脱 |
| 不採用: Pre-check 自体を削除 | IAM 付与忘れ時のエラー文言ガイダンスが失われ、運用負荷増 |

## Test plan

- [x] YAML syntax check: `node -e "yaml.load(...)"` → OK
- [x] grep で Pre-check 切替・stderr 取り扱い確認
- [ ] **merge 後**: `gh workflow run prod-monitoring-setup.yml -f email_address=...` で再 run、Pre-check step が success になり後続 channel / policies / dashboard create も success になることを確認
- [ ] verify step の dashboard URL を runbook prod-monitoring.md に追記 (GO-4 証跡 PR β)

## §4.6 同根再発スキャン

- 本 fix の root cause = 「`gcloud` コマンドが要求する具体的な IAM permission を確認せずに workflow を起草」。GO-3 でも 4 PR 連続 fix (#203/#205/#206/#207) が gcloud spec 確認漏れで発生したが、今回も同根の派生形。
- 防止策: 次回以降の workflow 起草時、`gcloud` の各サブコマンドが要求する `*.getIamPolicy` / `*.create` 等の具体的な permission を public docs で確認してから設計する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)