### PR TITLE
feat(infra): /dev/開発者ポータルをprodビルドから除外

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,6 +71,7 @@ jobs:
             --build-arg VITE_FIREBASE_STORAGE_BUCKET="$VITE_FIREBASE_STORAGE_BUCKET" \
             --build-arg VITE_FIREBASE_MESSAGING_SENDER_ID="$VITE_FIREBASE_MESSAGING_SENDER_ID" \
             --build-arg VITE_FIREBASE_APP_ID="$VITE_FIREBASE_APP_ID" \
+            --build-arg ENABLE_DEV_PORTAL=true \
             -t "$IMAGE" .
           docker push "$IMAGE"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,9 +111,9 @@ Browser → fetch(/api/*) → server/routes/ → server/services/ → Vertex AI 
 
 ### 開発者ポータル `/dev/` (PR #84)
 
-`public/dev/index.html` を Vite の publicDir 経由で `dist/dev/index.html` として配信する単一 HTML ポータル。本番 Cloud Run の `/dev/` で公開（認証ゲートなし、`<meta robots="noindex,nofollow">`）。本体アプリの SPA fallback より先に `express.static(distPath)` が解決するため非干渉。
+`public/dev/index.html` を Vite の publicDir 経由で `dist/dev/index.html` として配信する単一 HTML ポータル。**dev Cloud Run の `/dev/` でのみ公開**（認証ゲートなし、`<meta robots="noindex,nofollow">`）。本体アプリの SPA fallback より先に `express.static(distPath)` が解決するため非干渉。**2026-07-06〜 prod ビルドからは除外**（`Dockerfile` の `ENABLE_DEV_PORTAL` build-arg、`deploy.yml` のみ `true` を渡し `public/dev` を vite build 前に削除。クォータ単価・アーキテクチャ等の内部情報を無料版公開開始を機に prod の未認証URLから切り離す判断、`deploy-prod.yml` は変更なしで除外がデフォルト）。prod で `/dev/*` にアクセスすると SPA fallback (本体アプリの `index.html`) が返る
 
-- **目的**: 目視動作確認チェックリスト（50 項目 / 10 カテゴリ、`localStorage` 永続化）+ Mermaid 図 8 枚によるアーキテクチャ俯瞰 + エンドユーザー向け簡易マニュアル + 開発者情報を 1 ページで提供
+- **目的**: 目視動作確認チェックリスト（50 項目 / 10 カテゴリ、`localStorage` 永続化）+ Mermaid 図 8 枚によるアーキテクチャ俯瞰 + エンドユーザー向け簡易マニュアル + 開発者情報を 1 ページで提供（dev 環境限定）
 - **依存**: Mermaid を CDN (`https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs`) からロード。本番 FE bundle には未同梱（`/dev/` 専用、bundle サイズ影響ゼロ）
 - **CSP**: `server/index.ts` の helmet `scriptSrc` に `https://cdn.jsdelivr.net` を追加（`styleSrc` 等は変更なし、最小権限）
 - **更新運用**: マイルストーン進捗・テスト件数・Last Updated はファイル内に固定文字列で埋め込み。grep で機械的に書き換える（`v0.0.0 (M7-α)` / `2026-05-01` / `Tests · 435 / 435 PASS` / `<div class="milestone-row">` ブロックの状態）

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,9 @@ ARG VITE_FIREBASE_PROJECT_ID
 ARG VITE_FIREBASE_STORAGE_BUCKET
 ARG VITE_FIREBASE_MESSAGING_SENDER_ID
 ARG VITE_FIREBASE_APP_ID
+# dev 環境のみ true を渡す。/dev/ 開発者ポータルはクォータ単価・アーキテクチャ等の
+# 内部情報を含むため、無料版公開開始 (2026-07-06) を機に prod ビルドからは除外する。
+ARG ENABLE_DEV_PORTAL=""
 
 ENV VITE_FIREBASE_API_KEY=$VITE_FIREBASE_API_KEY \
     VITE_FIREBASE_AUTH_DOMAIN=$VITE_FIREBASE_AUTH_DOMAIN \
@@ -19,6 +22,7 @@ COPY package*.json ./
 RUN npm ci
 
 COPY . .
+RUN if [ "$ENABLE_DEV_PORTAL" != "true" ]; then rm -rf public/dev; fi
 RUN npx vite build
 
 FROM node:22-slim AS runner


### PR DESCRIPTION
## Summary
- `/dev/` 開発者ポータル(クォータ単価・Vertex AIモデル名・アーキテクチャ図等の内部情報を含む、認証ゲートなし)を、無料版公開開始(2026-07-06)を機にprodビルドから除外
- `Dockerfile` に `ENABLE_DEV_PORTAL` build-arg を追加(デフォルト除外)。`deploy.yml`(dev)のみ `true` を渡し、`deploy-prod.yml` は変更なし(除外がデフォルト)
- prodで `/dev/*` にアクセスするとSPA fallback(本体アプリ)が返る(404ではないが内部情報は含まれない)

## Test plan
- [x] `npm run lint` PASS
- [x] `npm run test` PASS (894/894)
- [x] ローカルで `docker build --target builder` を2パターン実行し実機確認:
  - `ENABLE_DEV_PORTAL` 未指定 → `dist/dev` が存在しないことを確認
  - `ENABLE_DEV_PORTAL=true` → `dist/dev/index.html` が存在することを確認
- [ ] 次回prodデプロイ後、実際に `/dev/` へアクセスしSPA fallbackが返ることを確認(このPR自体はCI/CD設定変更のみでprodへの即時影響はない)

🤖 Generated with [Claude Code](https://claude.com/claude-code)