### PR TITLE
fix(prod-monitoring): A4 comparison COMPARISON_GTE → COMPARISON_GE

### DIFF
--- a/monitoring/policies/A4-prod-instance-saturation.yaml
+++ b/monitoring/policies/A4-prod-instance-saturation.yaml
@@ -11,8 +11,9 @@ conditions:
   - displayName: Cloud Run instance count saturates max-instances
     conditionThreshold:
       filter: 'metric.type="run.googleapis.com/container/instance_count" AND resource.type="cloud_run_revision" AND resource.label."service_name"="novel-writer"'
-      comparison: COMPARISON_GTE
+      comparison: COMPARISON_GE
       # max-instances=2 に張り付き (Phase 1 で max-instances=2 設定)
+      # ComparisonType enum (公式): COMPARISON_GT(>) / COMPARISON_GE(>=) / COMPARISON_LT / COMPARISON_LE / COMPARISON_EQ / COMPARISON_NE
       thresholdValue: 2
       duration: 300s
       aggregations:


### PR DESCRIPTION
## Summary

A4 policy の `comparison: COMPARISON_GTE` が ComparisonType enum で無効値。正しくは `COMPARISON_GE` (greater than or equal)。起草意図 (instance_count >= max-instances=2 で 5 分継続検知) は変更なし、enum 値のみ修正。

エラー実例 (run #27876793187):
```
ERROR: (gcloud.monitoring.policies.create) INVALID_ARGUMENT:
  Invalid value at 'alert_policy.conditions[0].condition_threshold.comparison'
  (type.googleapis.com/google.monitoring.v3.ComparisonType), "COMPARISON_GTE"
```

## ComparisonType enum 公式値

| 記号 | enum 値 |
|------|---------|
| `>` | `COMPARISON_GT` |
| `>=` | **`COMPARISON_GE`** ← 正解 |
| `<` | `COMPARISON_LT` |
| `<=` | `COMPARISON_LE` |
| `==` | `COMPARISON_EQ` |
| `!=` | `COMPARISON_NE` |

出典: [Cloud Monitoring v3 API — ComparisonType](https://docs.cloud.google.com/monitoring/api/ref_v3/rpc/google.monitoring.v3) / [Java client reference](https://cloud.google.com/java/docs/reference/google-cloud-monitoring/3.4.0/com.google.monitoring.v3.ComparisonType)

## §4.6 3 連続 fix 元設計再レビュー (CLAUDE.md MUST)

本 PR は同一機能 (prod monitoring workflow) に対する 3 件連続 fix (#210, #211, #212) に該当するため、元 PR #208 設計を再レビューした:

### Policy YAML 全 enum 値再 grep

| Policy | comparison | 判定 |
|--------|-----------|------|
| A1-prod-5xx-rate | COMPARISON_GT | ✅ 有効 |
| A2-prod-auth-fail-rate | COMPARISON_GT | ✅ 有効 |
| A3-prod-vertex-ai-errors | COMPARISON_GT | ✅ 有効 |
| **A4-prod-instance-saturation** | **COMPARISON_GTE → COMPARISON_GE** | 本 PR で修正 |
| A5-prod-firestore-error | COMPARISON_GT | ✅ 有効 |

### dashboard.yaml 点検

- XYChart のみで `comparison:` enum 参照なし、本問題の影響なし
- filter / metric type は policy と共通参照のため、A1/A2/A3 success (run #27876793187) により実証済

### 再発予防

公式 enum / API spec は記憶ベースで書かず、protobuf / API docs を必ず参照する (本セッションでは PR #208 起草時に `gcloud monitoring policies create --help` で flag は確認したが、YAML body の field 値 enum は確認漏れ)。

## 連続 fix の振り返り

| PR | 内容 | root cause |
|----|------|-----------|
| #210 | Pre-check IAM 置換 | `gcloud projects get-iam-policy` の必要権限を確認漏れ (catch-22) |
| #211 | `gcloud beta monitoring channels` | GA/alpha/beta 提供範囲を確認漏れ |
| **#212 (本 PR)** | A4 COMPARISON_GE | ComparisonType enum 値を確認漏れ |

3 件すべて「公式 spec を記憶ベースで書いた」同根。Phase 4 段階 2 GO-4 起草段階で本田様判断項目に上げるべきだった (各 step の dry-run 試行を CI 外で先に通す等)。

## Test plan

- [x] YAML syntax check 全 6 ファイル → OK
- [x] A1-A5 全 enum 値再 grep → A4 のみ問題、本 PR で修正
- [x] dashboard.yaml に `comparison:` enum 参照なしを確認
- [x] ComparisonType enum 公式値を 2 ソースで cross-check
- [ ] **merge 後**: 再 workflow run → policies create A1-A5 全 success + dashboard create + verify

## 前提

- PR #208 (workflow 起草) merge 済
- PR #210 (Pre-check 置換) merge 済
- PR #211 (gcloud beta channels) merge 済
- prod IAM (roles/monitoring.editor) 付与済
- run #27876793187 で channel + A1/A2/A3 success まで実証済 (idempotent な再 run で既存 policy は delete → re-create)

🤖 Generated with [Claude Code](https://claude.com/claude-code)