### PR TITLE
fix(prod-monitoring): add scorecard threshold direction (W5/W6)

### DIFF
--- a/monitoring/dashboard.yaml
+++ b/monitoring/dashboard.yaml
@@ -116,8 +116,10 @@ mosaicLayout:
                 perSeriesAligner: ALIGN_MAX
                 crossSeriesReducer: REDUCE_MAX
           thresholds:
+            # Threshold.direction (公式必須): ABOVE = 閾値以上で強調、BELOW = 閾値以下で強調
             - value: 2
               color: RED
+              direction: ABOVE
 
     # W6: Firestore ERROR レベル log 件数 (scorecard、A5 alerting source)
     - width: 3
@@ -135,8 +137,10 @@ mosaicLayout:
                 perSeriesAligner: ALIGN_COUNT
                 crossSeriesReducer: REDUCE_SUM
           thresholds:
+            # Threshold.direction (公式必須): ABOVE = 閾値以上で強調 (ERROR log 1 件以上で黄色)
             - value: 1
               color: YELLOW
+              direction: ABOVE
 
     # W7: Vertex AI quota 利用率 (line chart、段階 2/3 で正確な metric に refactor 予定)
     - width: 6


### PR DESCRIPTION
## Summary

dashboard scorecard widget の `Threshold.direction` が必須フィールドだが起草時に未指定で API が INVALID_ARGUMENT を返す。

エラー実例 (run #27885859665):
\`\`\`
ERROR: (gcloud.monitoring.dashboards.create) INVALID_ARGUMENT:
  Field mosaicLayout.tiles[4].widget.scorecard.thresholds[0].direction
  has an invalid value: direction must be specified.
\`\`\`

修正: W5 (instance count, value:2 RED) と W6 (ERROR log count, value:1 YELLOW) の threshold に `direction: ABOVE` を追加。起草意図 (閾値以上で警告) と一致。

## Threshold.Direction enum 公式値

| 記号 | enum 値 | 意味 |
|------|---------|------|
| ↑ | `ABOVE` (1) | 値が閾値以上で強調表示 |
| ↓ | `BELOW` (2) | 値が閾値以下で強調表示 |

出典: [Threshold.Direction enum (Java client)](https://cloud.google.com/java/docs/reference/google-cloud-monitoring-dashboard/latest/com.google.monitoring.dashboard.v1.Threshold.Direction) / [REST: projects.dashboards](https://cloud.google.com/monitoring/api/ref_v3/rest/v1/projects.dashboards) / [Threshold.Direction (Ruby client)](https://docs.cloud.google.com/ruby/docs/reference/google-cloud-monitoring-dashboard-v1/latest/Google-Cloud-Monitoring-Dashboard-V1-Threshold-Direction)

## Changes

```diff
# W5 (instance count scorecard)
          thresholds:
+            # Threshold.direction (公式必須): ABOVE = 閾値以上で強調、BELOW = 閾値以下で強調
            - value: 2
              color: RED
+              direction: ABOVE

# W6 (ERROR log count scorecard)
          thresholds:
+            # Threshold.direction (公式必須): ABOVE = 閾値以上で強調 (ERROR log 1 件以上で黄色)
            - value: 1
              color: YELLOW
+              direction: ABOVE
```

xyChart widget (W1-W4 / W7-W8) は threshold 持たず影響なし。

## §4.6 5 連続 fix 振り返り (CLAUDE.md MUST 再々レビュー)

| PR | 修正 | root cause |
|----|------|-----------|
| #210 | Pre-check IAM 置換 | `gcloud projects get-iam-policy` の必要権限を確認漏れ |
| #211 | `gcloud beta monitoring channels` | GA/alpha/beta 提供範囲を確認漏れ |
| #212 | A4 GTE → GE | ComparisonType enum 値を確認漏れ |
| #213 | A4 GE → GT (threshold 2→1) | AlertPolicy MetricThreshold の支持範囲を確認漏れ |
| **#214 (本 PR)** | W5/W6 direction: ABOVE | Threshold.direction の必須性を確認漏れ |

**PR #212 / #213 の「元設計再レビュー」は policy 側だけ実施で dashboard 側を点検漏れ**。今回は dashboard.yaml 全 widget の必須フィールドを公式 spec で再点検済 (mosaicLayout / tile sizing / xyChart / scorecard 他フィールドは全て揃っている)。

### 残課題 / 教訓 (memory 化候補)

- 4 連続 fix 時の「元設計再レビュー」を policy + workflow + dashboard 全ファイルに展開する規律が必要
- YAML body の各 field について API spec の `required:` 表記を必ず確認 (gcloud --help は flag だけで body 内 field を保証しない)
- GO-3 (4 連続) + GO-4 (5 連続) の合計 9 連続 fix が同根 (公式 spec 確認漏れ) で発生。Phase 4 完了後に session 規律 (深夜帯禁止 / cross-check 必須 / sandbox 試行) を memory 化検討

## Test plan

- [x] YAML syntax check → OK
- [x] dashboard.yaml 全 widget の必須フィールド点検済 (scorecard 2 件のみ direction 漏れ、他は揃い)
- [x] 公式 docs 3 ソース cross-check (Java/REST/Ruby)
- [ ] **merge 後**: 6 回目 workflow run → A1-A5 全 success + dashboard create success + verify

## 前提

- PR #208 / #210 / #211 / #212 / #213 merge 済
- prod IAM 付与済
- run #27885859665 で channel + A1-A5 全 success まで到達 (dashboard だけ未作成)

🤖 Generated with [Claude Code](https://claude.com/claude-code)