### PR TITLE
fix(prod-monitoring): use `gcloud beta monitoring channels` (GA に未提供)

### DIFF
--- a/.github/workflows/prod-monitoring-setup.yml
+++ b/.github/workflows/prod-monitoring-setup.yml
@@ -48,6 +48,11 @@ jobs:
           service_account: github-deploy@novel-writer-prod.iam.gserviceaccount.com
 
       - uses: google-github-actions/setup-gcloud@v3
+        with:
+          # `gcloud monitoring channels` は GA に存在しない (GA は dashboards / policies / snoozes / uptime のみ)。
+          # notification channel 操作には beta が必要なため install_components で明示し、
+          # 以降は `gcloud beta monitoring channels` を使用する。
+          install_components: beta
 
       - name: Pre-check Monitoring API access
         run: |
@@ -56,7 +61,7 @@ jobs:
           # roles/monitoring.editor の範囲外であるため、IAM 直接確認は catch-22 で使えない。
           # 代わりに monitoring.notificationChannels.list を試行し、permission denied なら
           # 不足ロールガイダンスを出して fail する。
-          if ! gcloud monitoring channels list \
+          if ! gcloud beta monitoring channels list \
                 --project="$PROJECT_ID" \
                 --limit=1 \
                 --format='value(name)' >/dev/null 2>monitoring-precheck.err; then
@@ -79,13 +84,13 @@ jobs:
         run: |
           # idempotent: 既存 channel があれば ID 取得、なければ作成
           EMAIL='${{ inputs.email_address }}'
-          CHANNEL_ID=$(gcloud monitoring channels list \
+          CHANNEL_ID=$(gcloud beta monitoring channels list \
             --filter="displayName=\"$CHANNEL_DISPLAY_NAME\"" \
             --format='value(name)' \
             --project="$PROJECT_ID" | head -1)
           if [ -z "$CHANNEL_ID" ]; then
             echo "Channel not found, creating..."
-            CHANNEL_ID=$(gcloud monitoring channels create \
+            CHANNEL_ID=$(gcloud beta monitoring channels create \
               --display-name="$CHANNEL_DISPLAY_NAME" \
               --type=email \
               --channel-labels="email_address=$EMAIL" \
@@ -95,7 +100,7 @@ jobs:
           else
             echo "Existing channel found: $CHANNEL_ID"
             # email_address が変わっている可能性、update
-            gcloud monitoring channels update "$CHANNEL_ID" \
+            gcloud beta monitoring channels update "$CHANNEL_ID" \
               --update-channel-labels="email_address=$EMAIL" \
               --project="$PROJECT_ID"
             echo "Updated channel email_address to: $EMAIL"
@@ -148,7 +153,7 @@ jobs:
       - name: Verify created resources
         run: |
           echo "=== Notification channels ==="
-          gcloud monitoring channels list \
+          gcloud beta monitoring channels list \
             --filter="displayName=\"$CHANNEL_DISPLAY_NAME\"" \
             --format='table(name,displayName,type,labels.email_address)' \
             --project="$PROJECT_ID"


### PR DESCRIPTION
## Summary

PR #210 (Pre-check 置換) 後の workflow re-run で判明: **`gcloud monitoring channels` は GA に存在しない**。GA は `dashboards / policies / snoozes / uptime` のみ。notification channel 操作は `gcloud alpha` or `gcloud beta` 専用 (公式 docs 確認済、beta が安定)。

エラー実例 (run #27876666359):
\`\`\`
ERROR: (gcloud.monitoring) Invalid choice: 'channels'.
Maybe you meant:
  gcloud monitoring dashboards list
  gcloud monitoring policies list
  ...
\`\`\`

## Changes

| 箇所 | 修正 |
|------|------|
| setup-gcloud@v3 | `install_components: beta` 明示追加 (beta コンポーネント同梱の保証) |
| Pre-check Monitoring API access (l.63) | `gcloud monitoring channels list` → `gcloud beta monitoring channels list` |
| Create or get channel: list (l.86) / create (l.92) / update (l.102) | `gcloud beta monitoring channels ...` に統一 |
| Verify created resources (l.155) | `gcloud beta monitoring channels list` |

policies / dashboards は GA 提供で変更不要。

## Why this approach (not the alternative)

| 案 | 採用可否 |
|----|----------|
| **採用**: `gcloud beta monitoring channels` + `install_components: beta` | beta は GA 候補で stable channel と公式宣言、breaking change なし |
| 不採用: `gcloud alpha monitoring channels` | alpha は "might change without notice"、prod workflow に不適切 |
| 不採用: REST API 直叩き (`curl`) | 認証 / リトライ / エラー処理が増え、複雑度が逆増 |

## §4.6 同根再発スキャン

- **root cause**: PR #208 (GO-4 PR α) 起草時に `gcloud beta` prefix の確認漏れ。PR #210 の Pre-check 置換時もまだ `channels` 参照のままで、同じ間違いを引き継いだ (2 連続 fix)。
- **GO-3 の 4 連続 fix (#203/#205/#206/#207)** と同根: 「`gcloud` の提供範囲 (GA vs alpha vs beta) を確認せず workflow を起草」。
- **次回以降のルール案**: workflow に書く全 `gcloud <component> <resource>` について `gcloud <component> <resource> --help` を必ず実行して GA/alpha/beta 提供範囲を確認するか、公式 docs の `cloud.google.com/sdk/gcloud/reference/<component>` を WebFetch する。本田様判断項目: ルール化するか個別注意で済ますか。

## Test plan

- [x] YAML syntax check: `node -e "yaml.load(...)"` → OK
- [x] grep で 5 箇所の channels 参照すべて `beta` 付きに修正済確認
- [x] 公式 docs (`docs.cloud.google.com/sdk/gcloud/reference/monitoring`) で GA 非提供 / `alpha/beta` 提供を確認済
- [ ] **merge 後**: 再 workflow run → Pre-check + channel create + policies create + dashboard create + verify が全 success
- [ ] dashboard URL を runbook prod-monitoring.md に追記 (GO-4 証跡 PR β)

## 前提

- PR #208 (workflow 起草) merge 済
- PR #210 (Pre-check 置換) merge 済
- prod IAM (`roles/monitoring.editor`) 付与済 (AI 実行、本田様包括認可下)

🤖 Generated with [Claude Code](https://claude.com/claude-code)