### PR TITLE
fix(prompt-safety): estimateElementBytes を export し AC-3 backward compat を直接 pin

### DIFF
--- a/server/utils/promptSafety.test.ts
+++ b/server/utils/promptSafety.test.ts
@@ -11,6 +11,7 @@ import {
   truncateOversizedStrings,
   sanitizeForPrompt,
   createWarnAggregator,
+  estimateElementBytes,
 } from './promptSafety';
 import type { SafetyEventName } from './promptSafetyEvents';
 
@@ -1569,5 +1570,14 @@ describe('bytes-estimation-failed paired signal (Issue #149 残-B)', () => {
     const input = { items: Array.from({ length: 10 }, (_, i) => ({ id: i })) };
     stripPromptHeavyFields(input);
     expect(bytesEstimationCalls().length).toBe(0);
+  });
+
+  it('AC-3 backward compat (Issue #155): estimateElementBytes(value) を callback 未指定で直接呼んでも stringify failure 時に silent 4 byte fallback を返し、warn を emit しない', () => {
+    // Issue #155: 従来は stripPromptHeavyFields 経由の間接 pin のみで、callback 未指定
+    // 経路 (estimateElementBytes 単独呼出) を直接検証する test が存在しなかった。
+    const result = estimateElementBytes(BigInt(1));
+    expect(result).toBe(4);
+    expect(bytesEstimationCalls().length).toBe(0);
+    expect(bytesEstimationBatchCalls().length).toBe(0);
   });
 });

--- a/server/utils/promptSafety.ts
+++ b/server/utils/promptSafety.ts
@@ -141,7 +141,7 @@ export const COLLECTION_OVERFLOW_MARKER =
  * `processed element` = recurse 通過後の値 (image / non-image marker 化後の短文を含む) を想定。
  * 「leaf-level marker 化済の element は cumulative 圧迫しない」を保証する。
  */
-function estimateElementBytes(value: unknown, onStringifyFailure?: () => void): number {
+export function estimateElementBytes(value: unknown, onStringifyFailure?: () => void): number {
   try {
     return Buffer.byteLength(JSON.stringify(value) ?? 'null', 'utf8');
   } catch {


### PR DESCRIPTION
## Summary
- Issue #155 の残課題（AC-3 backward compat test の検証経路 gap）を解消
- `estimateElementBytes` を `server/utils/promptSafety.ts` から export
- `promptSafety.test.ts` に callback 未指定経路（BigInt 直接呼出 → 4 byte fallback + warn emit ゼロ）を直接検証する test を追加（既存の間接 test は維持）

## Test plan
- [x] `npx vitest run server/utils/promptSafety.test.ts` — 104/104 PASS
- [x] `npx vitest run`（全体） — 891/891 PASS（skip 5 件は既存分、新規追加分含む）
- [x] `npm run lint`（tsc --noEmit） — エラーなし

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)