### PR TITLE
experiment(image-gen): anime styleタグを外し安全フィルタ拒否への影響を検証

### DIFF
--- a/components/ImageGenerationModal.tsx
+++ b/components/ImageGenerationModal.tsx
@@ -216,7 +216,7 @@ export const ImageGenerationModal = ({ isOpen, onClose, onGenerate, onGeneratePr
                     <div className="mt-auto pt-4">
                         <button
                             onClick={() => {
-                                const prompt = `masterpiece, best quality, anime style, full body, solo, adult, simple white background, no text, no letters, ${characterDescription.replace(/[\n\r:]+/g, ', ')}`;
+                                const prompt = `masterpiece, best quality, full body, solo, adult, simple white background, no text, no letters, ${characterDescription.replace(/[\n\r:]+/g, ', ')}`;
                                 handleGenerate(prompt);
                             }}
                             disabled={!canUseAi || isBusy || !characterDescription.trim()}

--- a/server/services/characterService.ts
+++ b/server/services/characterService.ts
@@ -148,7 +148,7 @@ export const generateCharacterImagePrompt = async (chatHistory: ChatMessage[]) =
     **CRITICAL RULES:**
     1.  Your conversational replies ('reply' field) MUST be in Japanese.
     2.  The final image generation prompt ('finalPrompt' field) MUST be a detailed, comma-separated list of keywords in English.
-    3.  The 'finalPrompt' MUST ALWAYS start with: "masterpiece, best quality, anime style, full body, solo, adult, simple white background, no text, no letters, ".
+    3.  The 'finalPrompt' MUST ALWAYS start with: "masterpiece, best quality, full body, solo, adult, simple white background, no text, no letters, ".
     4.  After these initial keywords, append the detailed character description.
 
     **WORKFLOW:**


### PR DESCRIPTION
## Summary
- PR #255（1girl→adult修正）merge後、dev実機で再検証したところ、年齢17歳・25歳いずれの組み合わせでも `finishReason: IMAGE_SAFETY` による拒否が継続することを確認
- 1girlタグの除去だけでは不十分だったため、次の仮説として `anime style` タグ自体を切り分け検証する実験PR
- 本PRはdevでの実機検証専用。結果次第でこのまま本採用 or revert する

## Test plan
- [x] `npm run lint` 0 errors
- [x] `npm run test` 894/894 PASS
- [ ] dev実機で画像生成を再試行し、IMAGE_SAFETY拒否が解消するか確認（merge後に実施）

🤖 Generated with [Claude Code](https://claude.com/claude-code)