### PR TITLE
fix(export): HTML 書き出しの構成順を「題名→登場人物→世界観・用語集→目次→本文→あとがき」に変更

### DIFF
--- a/store/dataSlice.exportHtml.test.ts
+++ b/store/dataSlice.exportHtml.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../analysisApi', () => ({
+    analyzeText: vi.fn(),
+}));
+
+import { createDataSlice } from './dataSlice';
+import type { Project, SettingItem } from '../types';
+
+const baseProject = (overrides: Partial<Project> = {}): Project => ({
+    id: 'p-1',
+    name: 'テストプロジェクト',
+    lastModified: new Date(0).toISOString(),
+    settings: [],
+    novelContent: [],
+    chatHistory: [],
+    knowledgeBase: [],
+    plotBoard: [],
+    plotTypeColors: {},
+    plotRelations: [],
+    plotNodePositions: [],
+    timeline: [],
+    timelineLanes: [],
+    characterRelations: [],
+    nodePositions: [],
+    aiSettings: {} as Project['aiSettings'],
+    displaySettings: { theme: 'dark', fontFamily: 'sans', fontSize: 16 } as Project['displaySettings'],
+    ...overrides,
+});
+
+const characterFixture = (overrides: Partial<SettingItem> = {}): SettingItem => ({
+    id: 'c-1',
+    type: 'character',
+    name: '太郎',
+    exportDescription: '太郎の紹介文',
+    ...overrides,
+});
+
+const worldFixture = (overrides: Partial<SettingItem> = {}): SettingItem => ({
+    id: 'w-1',
+    type: 'world',
+    name: '魔法王国',
+    longDescription: '魔法に満ちた世界',
+    ...overrides,
+});
+
+const captureExportedHtml = (project: Project, options: Record<string, unknown>): string => {
+    let captured = '';
+    class FakeBlob {
+        constructor(parts: BlobPart[]) {
+            captured = parts.map(p => String(p)).join('');
+        }
+    }
+    vi.stubGlobal('Blob', FakeBlob);
+
+    const fakeAnchor = { href: '', download: '', click: vi.fn() };
+    vi.stubGlobal('document', {
+        createElement: vi.fn(() => fakeAnchor),
+    });
+    vi.stubGlobal('URL', {
+        createObjectURL: vi.fn(() => 'blob:fake'),
+        revokeObjectURL: vi.fn(),
+    });
+
+    const state = {
+        activeProjectId: project.id,
+        allProjectsData: { [project.id]: project },
+    };
+    const get = () => state as unknown as ReturnType<typeof createDataSlice>;
+    const set = vi.fn();
+    const slice = createDataSlice(set, get);
+
+    slice.exportHtml(options);
+
+    return captured;
+};
+
+const fullOptions = {
+    useCurrentStyle: true,
+    theme: 'dark',
+    fontFamily: 'sans',
+    fontSize: 16,
+    coverType: 'text_only',
+    coverImageSrc: '',
+    authorName: '著者名',
+    addToc: true,
+    selectedCharacterIds: ['c-1'],
+    selectedWorldIds: ['w-1'],
+    addCharacterImages: false,
+    afterword: 'これはあとがきです。',
+};
+
+describe('dataSlice.exportHtml — integration: section ordering & wiring', () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.restoreAllMocks();
+    });
+
+    it('regression: exported HTML must place 登場人物 and 世界観・用語集 sections BEFORE 本文', () => {
+        const project = baseProject({
+            settings: [characterFixture(), worldFixture()],
+            novelContent: [{ id: 'n-1', text: '本文のテキストです。', chapterId: null }],
+        });
+        const html = captureExportedHtml(project, fullOptions);
+
+        const charsIdx = html.indexOf('<h2>登場人物</h2>');
+        const worldsIdx = html.indexOf('<h2>世界観・用語集</h2>');
+        const contentIdx = html.indexOf('<div class="content">');
+
+        expect(charsIdx).toBeGreaterThan(-1);
+        expect(worldsIdx).toBeGreaterThan(-1);
+        expect(contentIdx).toBeGreaterThan(-1);
+        expect(charsIdx).toBeLessThan(contentIdx);
+        expect(worldsIdx).toBeLessThan(contentIdx);
+    });
+
+    it('should emit sections in order: cover → 登場人物 → 世界観・用語集 → 目次 → 本文 → あとがき', () => {
+        const project = baseProject({
+            settings: [characterFixture(), worldFixture()],
+            novelContent: [
+                { id: 'ch-1', text: '# 第一章', chapterId: 'ch-1' },
+                { id: 'n-1', text: '本文', chapterId: 'ch-1' },
+            ],
+        });
+        const html = captureExportedHtml(project, fullOptions);
+
+        const positions = [
+            { name: 'cover', idx: html.indexOf('<div class="cover">') },
+            { name: 'characters', idx: html.indexOf('<h2>登場人物</h2>') },
+            { name: 'worlds', idx: html.indexOf('<h2>世界観・用語集</h2>') },
+            { name: 'toc', idx: html.indexOf('<h2>目次</h2>') },
+            { name: 'content', idx: html.indexOf('<div class="content">') },
+            { name: 'afterword', idx: html.indexOf('<h2>あとがき</h2>') },
+        ];
+        positions.forEach(p => expect(p.idx, `${p.name} section missing`).toBeGreaterThan(-1));
+
+        const indices = positions.map(p => p.idx);
+        const sorted = [...indices].sort((a, b) => a - b);
+        expect(indices).toEqual(sorted);
+    });
+
+    it('wiring check: 登場人物 section must contain character names (not worlds)', () => {
+        const project = baseProject({
+            settings: [
+                characterFixture({ id: 'c-1', name: 'キャラ名前', exportDescription: '' }),
+                worldFixture({ id: 'w-1', name: '世界名前', longDescription: '' }),
+            ],
+            novelContent: [{ id: 'n-1', text: '本文', chapterId: null }],
+        });
+        const html = captureExportedHtml(project, fullOptions);
+
+        const charsSection = html.substring(
+            html.indexOf('<h2>登場人物</h2>'),
+            html.indexOf('<h2>世界観・用語集</h2>'),
+        );
+        expect(charsSection).toContain('キャラ名前');
+        expect(charsSection).not.toContain('世界名前');
+    });
+
+    it('regression: characters なしで世界観あり → 登場人物 section が出ず、世界観 → 本文 順は維持', () => {
+        const project = baseProject({
+            settings: [worldFixture()],
+            novelContent: [{ id: 'n-1', text: '本文', chapterId: null }],
+        });
+        const html = captureExportedHtml(project, { ...fullOptions, selectedCharacterIds: [] });
+
+        expect(html).not.toContain('<h2>登場人物</h2>');
+        const worldsIdx = html.indexOf('<h2>世界観・用語集</h2>');
+        const contentIdx = html.indexOf('<div class="content">');
+        expect(worldsIdx).toBeGreaterThan(-1);
+        expect(worldsIdx).toBeLessThan(contentIdx);
+    });
+
+    it('regression: 世界観なしで characters あり → 世界観 section が出ず、登場人物 → 本文 順は維持', () => {
+        const project = baseProject({
+            settings: [characterFixture()],
+            novelContent: [{ id: 'n-1', text: '本文', chapterId: null }],
+        });
+        const html = captureExportedHtml(project, { ...fullOptions, selectedWorldIds: [] });
+
+        expect(html).not.toContain('<h2>世界観・用語集</h2>');
+        const charsIdx = html.indexOf('<h2>登場人物</h2>');
+        const contentIdx = html.indexOf('<div class="content">');
+        expect(charsIdx).toBeGreaterThan(-1);
+        expect(charsIdx).toBeLessThan(contentIdx);
+    });
+
+    it('regression: あとがきなしで書き出し → あとがき section が出ず本文の後ろに余分なものがない', () => {
+        const project = baseProject({
+            novelContent: [{ id: 'n-1', text: '本文', chapterId: null }],
+        });
+        const html = captureExportedHtml(project, { ...fullOptions, afterword: '' });
+
+        expect(html).not.toContain('<h2>あとがき</h2>');
+    });
+});

--- a/store/dataSlice.ts
+++ b/store/dataSlice.ts
@@ -15,7 +15,7 @@ import {
     warnOnceInDev,
 } from '../utils';
 import { renderMarkdown } from '../utils/sanitizeHtml';
-import { buildCharacterAppendixHtml } from '../utils/htmlExport';
+import { buildCharacterAppendixHtml, composeExportSections } from '../utils/htmlExport';
 import { FONT_MAP } from '../constants';
 import * as analysisApi from '../analysisApi';
 
@@ -936,9 +936,7 @@ export const createDataSlice = (set, get): DataSlice => ({
         // utils.exportChapterAnchorId で生成する。TOC と本文 anchor の id 形式不一致を
         // 構造的に防ぐため必ず両者を utils 経由にする (AC-11)。
         const chapters = buildExportChapterEntries(novelContent);
-        const body = `
-            <div class="container">
-                ${options.coverType !== 'none' ? `
+        const coverSection = options.coverType !== 'none' ? `
                     <div class="cover">
                         ${(options.coverType === 'image_only' || options.coverType === 'image_with_text') && options.coverImageSrc ? `<img src="${escapeHtml(options.coverImageSrc)}" class="cover-image" alt="Cover Image">` : ''}
                         ${(options.coverType === 'text_only' || options.coverType === 'image_with_text') ? `
@@ -946,23 +944,23 @@ export const createDataSlice = (set, get): DataSlice => ({
                             ${options.authorName ? `<p class="author">${escapeHtml(options.authorName)}</p>` : ''}
                         ` : ''}
                     </div>
-                ` : ''}
-                ${options.addToc && chapters.length > 0 ? `
+                ` : '';
+        const tocSection = options.addToc && chapters.length > 0 ? `
                     <div class="toc">
                         <h2>目次</h2>
                         <ul>
                             ${chapters.map(ch => `<li><a href="#${ch.id}">${escapeHtml(ch.title)}</a></li>`).join('')}
                         </ul>
                     </div>
-                ` : ''}
+                ` : '';
+        const contentSection = `
                 <div class="content">
                     ${novelContent.map(chunk => {
                         const anchorId = isChapterTitleChunk(chunk) ? exportChapterAnchorId(chunk) : '';
                         return `<div id="${anchorId}">${renderMarkdown(chunk.text, settings.filter(s => s.type === 'character'), knowledgeBase, aiSettings)}</div>`;
                     }).join('')}
-                </div>
-                ${buildCharacterAppendixHtml(charactersToExport, { addCharacterImages: options.addCharacterImages })}
-                ${worldSettingsToExport.length > 0 ? `
+                </div>`;
+        const worldsSection = worldSettingsToExport.length > 0 ? `
                     <div class="appendix">
                         <h2>世界観・用語集</h2>
                         ${worldSettingsToExport.map(world => `
@@ -972,8 +970,18 @@ export const createDataSlice = (set, get): DataSlice => ({
                             </div>
                         `).join('')}
                     </div>
-                ` : ''}
-                ${options.afterword ? `<div class="appendix"><h2>あとがき</h2><div>${renderMarkdown(options.afterword, [], [], aiSettings)}</div></div>` : ''}
+                ` : '';
+        const afterwordSection = options.afterword ? `<div class="appendix"><h2>あとがき</h2><div>${renderMarkdown(options.afterword, [], [], aiSettings)}</div></div>` : '';
+        const body = `
+            <div class="container">
+                ${composeExportSections({
+                    cover: coverSection,
+                    characters: buildCharacterAppendixHtml(charactersToExport, { addCharacterImages: options.addCharacterImages }),
+                    worlds: worldsSection,
+                    toc: tocSection,
+                    content: contentSection,
+                    afterword: afterwordSection,
+                })}
             </div>
         `;
         const fullHtml = `<!DOCTYPE html><html lang="ja"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"><title>${escapeHtml(project.name)}</title><style>body { font-family: ${fontCss}; font-size: ${fontSize}px; line-height: 1.8; margin: 0; padding: 0; } .container { max-width: 800px; margin: 4rem auto; padding: 2rem; } ${themeStyles} h1, h2, h3 { line-height: 1.3; font-weight: bold; } h1.title { font-size: 2.5em; text-align: center; margin-bottom: 0.5em; } h1.chapter-title { font-size: 1.5em; margin-top: 3em; border-bottom: 1px solid; padding-bottom: 0.5em; } h2 { font-size: 1.2em; margin-top: 2em; border-bottom: 1px solid; padding-bottom: 0.3em;} p.author { text-align: center; font-size: 1.2em; color: #888; margin-bottom: 4em; } .cover { text-align: center; margin-bottom: 4rem; } .cover-image { max-width: 100%; height: auto; max-height: 70vh; margin: 0 auto 2rem; } .content > div { margin: 1.5em 0; } .toc { margin-bottom: 4rem; padding: 1.5rem; border: 1px solid #ccc; border-radius: 8px; } .toc ul { list-style: none; padding-left: 0; } .toc a { text-decoration: none; } .appendix { margin-top: 4rem; border-top: 1px solid #ccc; padding-top: 2rem; } .appendix h2 { border-bottom: none; } .char-card { margin-bottom: 2rem; overflow: hidden; } .char-card img { max-width: 150px; float: left; margin-right: 1rem; border-radius: 4px; } ruby { ruby-position: over; } rt { font-size: 0.7em; } .knowledge-link { text-decoration: none; color: inherit; font-weight: bold; }</style></head><body>${body}</body></html>`;

--- a/utils/htmlExport.test.ts
+++ b/utils/htmlExport.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { SettingItem } from '../types';
-import { buildCharacterAppendixHtml, escapeHtmlForExport } from './htmlExport';
+import { buildCharacterAppendixHtml, composeExportSections, escapeHtmlForExport } from './htmlExport';
 
 const characterFixture = (overrides: Partial<SettingItem> = {}): SettingItem => ({
     id: 'c-1',
@@ -130,6 +130,69 @@ describe('buildCharacterAppendixHtml', () => {
         const html = buildCharacterAppendixHtml(characters, { addCharacterImages: true });
         expect(html).not.toContain('onerror="alert(1)');
         expect(html).toContain('&quot; onerror=&quot;alert(1)');
+    });
+});
+
+describe('composeExportSections (section ordering)', () => {
+    const sections = {
+        cover: '<div class="cover">COVER_MARKER</div>',
+        characters: '<div class="appendix">CHARACTERS_MARKER</div>',
+        worlds: '<div class="appendix">WORLDS_MARKER</div>',
+        toc: '<div class="toc">TOC_MARKER</div>',
+        content: '<div class="content">CONTENT_MARKER</div>',
+        afterword: '<div class="appendix">AFTERWORD_MARKER</div>',
+    };
+
+    it('regression: must place characters and worlds BEFORE content (bug fix for HTML export ordering)', () => {
+        const html = composeExportSections(sections);
+        expect(html.indexOf('CHARACTERS_MARKER')).toBeLessThan(html.indexOf('CONTENT_MARKER'));
+        expect(html.indexOf('WORLDS_MARKER')).toBeLessThan(html.indexOf('CONTENT_MARKER'));
+    });
+
+    it('should emit sections in order: cover → characters → worlds → toc → content → afterword', () => {
+        const html = composeExportSections(sections);
+        const order = [
+            html.indexOf('COVER_MARKER'),
+            html.indexOf('CHARACTERS_MARKER'),
+            html.indexOf('WORLDS_MARKER'),
+            html.indexOf('TOC_MARKER'),
+            html.indexOf('CONTENT_MARKER'),
+            html.indexOf('AFTERWORD_MARKER'),
+        ];
+        const sorted = [...order].sort((a, b) => a - b);
+        expect(order).toEqual(sorted);
+    });
+
+    it('should place characters BEFORE worlds (登場人物 → 世界観・用語集)', () => {
+        const html = composeExportSections(sections);
+        expect(html.indexOf('CHARACTERS_MARKER')).toBeLessThan(html.indexOf('WORLDS_MARKER'));
+    });
+
+    it('should place toc BEFORE content (目次 → 本文)', () => {
+        const html = composeExportSections(sections);
+        expect(html.indexOf('TOC_MARKER')).toBeLessThan(html.indexOf('CONTENT_MARKER'));
+    });
+
+    it('should place afterword LAST', () => {
+        const html = composeExportSections(sections);
+        const afterwordIdx = html.indexOf('AFTERWORD_MARKER');
+        ['COVER_MARKER', 'CHARACTERS_MARKER', 'WORLDS_MARKER', 'TOC_MARKER', 'CONTENT_MARKER'].forEach(marker => {
+            expect(html.indexOf(marker)).toBeLessThan(afterwordIdx);
+        });
+    });
+
+    it('should emit empty sections unchanged (no marker injection for empty strings)', () => {
+        const html = composeExportSections({
+            cover: '',
+            characters: '<div>CHARACTERS_MARKER</div>',
+            worlds: '',
+            toc: '',
+            content: '<div>CONTENT_MARKER</div>',
+            afterword: '',
+        });
+        expect(html).toContain('CHARACTERS_MARKER');
+        expect(html).toContain('CONTENT_MARKER');
+        expect(html.indexOf('CHARACTERS_MARKER')).toBeLessThan(html.indexOf('CONTENT_MARKER'));
     });
 });
 

--- a/utils/htmlExport.ts
+++ b/utils/htmlExport.ts
@@ -43,3 +43,23 @@ export function buildCharacterAppendixHtml(
                     </div>
                 `;
 }
+
+export interface ExportSections {
+    cover: string;
+    characters: string;
+    worlds: string;
+    toc: string;
+    content: string;
+    afterword: string;
+}
+
+export function composeExportSections(parts: ExportSections): string {
+    return [
+        parts.cover,
+        parts.characters,
+        parts.worlds,
+        parts.toc,
+        parts.content,
+        parts.afterword,
+    ].join('\n');
+}


### PR DESCRIPTION
## Summary

- HTML 書き出しで section の出力順を変更
- 旧: `題名 → 本文 → 登場人物 → 世界観・用語集 → あとがき`
- 新: `題名 → 登場人物 → 世界観・用語集 → 目次 → 本文 → あとがき`
- 理由: 旧構成は本文を読み進める前にキャラ/世界観を確認できず不自然 (ユーザー報告)。設定資料を先に出すことで読者が本文に入る前に登場人物・世界観を把握できる
- 目次 (TOC) は本文の章リストなので本文の直前に配置

## 修正内容

| ファイル | 変更 |
|---|---|
| `utils/htmlExport.ts` | `composeExportSections(parts: ExportSections)` pure function 追加。順序を encapsulate (cover → characters → worlds → toc → content → afterword) |
| `utils/htmlExport.test.ts` | section 順序を pin する test 6 件追加 (regression: characters/worlds が content より前) |
| `store/dataSlice.ts` | `exportHtml` 内で各 section を変数化して `composeExportSections` に渡す形にリファクタ。inline if 連結を排除し順序判断を一元化 |

## Scope 判断

- **世界観 \`world.exportDescription || world.longDescription\` fallback は scope 外**: \`longDescription\` は「長文説明」という名称・意味的に妥当な fallback (PR #219 と同じ判断、変更なし)
- 既存 \`escapeHtml\` (dataSlice 内 local) と \`escapeHtmlForExport\` (utils) の二重化も touch しない (PR #219 と同じ scope 規律)

## 検証

- ✅ \`npm run lint\` (tsc --noEmit) PASS, エラー 0
- ✅ \`npm run test\` 56 files / **858 tests PASS** (新規 6 件含む、回帰なし)
- ✅ \`/code-review low\` findings なし

## Test plan (dev merge 後の手動再現確認)

dev URL で以下を確認:

- [ ] キャラクター / 世界観 / 本文 / あとがき / 目次 全て入力した状態で HTML 書き出し
- [ ] 書き出された HTML の section 順序が **題名 → 登場人物 → 世界観・用語集 → 目次 → 本文 → あとがき** になっている
- [ ] (regression) キャラなしで書き出し → 登場人物 section が出ず、世界観 → 目次 → 本文 の順で正常表示
- [ ] (regression) 世界観なしで書き出し → 世界観 section が出ず、登場人物 → 目次 → 本文 の順で正常表示
- [ ] (regression) あとがきなしで書き出し → あとがき section が出ず本文で終わる
- [ ] (regression) 目次無効で書き出し → 目次なしで 登場人物 → 世界観 → 本文 の順

## prod deploy 待機

ADR-0002 「bug fix」フローに従い、dev merge 後 dev 確認 + 本田様明示 GO 後に prod deploy 実行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)