### PR TITLE
docs(dev-portal): Tier 1月間割当のsen合計値(10000)を明記

### DIFF
--- a/public/dev/index.html
+++ b/public/dev/index.html
@@ -1186,7 +1186,7 @@ gantt
     <details>
       <summary>「クォータが足りません」と出る</summary>
       <div>
-        <p>Tier 1 は月あたり 100 円相当（sen 単位）の割当です。route ごとの単価は概ね：小説生成 200 sen、キャラ・世界観 100 sen、画像生成 1200 sen（2枚分）、ユーティリティ 50–100 sen。</p>
+        <p>Tier 1 は月あたり 100 円相当（合計 10000 sen、1 sen = 1/100 円）の割当です。route ごとの単価は概ね：小説生成 200 sen、キャラ・世界観 100 sen、画像生成 1200 sen（2枚分）、ユーティリティ 50–100 sen。</p>
       </div>
     </details>
     <details>


### PR DESCRIPTION
## Summary
- `public/dev/index.html` FAQ「クォータが足りません」の記述が「100円相当（sen単位）」とだけ書かれ、合計sen数(10000)が明記されていなかったため追記
- `server/services/usageConfig.ts` の `MONTHLY_LIMIT_SEN.free = 10000` と一致する形で明記

## Test plan
- [x] `npm run lint` PASS
- [x] `npm run test` PASS (894/894)
- [x] ドキュメントのみの変更

🤖 Generated with [Claude Code](https://claude.com/claude-code)