### PR TITLE
docs(claude-md): prod CI/CDがworkflow_dispatch専用であることを明記

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,7 +128,7 @@ Browser → fetch(/api/*) → server/routes/ → server/services/ → Vertex AI 
 - **開発**: `novel-writer-dev`（課金有効、asia-northeast1）
 - **本番**: `novel-writer-prod`（課金クォータ引き上げ待ち）
 - **ランタイム**: Cloud Run + Vertex AI（Workload Identity認証）
-- **CI/CD**: GitHub Actions → WIF → Cloud Run自動デプロイ（mainブランチ）
+- **CI/CD**: GitHub Actions → WIF → Cloud Run デプロイ。**dev のみ** `deploy.yml` が main push で自動デプロイ、**prod は** `deploy-prod.yml` が `workflow_dispatch` 専用（手動実行のみ、push trigger なし）。prod への反映確認は `gcloud run services describe --format="value(spec.template.spec.containers[0].image)"` で実際のデプロイ済みイメージのcommit shaを確認すること（自動反映を前提にしない）
 - **Docker**: マルチステージビルド（`Dockerfile`）。Vite の build-time 静的置換のため、`VITE_FIREBASE_*` 6 変数は `docker build --build-arg` で注入する必要があり、GitHub Secrets → workflow の `env:` ブロック → shell 変数の順で受け渡す（直接 `${{ secrets.* }}` を `run:` に展開しない、command injection 回避）
 - **direnv**: `.envrc` で `CLOUDSDK_ACTIVE_CONFIG_NAME=novel-writer-dev` 自動設定 + `gh auth switch --user yasushi-honda` 自動実行（direnv は shell の interactive hook (`eval "$(direnv hook bash)"`) に依存し、Claude Code Bash ツールが起動する非対話 subshell では発火しないため、補助として下記 §5 の `.claude/hooks/` で吸収）
 


### PR DESCRIPTION
## Summary
- CLAUDE.mdの「CI/CD: GitHub Actions → WIF → Cloud Run自動デプロイ（mainブランチ）」はdev/prodを区別しない曖昧な記述で、prodも自動デプロイされると誤解させる
- 実際は `deploy.yml`（dev）のみ main push で自動デプロイ、`deploy-prod.yml`（prod）は `workflow_dispatch` 専用（手動実行のみ）
- この曖昧さが直接の原因となり、前PR（#236）で「prodはCI/CDが自動デプロイする構成」と誤記する事案が発生（PR #238で訂正済み）
- 根本原因である本体側のドキュメント記述を訂正し、今後同種の誤認が再発しないようにする

「これで確実に完了したか」という確認要求を受けて実施した横断的な再検証の過程で発見。

## Test plan
- [x] `.github/workflows/deploy.yml` と `deploy-prod.yml` の `on:` 定義差分を再確認
- [x] 訂正後の記述が実態と一致することを確認
- [x] 他に同種の誤解を招く記述が残っていないか `grep -rn "自動デプロイ"` で全文書横断確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)