### PR TITLE
feat(export): HTML 書き出しの「用語説明」セクションに knowledge を含める

### DIFF
--- a/components/HtmlExportModal.tsx
+++ b/components/HtmlExportModal.tsx
@@ -2,7 +2,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import * as Icons from '../icons';
-import { DisplaySettings, SettingItem } from '../types';
+import { DisplaySettings, KnowledgeItem, SettingItem } from '../types';
 import { compressImage } from '../utils';
 
 interface HtmlExportModalProps {
@@ -11,6 +11,7 @@ interface HtmlExportModalProps {
   onExport: (options: any) => void;
   displaySettings: DisplaySettings;
   settings: SettingItem[];
+  knowledgeBase: KnowledgeItem[];
 }
 
 const Checkbox: React.FC<{
@@ -98,9 +99,10 @@ const DescriptionEditorPopover = ({ editingItem, onClose, onSave }) => {
 };
 
 
-export const HtmlExportModal = ({ isOpen, onClose, onExport, displaySettings, settings }: HtmlExportModalProps) => {
+export const HtmlExportModal = ({ isOpen, onClose, onExport, displaySettings, settings, knowledgeBase }: HtmlExportModalProps) => {
     const [localCharacters, setLocalCharacters] = useState<SettingItem[]>([]);
     const [localWorldSettings, setLocalWorldSettings] = useState<SettingItem[]>([]);
+    const [localKnowledge, setLocalKnowledge] = useState<KnowledgeItem[]>([]);
     const [editingItem, setEditingItem] = useState<{ item: SettingItem; type: 'character' | 'world'; anchorEl: HTMLElement } | null>(null);
 
     const [options, setOptions] = useState({
@@ -115,15 +117,18 @@ export const HtmlExportModal = ({ isOpen, onClose, onExport, displaySettings, se
         selectedCharacterIds: [],
         addCharacterImages: true,
         selectedWorldIds: [],
+        selectedKnowledgeIds: [],
         afterword: '',
     });
-    
+
     useEffect(() => {
         if (isOpen) {
             const chars = settings.filter(s => s.type === 'character');
             const worlds = settings.filter(s => s.type === 'world');
+            const knowledgeSelectable = (knowledgeBase || []).filter(k => !k.isArchived);
             setLocalCharacters(chars);
             setLocalWorldSettings(worlds);
+            setLocalKnowledge(knowledgeSelectable);
 
             setOptions(prev => ({
                 ...prev,
@@ -132,11 +137,12 @@ export const HtmlExportModal = ({ isOpen, onClose, onExport, displaySettings, se
                 theme: displaySettings.theme,
                 selectedCharacterIds: chars.map(c => c.id),
                 selectedWorldIds: worlds.map(w => w.id),
+                selectedKnowledgeIds: knowledgeSelectable.map(k => k.id),
             }));
         } else {
             setEditingItem(null);
         }
-    }, [isOpen, displaySettings, settings]);
+    }, [isOpen, displaySettings, settings, knowledgeBase]);
 
     const handleChange = (key, value) => {
         setOptions(prev => ({ ...prev, [key]: value }));
@@ -160,6 +166,7 @@ export const HtmlExportModal = ({ isOpen, onClose, onExport, displaySettings, se
             ...options,
             charactersToExport: localCharacters.filter(c => options.selectedCharacterIds.includes(c.id)),
             worldSettingsToExport: localWorldSettings.filter(w => options.selectedWorldIds.includes(w.id)),
+            knowledgeToExport: localKnowledge.filter(k => options.selectedKnowledgeIds.includes(k.id)),
         });
         onClose();
     };
@@ -328,6 +335,26 @@ export const HtmlExportModal = ({ isOpen, onClose, onExport, displaySettings, se
                                             </div>
                                         </>
                                     ) : <p className="text-sm text-gray-500">追加できる世界観設定がありません。</p>}
+                                </div>
+
+                                {/* Knowledge Selection */}
+                                <div>
+                                    <h4 className="text-md font-semibold text-gray-300 mb-2">ナレッジ (用語説明に含めます)</h4>
+                                    {localKnowledge.length > 0 ? (
+                                        <>
+                                            <div className="flex gap-2 mb-2">
+                                                <button onClick={() => handleSelectAll('selectedKnowledgeIds', localKnowledge)} className="text-xs px-2 py-1 bg-gray-700 rounded hover:bg-gray-600 text-white">すべて選択</button>
+                                                <button onClick={() => handleDeselectAll('selectedKnowledgeIds')} className="text-xs px-2 py-1 bg-gray-700 rounded hover:bg-gray-600 text-white">すべて解除</button>
+                                            </div>
+                                            <div className="max-h-32 overflow-y-auto space-y-1 p-2 border border-gray-700 rounded-md">
+                                                {localKnowledge.map(item => (
+                                                    <div key={item.id} className="flex items-center justify-between">
+                                                        <Checkbox id={`knowledge-${item.id}`} label={item.name} checked={options.selectedKnowledgeIds.includes(item.id)} onChange={() => handleSelectionChange('selectedKnowledgeIds', item.id)} />
+                                                    </div>
+                                                ))}
+                                            </div>
+                                        </>
+                                    ) : <p className="text-sm text-gray-500">追加できるナレッジがありません。</p>}
                                 </div>
                             </div>
                         </div>

--- a/components/ModalManager.tsx
+++ b/components/ModalManager.tsx
@@ -122,7 +122,7 @@ export const ModalManager: React.FC<ModalManagerProps> = ({ displayMenuButtonRef
                 modalContent = <CharacterChartModal isOpen={true} onClose={closeModal} characters={settings.filter(s => s.type === 'character')} relations={activeProjectData?.characterRelations || []} nodePositions={activeProjectData?.nodePositions || []} onSave={handleSaveChart} onHelpClick={(topic) => openModal('help', { topic })} isMobile={isMobile} />;
                 break;
             case 'htmlExport':
-                modalContent = <HtmlExportModal isOpen={true} onClose={closeModal} onExport={exportHtml} displaySettings={displaySettings} settings={settings} />;
+                modalContent = <HtmlExportModal isOpen={true} onClose={closeModal} onExport={exportHtml} displaySettings={displaySettings} settings={settings} knowledgeBase={knowledgeBase} />;
                 break;
             case 'timeline':
                 modalContent = <TimelineModal isOpen={true} onClose={closeModal} timeline={timeline} lanes={timelineLanes} allSettings={settings} plotBoard={plotBoard} isMobile={isMobile} />;

--- a/store/dataSlice.exportHtml.test.ts
+++ b/store/dataSlice.exportHtml.test.ts
@@ -5,7 +5,7 @@ vi.mock('../analysisApi', () => ({
 }));
 
 import { createDataSlice } from './dataSlice';
-import type { Project, SettingItem } from '../types';
+import type { KnowledgeItem, Project, SettingItem } from '../types';
 
 const baseProject = (overrides: Partial<Project> = {}): Project => ({
     id: 'p-1',
@@ -41,6 +41,13 @@ const worldFixture = (overrides: Partial<SettingItem> = {}): SettingItem => ({
     type: 'world',
     name: '魔法王国',
     longDescription: '魔法に満ちた世界',
+    ...overrides,
+});
+
+const knowledgeFixture = (overrides: Partial<KnowledgeItem> = {}): KnowledgeItem => ({
+    id: 'k-1',
+    name: '霊脈',
+    content: '大地に流れる魔力の通り道。',
     ...overrides,
 });
 
@@ -192,5 +199,60 @@ describe('dataSlice.exportHtml — integration: section ordering & wiring', () =
         const html = captureExportedHtml(project, { ...fullOptions, afterword: '' });
 
         expect(html).not.toContain('<h2>あとがき</h2>');
+    });
+
+    it('用語説明 section に world と knowledge が world → knowledge の順で並ぶ', () => {
+        const project = baseProject({
+            settings: [worldFixture({ id: 'w-1', name: '魔法王国', longDescription: '魔法の国' })],
+            knowledgeBase: [knowledgeFixture({ id: 'k-1', name: '霊脈', content: '魔力の通り道' })],
+            novelContent: [{ id: 'n-1', text: '本文', chapterId: null }],
+        });
+        const html = captureExportedHtml(project, { ...fullOptions, selectedKnowledgeIds: ['k-1'] });
+
+        expect(html).toContain('<h2>用語説明</h2>');
+        const worldIdx = html.indexOf('魔法王国');
+        const knowledgeIdx = html.indexOf('霊脈');
+        expect(worldIdx).toBeGreaterThan(-1);
+        expect(knowledgeIdx).toBeGreaterThan(-1);
+        expect(worldIdx).toBeLessThan(knowledgeIdx);
+        expect(html).toContain('魔力の通り道');
+    });
+
+    it('世界観なし + knowledge あり → 用語説明 section が knowledge だけで出る', () => {
+        const project = baseProject({
+            settings: [characterFixture()],
+            knowledgeBase: [knowledgeFixture({ id: 'k-2', name: '魔導士団', content: '王国に仕える組織' })],
+            novelContent: [{ id: 'n-1', text: '本文', chapterId: null }],
+        });
+        const html = captureExportedHtml(project, { ...fullOptions, selectedWorldIds: [], selectedKnowledgeIds: ['k-2'] });
+
+        expect(html).toContain('<h2>用語説明</h2>');
+        expect(html).toContain('魔導士団');
+        expect(html).toContain('王国に仕える組織');
+    });
+
+    it('selectedKnowledgeIds 未指定 (後方互換) でも従来どおり world のみ出力される', () => {
+        const project = baseProject({
+            settings: [worldFixture()],
+            knowledgeBase: [knowledgeFixture({ id: 'k-x', name: '出ないナレッジ', content: 'これは出ない' })],
+            novelContent: [{ id: 'n-1', text: '本文', chapterId: null }],
+        });
+        const html = captureExportedHtml(project, fullOptions);
+
+        expect(html).toContain('<h2>用語説明</h2>');
+        expect(html).toContain('魔法王国');
+        expect(html).not.toContain('出ないナレッジ');
+        expect(html).not.toContain('これは出ない');
+    });
+
+    it('全選択解除 (selectedWorldIds=[] + selectedKnowledgeIds=[]) → 用語説明 section が出ない', () => {
+        const project = baseProject({
+            settings: [worldFixture(), characterFixture()],
+            knowledgeBase: [knowledgeFixture()],
+            novelContent: [{ id: 'n-1', text: '本文', chapterId: null }],
+        });
+        const html = captureExportedHtml(project, { ...fullOptions, selectedWorldIds: [], selectedKnowledgeIds: [] });
+
+        expect(html).not.toContain('<h2>用語説明</h2>');
     });
 });

--- a/store/dataSlice.ts
+++ b/store/dataSlice.ts
@@ -932,6 +932,8 @@ export const createDataSlice = (set, get): DataSlice => ({
         const escapeHtml = (unsafe) => unsafe.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#039;");
         const charactersToExport = settings.filter(s => s.type === 'character' && options.selectedCharacterIds.includes(s.id));
         const worldSettingsToExport = settings.filter(s => s.type === 'world' && options.selectedWorldIds.includes(s.id));
+        const selectedKnowledgeIds: string[] = Array.isArray(options.selectedKnowledgeIds) ? options.selectedKnowledgeIds : [];
+        const knowledgeToExport = (knowledgeBase || []).filter(k => selectedKnowledgeIds.includes(k.id));
         // 章一覧は utils.buildExportChapterEntries で生成し、本文 anchor は同じ
         // utils.exportChapterAnchorId で生成する。TOC と本文 anchor の id 形式不一致を
         // 構造的に防ぐため必ず両者を utils 経由にする (AC-11)。
@@ -960,13 +962,23 @@ export const createDataSlice = (set, get): DataSlice => ({
                         return `<div id="${anchorId}">${renderMarkdown(chunk.text, settings.filter(s => s.type === 'character'), knowledgeBase, aiSettings)}</div>`;
                     }).join('')}
                 </div>`;
-        const worldsSection = worldSettingsToExport.length > 0 ? `
+        const termsEntries: { name: string; body: string }[] = [
+            ...worldSettingsToExport.map(world => ({
+                name: world.name,
+                body: world.exportDescription || world.longDescription || '',
+            })),
+            ...knowledgeToExport.map(item => ({
+                name: item.name,
+                body: item.content || '',
+            })),
+        ];
+        const worldsSection = termsEntries.length > 0 ? `
                     <div class="appendix">
                         <h2>用語説明</h2>
-                        ${worldSettingsToExport.map(world => `
+                        ${termsEntries.map(entry => `
                             <div>
-                                <h3>${escapeHtml(world.name)}</h3>
-                                <p>${escapeHtml(world.exportDescription || world.longDescription || '')}</p>
+                                <h3>${escapeHtml(entry.name)}</h3>
+                                <p>${escapeHtml(entry.body)}</p>
                             </div>
                         `).join('')}
                     </div>


### PR DESCRIPTION
## Summary
HTML 書き出しの「用語説明」セクションに、世界観だけでなくナレッジも並べて出力できるようにする。ユーザー要望「HTML書き出しの際の \"世界観・用語集\" について、この項目に世界観だけでなく、ナレッジも含めてほしい」への対応。

## Changes (4 files, +111 / -10)
- `components/HtmlExportModal.tsx`: props に `knowledgeBase` 追加、世界観セクション直下に同パターンのナレッジ選択 UI を配置（`isArchived` は非表示、デフォルト全選択、「すべて選択 / 解除」付き）
- `components/ModalManager.tsx`: HtmlExportModal に `knowledgeBase` を wire
- `store/dataSlice.ts` (`exportHtml`): `options.selectedKnowledgeIds` を受け取り、world → knowledge の順で `<h2>用語説明</h2>` セクションへ並べる。`undefined` は空配列フォールバックで後方互換維持
- `store/dataSlice.exportHtml.test.ts`: regression 4 件追加
  - world + knowledge 並び順
  - knowledge 単独で section が出る
  - 後方互換 (`selectedKnowledgeIds` 省略時は従来どおり)
  - 両方解除で section が出ない

## Test plan
- [x] `npm run lint` (tsc --noEmit) PASS
- [x] `npm run test -- --run` 868 / 868 PASS（+4 件追加）
- [ ] dev で Playwright MCP: モーダルにナレッジ選択 UI が表示、書き出し HTML の `<h2>用語説明</h2>` セクションに world と knowledge が並ぶこと
- [ ] prod 反映後に再確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)