### PR TITLE
fix(chart): キャラクター相関図のドラッグ可能領域を視覚化 + 境界クランプ

### DIFF
--- a/components/CharacterChart.tsx
+++ b/components/CharacterChart.tsx
@@ -253,7 +253,7 @@ export const CharacterChartModal = ({ isOpen, onClose, characters, relations, no
                     </div>
                 </div>
 
-                <div className="flex-grow relative overflow-auto bg-gray-900/50" onClick={() => setFirstSelectionForAdd(null)}>
+                <div className="flex-grow relative overflow-hidden bg-gray-900/50" onClick={() => setFirstSelectionForAdd(null)}>
                     {mode === 'delete_relation' && (
                         <div className="absolute top-4 inset-x-0 mx-auto w-max z-30 bg-red-600 text-white px-4 py-1.5 rounded-full text-sm font-bold shadow-lg animate-bounce">
                             削除したい関係の線をクリックしてください
@@ -265,14 +265,20 @@ export const CharacterChartModal = ({ isOpen, onClose, characters, relations, no
                         </div>
                     )}
 
-                    <svg id="tutorial-chart-svg" ref={svgRef} width="800" height="600" viewBox="0 0 800 600" className={`mx-auto ${mode === 'add_relation' ? 'cursor-crosshair' : ''}`}
+                    <svg id="tutorial-chart-svg" ref={svgRef} viewBox="0 0 800 600" preserveAspectRatio="xMidYMid meet" className={`w-full h-full block ${mode === 'add_relation' ? 'cursor-crosshair' : ''}`}
                          onMouseMove={(e) => {
                              if (!activeDrag) return;
                              const p = getSVGPoint(e);
-                             setLocalNodes(prev => prev.map(n => n.id === activeDrag.nodeId ? { ...n, x: p.x - activeDrag.offsetX, y: p.y - activeDrag.offsetY } : n));
+                             const NODE_R = 32;
+                             const nextX = Math.max(NODE_R, Math.min(800 - NODE_R, p.x - activeDrag.offsetX));
+                             const nextY = Math.max(NODE_R, Math.min(600 - NODE_R, p.y - activeDrag.offsetY));
+                             setLocalNodes(prev => prev.map(n => n.id === activeDrag.nodeId ? { ...n, x: nextX, y: nextY } : n));
                          }}
                          onMouseUp={() => setActiveDrag(null)}>
-                        
+
+                        {/* ドラッグ可能領域の視覚化 */}
+                        <rect x="2" y="2" width="796" height="596" rx="10" fill="rgba(30,41,59,0.35)" stroke="rgba(148,163,184,0.45)" strokeWidth="1.5" strokeDasharray="8 6" pointerEvents="none" />
+
                         <g>
                             {relationsWithCurveData.map((rel, i) => {
                                 const s = nodesById[rel.source], t = nodesById[rel.target];


### PR DESCRIPTION
## Summary
- 相関図モーダル内で SVG が 800x600 固定 + `mx-auto` 中央配置だったため、モーダル下端まで描画領域が届かず「ウィンドウ下端まで動かせない」「動ける範囲が分からない」というユーザー指摘の改修
- SVG を親コンテナにフィット（aspect 4:3 維持）+ 境界 dashed rect の追加 + ドラッグ時のクランプ実装

## Changes (`components/CharacterChart.tsx`)
- SVG 属性: `width=800 height=600 mx-auto` → `w-full h-full preserveAspectRatio="xMidYMid meet"` (viewBox 800x600 は維持、既存ノード座標と互換)
- 親 `div`: `overflow-auto` → `overflow-hidden`
- 視覚境界: SVG 内に `<rect>` (rx=10, 薄い背景 + 破線 stroke + `pointerEvents="none"`) をノード描画より背面に追加
- ドラッグ `onMouseMove`: ノード半径 32 を考慮した `Math.max/min` クランプを追加（中心が 32..768, 32..568 に収まる）

## Test plan
- [x] `npm run lint` (tsc --noEmit) PASS
- [x] `npm run test -- --run` 864 / 864 PASS
- [ ] dev で Playwright MCP / 実機操作: 境界 rect が見える、ドラッグでノードが rect を越えられない
- [ ] prod 反映後に再確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)