### PR TITLE
feat(image-gen): finishReasonを捕捉し安全フィルタ拒否を判別可能にする

### DIFF
--- a/server/services/imageService.test.ts
+++ b/server/services/imageService.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { logger } from '../utils/logger';
 
 // aiClient 全体 (@google/genai の GoogleGenAI インスタンス構築) はモック整備コストが高いため、
 // wrapper である getAiClient のみを差し替える。これにより generateImage() 内の
@@ -25,10 +26,82 @@ const fulfilledNoImageResponse = () => ({
     candidates: [{ content: { parts: [{ text: 'safety block' }] } }],
 });
 
+// Issue #243: 安全フィルタ拒否等で画像データが欠落したケースの finishReason 捕捉検証用。
+const fulfilledNoImageResponseWithFinishReason = () => ({
+    candidates: [{
+        content: { parts: [{ text: 'safety block' }] },
+        finishReason: 'SAFETY',
+        finishMessage: 'Blocked due to safety guidelines.',
+    }],
+    promptFeedback: { blockReason: 'SAFETY' },
+});
+
 describe('generateImage - Nano Banana 2 Lite (Gemini 3.1 Flash-Lite Image) 並列2回呼び出し（quota制約による段階生成方式）', () => {
+    let warnSpy: ReturnType<typeof vi.spyOn>;
+
     beforeEach(() => {
         generateContentMock.mockReset();
         vertexAiModeMock = true;
+        warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    });
+
+    function imageOmittedCalls(): unknown[][] {
+        return warnSpy.mock.calls.filter(
+            (c) => (c[0] as { imageGenerationEvent?: string }).imageGenerationEvent === 'no-image-data'
+        );
+    }
+
+    it('Issue #243: finishReason: SAFETY で画像データ無し → logger.warn に finishReason / finishMessage / blockReason を記録する', async () => {
+        generateContentMock
+            .mockResolvedValueOnce(fulfilledImageResponse())
+            .mockResolvedValueOnce(fulfilledNoImageResponseWithFinishReason());
+        const { generateImage } = await import('./imageService');
+        const { PartialSuccessError } = await import('./usageService');
+
+        try {
+            await generateImage('prompt');
+            expect.unreachable('should have thrown');
+        } catch (err) {
+            expect(err).toBeInstanceOf(PartialSuccessError);
+        }
+
+        const calls = imageOmittedCalls();
+        expect(calls).toHaveLength(1);
+        const payload = calls[0]![0] as Record<string, unknown>;
+        expect(payload.finishReason).toBe('SAFETY');
+        expect(payload.finishMessage).toBe('Blocked due to safety guidelines.');
+        expect(payload.blockReason).toBe('SAFETY');
+    });
+
+    it('Issue #243: 画像データありの成功時は no-image-data ログを発火しない（false positive ゼロ）', async () => {
+        generateContentMock.mockResolvedValue(fulfilledImageResponse());
+        const { generateImage } = await import('./imageService');
+
+        await generateImage('prompt');
+
+        expect(imageOmittedCalls()).toHaveLength(0);
+    });
+
+    it('Issue #243: finishReason が undefined の応答でも例外を投げず、null として記録する（防御的ケース）', async () => {
+        generateContentMock.mockResolvedValue(fulfilledNoImageResponse());
+        const { generateImage } = await import('./imageService');
+
+        try {
+            await generateImage('prompt');
+            expect.unreachable('should have thrown');
+        } catch {
+            // 全滅ケースなので Error が throw される (別テストで既に検証済み)。ここでは
+            // logger.warn 呼出の有無のみ検証する。
+        }
+
+        const calls = imageOmittedCalls();
+        expect(calls).toHaveLength(2);
+        for (const call of calls) {
+            const payload = call[0] as Record<string, unknown>;
+            expect(payload.finishReason).toBeNull();
+            expect(payload.finishMessage).toBeNull();
+            expect(payload.blockReason).toBeNull();
+        }
     });
 
     it('2件とも画像を返す場合、2枚の data URI 配列を返す', async () => {

--- a/server/services/imageService.ts
+++ b/server/services/imageService.ts
@@ -2,6 +2,7 @@ import { GenerateContentResponse, Modality } from '@google/genai';
 import { getAiClient, IMAGE_MODEL, isVertexAiMode } from '../aiClient';
 import { PartialSuccessError } from './usageService';
 import { IMAGE_GENERATION_BATCH_SIZE } from '../../shared/imageGenerationConfig';
+import { logger } from '../utils/logger';
 
 // 並列数は quota 上限 (shared/imageGenerationConfig.ts 参照) に合わせる。4枚欲しい場合は
 // 呼び出し元 (ImageGenerationModal) の「追加生成」ボタンで本関数を再度呼び出す段階生成方式とする。
@@ -15,6 +16,20 @@ const extractImageDataUri = (response: GenerateContentResponse): string | null =
     }
     const mimeType = imagePart.inlineData.mimeType || 'image/png';
     return `data:${mimeType};base64,${imagePart.inlineData.data}`;
+};
+
+// Issue #243: 「呼出は成功したが画像データが無い」現象 (GCP実測 n=14 中 13 件が関与) の原因を
+// 事後判別可能にするため、安全フィルタ拒否等で使われる finishReason 系フィールドのみを記録する
+// (プロンプト本文・生成テキストは含めない、PII/機密混入を避けるため promptSafety.ts と同じ方針)。
+const logImageOmittedNoData = (response: GenerateContentResponse): void => {
+    const candidate = response.candidates?.[0];
+    logger.warn({
+        message: 'imageService: generateContent は成功したが画像データが含まれていない（安全フィルタ拒否の可能性）',
+        imageGenerationEvent: 'no-image-data',
+        finishReason: candidate?.finishReason ?? null,
+        finishMessage: candidate?.finishMessage ?? null,
+        blockReason: response.promptFeedback?.blockReason ?? null,
+    });
 };
 
 export const generateImage = async (prompt: string): Promise<string[]> => {
@@ -53,7 +68,11 @@ export const generateImage = async (prompt: string): Promise<string[]> => {
             continue;
         }
         const uri = extractImageDataUri(result.value);
-        if (uri !== null) images.push(uri);
+        if (uri !== null) {
+            images.push(uri);
+        } else {
+            logImageOmittedNoData(result.value);
+        }
     }
 
     if (images.length === NUM_IMAGES) {


### PR DESCRIPTION
## Summary
- Issue #243 対応候補(a): `generateImage` が「成功したが画像データなし」の応答を受けた際、`finishReason` / `finishMessage` / `promptFeedback.blockReason` を `logger.warn` に記録するようにした
- GCP Cloud Loggingの実ログ調査（n=14中13件が本現象に関与）+ 外部一次情報（litellm等での既知のfinishReason欠落バグ報告）を踏まえた対応
- スコープは(a)のみ。ユーザー向けメッセージ分岐(b)・プロンプト依存性の追加検証(c)は対象外（判断待ち）
- プロンプト本文・生成テキストはログに含めない（`promptSafety.ts`と同じPII配慮方針）

## Test plan
- [x] TDD: Red→Green確認（先にテスト3件を追加し失敗を確認、実装後にPASS）
- [x] `npx vitest run server/services/imageService.test.ts` — 16/16 PASS
- [x] `npx vitest run`（全体） — 894/894 PASS
- [x] `npm run lint`（tsc --noEmit） — エラーなし
- [x] `/safe-refactor` — 指摘0件
- [x] `/code-review low` — 指摘0件

Closes #243（対応候補(a)のみ、(b)(c)は別途判断）

🤖 Generated with [Claude Code](https://claude.com/claude-code)