### PR TITLE
chore(export): HTML 書き出しのセクション名「世界観・用語集」→「用語説明」

### DIFF
--- a/components/HtmlExportModal.tsx
+++ b/components/HtmlExportModal.tsx
@@ -304,7 +304,7 @@ export const HtmlExportModal = ({ isOpen, onClose, onExport, displaySettings, se
 
                                 {/* World Selection */}
                                 <div>
-                                    <h4 className="text-md font-semibold text-gray-300 mb-2">世界観・用語集</h4>
+                                    <h4 className="text-md font-semibold text-gray-300 mb-2">用語説明</h4>
                                     {localWorldSettings.length > 0 ? (
                                         <>
                                             <div className="flex gap-2 mb-2">

--- a/components/WorldHelpModal.tsx
+++ b/components/WorldHelpModal.tsx
@@ -13,7 +13,7 @@ const helpData = {
     ai_settings: [
         { icon: <Icons.BotIcon className="h-5 w-5 text-indigo-300"/>, title: '詳細設定 (AIが参照)', description: 'ここに書かれた内容は、AIが物語を生成する際に、世界の詳細設定として参照します。物語の歴史、文化、地理、物理法則など、AIに記憶させておきたい情報を入力してください。' },
         { icon: <Icons.PenSquareIcon className="h-5 w-5 text-gray-300"/>, title: 'メモ (AIは非参照)', description: 'このメモはあなた専用です。AIはこの内容を見ることができないため、プロットのアイデアや今後の展開など、ネタバレを含む情報も安心して書き込めます。' },
-        { icon: <Icons.BookIcon className="h-5 w-5 text-orange-300"/>, title: '書き出し用説明文', description: 'HTML書き出し時に「世界観・用語集」として表示される説明文です。空の場合は、「詳細設定」の内容が使用されます。' },
+        { icon: <Icons.BookIcon className="h-5 w-5 text-orange-300"/>, title: '書き出し用説明文', description: 'HTML書き出し時に「用語説明」として表示される説明文です。空の場合は、「詳細設定」の内容が使用されます。' },
     ]
 };
 

--- a/store/dataSlice.exportHtml.test.ts
+++ b/store/dataSlice.exportHtml.test.ts
@@ -96,7 +96,7 @@ describe('dataSlice.exportHtml — integration: section ordering & wiring', () =
         vi.restoreAllMocks();
     });
 
-    it('regression: exported HTML must place 登場人物 and 世界観・用語集 sections BEFORE 本文', () => {
+    it('regression: exported HTML must place 登場人物 and 用語説明 sections BEFORE 本文', () => {
         const project = baseProject({
             settings: [characterFixture(), worldFixture()],
             novelContent: [{ id: 'n-1', text: '本文のテキストです。', chapterId: null }],
@@ -104,7 +104,7 @@ describe('dataSlice.exportHtml — integration: section ordering & wiring', () =
         const html = captureExportedHtml(project, fullOptions);
 
         const charsIdx = html.indexOf('<h2>登場人物</h2>');
-        const worldsIdx = html.indexOf('<h2>世界観・用語集</h2>');
+        const worldsIdx = html.indexOf('<h2>用語説明</h2>');
         const contentIdx = html.indexOf('<div class="content">');
 
         expect(charsIdx).toBeGreaterThan(-1);
@@ -114,7 +114,7 @@ describe('dataSlice.exportHtml — integration: section ordering & wiring', () =
         expect(worldsIdx).toBeLessThan(contentIdx);
     });
 
-    it('should emit sections in order: cover → 登場人物 → 世界観・用語集 → 目次 → 本文 → あとがき', () => {
+    it('should emit sections in order: cover → 登場人物 → 用語説明 → 目次 → 本文 → あとがき', () => {
         const project = baseProject({
             settings: [characterFixture(), worldFixture()],
             novelContent: [
@@ -127,7 +127,7 @@ describe('dataSlice.exportHtml — integration: section ordering & wiring', () =
         const positions = [
             { name: 'cover', idx: html.indexOf('<div class="cover">') },
             { name: 'characters', idx: html.indexOf('<h2>登場人物</h2>') },
-            { name: 'worlds', idx: html.indexOf('<h2>世界観・用語集</h2>') },
+            { name: 'worlds', idx: html.indexOf('<h2>用語説明</h2>') },
             { name: 'toc', idx: html.indexOf('<h2>目次</h2>') },
             { name: 'content', idx: html.indexOf('<div class="content">') },
             { name: 'afterword', idx: html.indexOf('<h2>あとがき</h2>') },
@@ -151,7 +151,7 @@ describe('dataSlice.exportHtml — integration: section ordering & wiring', () =
 
         const charsSection = html.substring(
             html.indexOf('<h2>登場人物</h2>'),
-            html.indexOf('<h2>世界観・用語集</h2>'),
+            html.indexOf('<h2>用語説明</h2>'),
         );
         expect(charsSection).toContain('キャラ名前');
         expect(charsSection).not.toContain('世界名前');
@@ -165,7 +165,7 @@ describe('dataSlice.exportHtml — integration: section ordering & wiring', () =
         const html = captureExportedHtml(project, { ...fullOptions, selectedCharacterIds: [] });
 
         expect(html).not.toContain('<h2>登場人物</h2>');
-        const worldsIdx = html.indexOf('<h2>世界観・用語集</h2>');
+        const worldsIdx = html.indexOf('<h2>用語説明</h2>');
         const contentIdx = html.indexOf('<div class="content">');
         expect(worldsIdx).toBeGreaterThan(-1);
         expect(worldsIdx).toBeLessThan(contentIdx);
@@ -178,7 +178,7 @@ describe('dataSlice.exportHtml — integration: section ordering & wiring', () =
         });
         const html = captureExportedHtml(project, { ...fullOptions, selectedWorldIds: [] });
 
-        expect(html).not.toContain('<h2>世界観・用語集</h2>');
+        expect(html).not.toContain('<h2>用語説明</h2>');
         const charsIdx = html.indexOf('<h2>登場人物</h2>');
         const contentIdx = html.indexOf('<div class="content">');
         expect(charsIdx).toBeGreaterThan(-1);

--- a/store/dataSlice.ts
+++ b/store/dataSlice.ts
@@ -962,7 +962,7 @@ export const createDataSlice = (set, get): DataSlice => ({
                 </div>`;
         const worldsSection = worldSettingsToExport.length > 0 ? `
                     <div class="appendix">
-                        <h2>世界観・用語集</h2>
+                        <h2>用語説明</h2>
                         ${worldSettingsToExport.map(world => `
                             <div>
                                 <h3>${escapeHtml(world.name)}</h3>

--- a/utils/htmlExport.test.ts
+++ b/utils/htmlExport.test.ts
@@ -163,7 +163,7 @@ describe('composeExportSections (section ordering)', () => {
         expect(order).toEqual(sorted);
     });
 
-    it('should place characters BEFORE worlds (登場人物 → 世界観・用語集)', () => {
+    it('should place characters BEFORE worlds (登場人物 → 用語説明)', () => {
         const html = composeExportSections(sections);
         expect(html.indexOf('CHARACTERS_MARKER')).toBeLessThan(html.indexOf('WORLDS_MARKER'));
     });


### PR DESCRIPTION
## Summary
- HTML 書き出しで表示される `<h2>世界観・用語集</h2>` を `<h2>用語説明</h2>` に変更（読み手にとってより自然な名称）
- 同名で連動する UI 3 箇所（書き出しモーダル / 世界観ヘルプ / テスト assertion / テスト名）を一括統一
- セクションの並び順・出力構造・選択 UI のロジックは無変更（リネーム only）

### 変更ファイル (5)
- `store/dataSlice.ts` — 出力 HTML の `<h2>` ラベル
- `components/HtmlExportModal.tsx` — 書き出しモーダル内の対象セクション見出し
- `components/WorldHelpModal.tsx` — 「書き出し用説明文」ヘルプ文中の引用名
- `store/dataSlice.exportHtml.test.ts` — 5 箇所の assertion 文字列 + test 名 2 件
- `utils/htmlExport.test.ts` — test 名 1 件

## Test plan
- [x] `npm run lint`（tsc --noEmit）PASS
- [x] `npm run test -- --run` 864 / 864 PASS（exportHtml regression を含む）
- [ ] 次セッションで実機 HTML 書き出しを 1 回実行し `<h2>用語説明</h2>` が描画されること、書き出しモーダル右ペインの見出しが「用語説明」に変わっていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)