### PR TITLE
fix(prod-monitoring): A4 comparison COMPARISON_GE→GT, thresholdValue 2→1

### DIFF
--- a/monitoring/policies/A4-prod-instance-saturation.yaml
+++ b/monitoring/policies/A4-prod-instance-saturation.yaml
@@ -11,10 +11,12 @@ conditions:
   - displayName: Cloud Run instance count saturates max-instances
     conditionThreshold:
       filter: 'metric.type="run.googleapis.com/container/instance_count" AND resource.type="cloud_run_revision" AND resource.label."service_name"="novel-writer"'
-      comparison: COMPARISON_GE
+      comparison: COMPARISON_GT
       # max-instances=2 に張り付き (Phase 1 で max-instances=2 設定)
-      # ComparisonType enum (公式): COMPARISON_GT(>) / COMPARISON_GE(>=) / COMPARISON_LT / COMPARISON_LE / COMPARISON_EQ / COMPARISON_NE
-      thresholdValue: 2
+      # 公式 ComparisonType enum は GT/GE/LT/LE/EQ/NE を定義するが、
+      # AlertPolicy MetricThreshold の実装は GT/LT のみサポート (公式 docs / Terraform / Python client 共通)。
+      # 起草意図「instance_count >= 2」は整数値特性により「instance_count > 1」と等価。
+      thresholdValue: 1
       duration: 300s
       aggregations:
         - alignmentPeriod: 60s


### PR DESCRIPTION
## Summary

AlertPolicy MetricThreshold は実装上 `COMPARISON_LT` / `COMPARISON_GT` のみサポート (enum 上は GE/LE/EQ/NE も存在するが unsupported)。公式 docs / Terraform provider / Python client が一貫してこの制約を記載。

意図保持: 整数値特性により **「instance_count >= 2」≡「instance_count > 1」**、duration 300s も維持。起草意図 (instance_count が max-instances=2 に張り付き 5 分継続) は変わらず。

エラー実例 (run #27885477491):
```
ERROR: (gcloud.monitoring.policies.create) INVALID_ARGUMENT:
  had an invalid value of "COMPARISON_GE":
  Unsupported comparison; only COMPARISON_LT and COMPARISON_GT are supported at present.
```

## Changes

```diff
-      comparison: COMPARISON_GE
+      comparison: COMPARISON_GT
-      thresholdValue: 2
+      thresholdValue: 1
+      # 公式 ComparisonType enum は GT/GE/LT/LE/EQ/NE を定義するが、
+      # AlertPolicy MetricThreshold の実装は GT/LT のみサポート (公式 docs / Terraform / Python client 共通)。
+      # 起草意図「instance_count >= 2」は整数値特性により「instance_count > 1」と等価。
```

## §4.6 4 連続 fix 振り返り (CLAUDE.md MUST)

| PR | 修正 | root cause |
|----|------|-----------|
| #210 | Pre-check IAM 置換 | `gcloud projects get-iam-policy` の必要権限を確認漏れ (catch-22) |
| #211 | `gcloud beta monitoring channels` | GA/alpha/beta 提供範囲を確認漏れ |
| #212 | A4 GTE → GE | ComparisonType enum 値を確認漏れ |
| **#213 (本 PR)** | A4 GE → GT (thresholdValue 2→1) | AlertPolicy MetricThreshold の支持範囲を確認漏れ |

**#212 で「元設計再レビュー」を実施したが、enum 一般定義 (公式 enum 一覧) と AlertPolicy 実装の支持範囲 (Terraform / Python client / sample policies in JSON) を分けて確認する必要があった**。本セッションの 4 連続 fix は全て「公式 spec を 1 ソースで確認、cross-check 不足」が同根。

### 教訓 (memory 化候補)

- gcloud / GCP API 系の設定値は **最低 2 ソース cross-check** (公式 docs / Terraform provider / SDK client reference)
- 特に「enum 一般定義」と「特定 resource での実装支持範囲」は別物として扱う
- workflow 起草時に dry-run / 小規模 sandbox 試行を CI 外で先に通せれば連鎖を避けられる (本田様判断項目)

## Test plan

- [x] YAML syntax check → OK
- [x] A4 修正後 grep で意図 (max-instances=2 で 5 分継続) の整合性確認 (整数値で `>=2` ≡ `>1`)
- [x] 3 ソース cross-check 済 ([Terraform google_monitoring_alert_policy](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_alert_policy.html) / [Python client MetricThreshold](https://cloud.google.com/python/docs/reference/monitoring/0.35.0/google.cloud.monitoring_v3.types.AlertPolicy.Condition.MetricThreshold) / [Sample policies in JSON](https://docs.cloud.google.com/monitoring/alerts/policies-in-json))
- [ ] **merge 後**: 5 回目 workflow run → policies A1-A5 全 success + dashboard create + verify

## 前提

- PR #208 / #210 / #211 / #212 merge 済
- prod IAM (roles/monitoring.editor) 付与済
- run #27885477491 で channel + A1/A2/A3 success までは到達 (idempotent re-run で A4/A5/dashboard 補完)

🤖 Generated with [Claude Code](https://claude.com/claude-code)