### PR TITLE
fix(image-gen): ハードコードされた1girlタグがVertex AI安全フィルタを誘発する問題を修正

### DIFF
--- a/components/ImageGenerationModal.tsx
+++ b/components/ImageGenerationModal.tsx
@@ -216,7 +216,7 @@ export const ImageGenerationModal = ({ isOpen, onClose, onGenerate, onGeneratePr
                     <div className="mt-auto pt-4">
                         <button
                             onClick={() => {
-                                const prompt = `masterpiece, best quality, anime style, full body, 1girl, solo, simple white background, no text, no letters, ${characterDescription.replace(/[\n\r:]+/g, ', ')}`;
+                                const prompt = `masterpiece, best quality, anime style, full body, solo, adult, simple white background, no text, no letters, ${characterDescription.replace(/[\n\r:]+/g, ', ')}`;
                                 handleGenerate(prompt);
                             }}
                             disabled={!canUseAi || isBusy || !characterDescription.trim()}

--- a/server/services/characterService.ts
+++ b/server/services/characterService.ts
@@ -148,7 +148,7 @@ export const generateCharacterImagePrompt = async (chatHistory: ChatMessage[]) =
     **CRITICAL RULES:**
     1.  Your conversational replies ('reply' field) MUST be in Japanese.
     2.  The final image generation prompt ('finalPrompt' field) MUST be a detailed, comma-separated list of keywords in English.
-    3.  The 'finalPrompt' MUST ALWAYS start with: "masterpiece, best quality, anime style, full body, 1girl, solo, simple white background, no text, no letters, ".
+    3.  The 'finalPrompt' MUST ALWAYS start with: "masterpiece, best quality, anime style, full body, solo, adult, simple white background, no text, no letters, ".
     4.  After these initial keywords, append the detailed character description.
 
     **WORKFLOW:**


### PR DESCRIPTION
## Summary
- SNS投稿キット用スクリーンショット撮影中に、AI立ち絵生成が `finishReason: IMAGE_SAFETY`（「未成年に見える」判定）で毎回拒否される事象を発見
- テスト用ダミーキャラクター（17歳）で再現 → 年齢を25歳に変更して再試行しても同じ理由で拒否 → 年齢設定は原因ではないと判明
- ソースコード調査の結果、`components/ImageGenerationModal.tsx`（簡易生成）と `server/services/characterService.ts`（詳細生成、LLMへのsystem instruction）の両方で、プロンプト先頭に **`1girl`**（Danbooru由来のanimeタグ）を**キャラクターの実際の年齢・性別に関わらず常にハードコード**していたことが根本原因
- `personGeneration: ALLOW_ADULT` を指定していても、`1girl` + `anime style` の組み合わせ自体が Vertex AI の安全フィルタに「未成年らしきキャラクター」と判定され、テキストでの年齢指定はこの判定を上書きできていなかった
- `1girl` を削除し `adult` を追加（`solo` は維持、1体のみ生成する指示自体は変更なし）
- Issue #243/#244（finishReason捕捉機能追加）は「なぜ失敗するかを可視化する」対応で終わっており、本PRで初めて具体的な根本原因（1girlタグ）を特定・修正

## Test plan
- [x] `npm run lint`（tsc --noEmit）0 errors
- [x] `npm run test` 894/894 PASS（既存の `ImageGenerationModal.handlers.test.ts` / `characterService.test.ts` は `1girl` 文字列を pin していないため無影響）
- [ ] dev環境デプロイ後、実際にキャラクター画像生成が成功することを実機確認（本PR merge後、次のメッセージで実施）

🤖 Generated with [Claude Code](https://claude.com/claude-code)