### PR TITLE
feat(usage): 画像生成コンバージョン計測基盤を追加 (Issue #232 着手)

### DIFF
--- a/components/ImageGenerationModal.handlers.test.ts
+++ b/components/ImageGenerationModal.handlers.test.ts
@@ -34,4 +34,11 @@ describe('ImageGenerationModal.handleGenerate (PR #233 static pin)', () => {
         const handler = handlerMatch![0];
         expect(handler).toMatch(/setGeneratedImages\(prev => append \? \[\.\.\.prev, \.\.\.result\] : result\);/);
     });
+
+    it('Issue #232 計測: onGenerate に append (isAdditionalGeneration) を伝搬する', () => {
+        // append を渡し忘れると、BE 側の recordImageGenerationKind が常に
+        // isAdditionalGeneration=false として記録され、追加生成利用率が計測できなくなる。
+        const handler = handlerMatch![0];
+        expect(handler).toMatch(/onGenerate\(promptToUse, append\)/);
+    });
 });

--- a/components/ImageGenerationModal.tsx
+++ b/components/ImageGenerationModal.tsx
@@ -62,7 +62,7 @@ export const ImageGenerationModal = ({ isOpen, onClose, onGenerate, onGeneratePr
             setGeneratedImages([]);
         }
         setBasePrompt(promptToUse);
-        const result = await onGenerate(promptToUse);
+        const result = await onGenerate(promptToUse, append);
         if (result) {
             setGeneratedImages(prev => append ? [...prev, ...result] : result);
         } else {

--- a/components/SettingModals.imageGeneration.test.ts
+++ b/components/SettingModals.imageGeneration.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// Issue #232 計測: 「追加生成」フラグが handleGenerateImage → imageApi.generateImage まで
+// 正しく伝搬することを static pin する。RTL 未導入のため
+// ImageGenerationModal.handlers.test.ts と同じ readFileSync + regex パターンで検証する。
+// store/firebaseClient への transitive import を避けるため（CI で VITE_FIREBASE_*
+// 必須化を防ぐ既存規律、CLAUDE.md「pure helper 分離パターン」参照）、レンダリングでは
+// なくソース文字列を直接検証する。
+
+describe('SettingModals.handleGenerateImage (Issue #232 計測 static pin)', () => {
+    const source = readFileSync(resolve(__dirname, 'SettingModals.tsx'), 'utf-8');
+    const handlerMatch = source.match(/const handleGenerateImage = async[\s\S]*?\n {4}\};/);
+
+    it('handleGenerateImage 定義が抽出できる', () => {
+        expect(handlerMatch).toBeTruthy();
+    });
+
+    it('isAdditionalGeneration をデフォルト false で受け取る', () => {
+        const handler = handlerMatch![0];
+        expect(handler).toMatch(/isAdditionalGeneration: boolean = false/);
+    });
+
+    it('imageApi.generateImage に isAdditionalGeneration をそのまま渡す', () => {
+        // ここで isAdditionalGeneration の受け渡しが握りつぶされると、
+        // 追加生成ボタンを押しても常に isAdditionalGeneration=false が送信され、
+        // imageGenerationCounts.additional が永久に 0 のまま計測が破綻する。
+        const handler = handlerMatch![0];
+        expect(handler).toMatch(/imageApi\.generateImage\(\{ prompt, isAdditionalGeneration \}\)/);
+    });
+});

--- a/components/SettingModals.tsx
+++ b/components/SettingModals.tsx
@@ -39,10 +39,10 @@ export const SettingItemModal = ({ isOpen, onClose, onSave, itemToEdit, itemType
 
     const isImageGenerating = useStore(state => state.isImageGenerating);
 
-    const handleGenerateImage = async (prompt: string): Promise<string[] | null> => {
+    const handleGenerateImage = async (prompt: string, isAdditionalGeneration: boolean = false): Promise<string[] | null> => {
         const { setIsImageGenerating, showToast } = useStore.getState();
         setIsImageGenerating(true);
-        const result = await imageApi.generateImage({ prompt });
+        const result = await imageApi.generateImage({ prompt, isAdditionalGeneration });
         setIsImageGenerating(false);
         if (result.success === false) {
             if (result.error.message.includes('permission') || result.error.message.includes('PERMISSION_DENIED')) {

--- a/imageApi.test.ts
+++ b/imageApi.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// Issue #232 計測: isAdditionalGeneration が apiCall のボディに正しく含まれることを
+// static pin する。RTL 未導入のため ImageGenerationModal.handlers.test.ts と同じ
+// readFileSync + regex パターンで検証する。
+
+describe('imageApi.generateImage (Issue #232 計測 static pin)', () => {
+    const source = readFileSync(resolve(__dirname, 'imageApi.ts'), 'utf-8');
+
+    it('isAdditionalGeneration をデフォルト false で受け取る', () => {
+        expect(source).toMatch(/isAdditionalGeneration = false/);
+    });
+
+    it('apiCall のボディに prompt と isAdditionalGeneration を含める', () => {
+        // ここが崩れると isAdditionalGeneration が BE に伝搬されず、
+        // imageGenerationCounts.additional が常に 0 のまま計測が破綻する。
+        expect(source).toMatch(/apiCall<string\[\]>\('\/image\/generate', \{ prompt, isAdditionalGeneration \}\)/);
+    });
+});

--- a/imageApi.ts
+++ b/imageApi.ts
@@ -1,5 +1,7 @@
 import { apiCall } from './apiClient';
 
-export const generateImage = async ({ prompt }: { prompt: string }): Promise<{ success: true; data: string[] } | { success: false; error: Error }> => {
-    return apiCall<string[]>('/image/generate', { prompt });
+export const generateImage = async (
+    { prompt, isAdditionalGeneration = false }: { prompt: string; isAdditionalGeneration?: boolean },
+): Promise<{ success: true; data: string[] } | { success: false; error: Error }> => {
+    return apiCall<string[]>('/image/generate', { prompt, isAdditionalGeneration });
 };

--- a/server/middleware/withUsageQuota.test.ts
+++ b/server/middleware/withUsageQuota.test.ts
@@ -29,6 +29,8 @@ vi.mock('../services/analysisService', () => ({ analyzeTextForImport: vi.fn() })
 const reserveMock = vi.fn();
 const commitMock = vi.fn();
 const cancelMock = vi.fn();
+const recordQuotaExceededMock = vi.fn();
+const recordImageGenerationKindMock = vi.fn();
 vi.mock('../services/usageService', async (importOriginal) => {
     const actual = await importOriginal<typeof import('../services/usageService')>();
     return {
@@ -36,6 +38,8 @@ vi.mock('../services/usageService', async (importOriginal) => {
         reserve: (...args: unknown[]) => reserveMock(...args),
         commit: (...args: unknown[]) => commitMock(...args),
         cancel: (...args: unknown[]) => cancelMock(...args),
+        recordQuotaExceeded: (...args: unknown[]) => recordQuotaExceededMock(...args),
+        recordImageGenerationKind: (...args: unknown[]) => recordImageGenerationKindMock(...args),
     };
 });
 
@@ -48,7 +52,7 @@ vi.mock('../firebaseAdmin', () => ({
 }));
 
 const { mountAiRoutes } = await import('../aiRoutes');
-const { PartialSuccessError } = await import('../services/usageService');
+const { PartialSuccessError, QuotaExceededError } = await import('../services/usageService');
 
 const buildApp = () => {
     const app = express();
@@ -66,9 +70,13 @@ describe('withUsageQuota - PartialSuccessError 按分 commit', () => {
         reserveMock.mockReset();
         commitMock.mockReset();
         cancelMock.mockReset();
+        recordQuotaExceededMock.mockReset();
+        recordImageGenerationKindMock.mockReset();
         generateImageMock.mockReset();
         verifyIdTokenSdkMock.mockResolvedValue({ uid: 'u1', email: 'a@example.com' });
         reserveMock.mockResolvedValue(handle);
+        recordQuotaExceededMock.mockResolvedValue(undefined);
+        recordImageGenerationKindMock.mockResolvedValue(undefined);
     });
 
     it('全件成功時は estimatedCost で commit される（回帰確認）', async () => {
@@ -80,7 +88,7 @@ describe('withUsageQuota - PartialSuccessError 按分 commit', () => {
             .send({ requestId: REQ_ID, prompt: 'test' });
 
         expect(res.status).toBe(200);
-        expect(commitMock).toHaveBeenCalledWith('u1', REQ_ID, 1200, handle);
+        expect(commitMock).toHaveBeenCalledWith('u1', REQ_ID, 1200, handle, 'image/generate');
         expect(cancelMock).not.toHaveBeenCalled();
     });
 
@@ -95,7 +103,7 @@ describe('withUsageQuota - PartialSuccessError 按分 commit', () => {
             .send({ requestId: REQ_ID, prompt: 'test' });
 
         expect(res.status).toBe(500);
-        expect(commitMock).toHaveBeenCalledWith('u1', REQ_ID, 600, handle);
+        expect(commitMock).toHaveBeenCalledWith('u1', REQ_ID, 600, handle, 'image/generate');
         expect(cancelMock).not.toHaveBeenCalled();
     });
 
@@ -126,7 +134,133 @@ describe('withUsageQuota - PartialSuccessError 按分 commit', () => {
             .send({ requestId: REQ_ID, prompt: 'test' });
 
         expect(res.status).toBe(500);
-        expect(commitMock).toHaveBeenCalledWith('u1', REQ_ID, 600, handle);
+        expect(commitMock).toHaveBeenCalledWith('u1', REQ_ID, 600, handle, 'image/generate');
         expect(cancelMock).toHaveBeenCalledWith('u1', REQ_ID, handle);
+    });
+});
+
+describe('withUsageQuota - QuotaExceededError 計測 (Issue #232)', () => {
+    beforeEach(() => {
+        verifyIdTokenSdkMock.mockReset();
+        reserveMock.mockReset();
+        commitMock.mockReset();
+        cancelMock.mockReset();
+        recordQuotaExceededMock.mockReset();
+        generateImageMock.mockReset();
+        verifyIdTokenSdkMock.mockResolvedValue({ uid: 'u1', email: 'a@example.com' });
+        recordQuotaExceededMock.mockResolvedValue(undefined);
+    });
+
+    it('quota 超過時に recordQuotaExceeded(uid, routeKey) が呼ばれ、429 を返す', async () => {
+        reserveMock.mockRejectedValueOnce(new QuotaExceededError(9500, 500, 10000));
+
+        const res = await request(buildApp())
+            .post('/api/ai/image/generate')
+            .set('Authorization', 'Bearer valid-token')
+            .send({ requestId: REQ_ID, prompt: 'test' });
+
+        expect(res.status).toBe(429);
+        expect(res.body.code).toBe('QUOTA_EXCEEDED');
+        expect(recordQuotaExceededMock).toHaveBeenCalledWith('u1', 'image/generate');
+    });
+
+    it('recordQuotaExceeded が失敗しても 429 レスポンス自体は正常に返る（best-effort）', async () => {
+        reserveMock.mockRejectedValueOnce(new QuotaExceededError(9500, 500, 10000));
+        recordQuotaExceededMock.mockRejectedValueOnce(new Error('firestore transient error'));
+
+        const res = await request(buildApp())
+            .post('/api/ai/image/generate')
+            .set('Authorization', 'Bearer valid-token')
+            .send({ requestId: REQ_ID, prompt: 'test' });
+
+        expect(res.status).toBe(429);
+        expect(res.body.code).toBe('QUOTA_EXCEEDED');
+    });
+});
+
+describe('image/generate - isAdditionalGeneration 計測 (Issue #232)', () => {
+    beforeEach(() => {
+        verifyIdTokenSdkMock.mockReset();
+        reserveMock.mockReset();
+        commitMock.mockReset();
+        cancelMock.mockReset();
+        recordImageGenerationKindMock.mockReset();
+        generateImageMock.mockReset();
+        verifyIdTokenSdkMock.mockResolvedValue({ uid: 'u1', email: 'a@example.com' });
+        reserveMock.mockResolvedValue(handle);
+        recordImageGenerationKindMock.mockResolvedValue(undefined);
+        generateImageMock.mockResolvedValue(['data:image/png;base64,aaa']);
+    });
+
+    it('isAdditionalGeneration 省略時は false として記録される（初回生成）', async () => {
+        const res = await request(buildApp())
+            .post('/api/ai/image/generate')
+            .set('Authorization', 'Bearer valid-token')
+            .send({ requestId: REQ_ID, prompt: 'test' });
+
+        expect(res.status).toBe(200);
+        expect(recordImageGenerationKindMock).toHaveBeenCalledWith('u1', false, handle);
+    });
+
+    it('isAdditionalGeneration: true を送ると true として記録される（追加生成）', async () => {
+        const res = await request(buildApp())
+            .post('/api/ai/image/generate')
+            .set('Authorization', 'Bearer valid-token')
+            .send({ requestId: REQ_ID, prompt: 'test', isAdditionalGeneration: true });
+
+        expect(res.status).toBe(200);
+        expect(recordImageGenerationKindMock).toHaveBeenCalledWith('u1', true, handle);
+    });
+
+    it('isAdditionalGeneration が truthy な非 boolean 値（文字列 "true" 等）の場合は false 扱いにする', async () => {
+        const res = await request(buildApp())
+            .post('/api/ai/image/generate')
+            .set('Authorization', 'Bearer valid-token')
+            .send({ requestId: REQ_ID, prompt: 'test', isAdditionalGeneration: 'true' });
+
+        expect(res.status).toBe(200);
+        expect(recordImageGenerationKindMock).toHaveBeenCalledWith('u1', false, handle);
+    });
+
+    it('recordImageGenerationKind が失敗しても画像生成レスポンス自体は成功として返る（best-effort）', async () => {
+        recordImageGenerationKindMock.mockRejectedValueOnce(new Error('firestore transient error'));
+
+        const res = await request(buildApp())
+            .post('/api/ai/image/generate')
+            .set('Authorization', 'Bearer valid-token')
+            .send({ requestId: REQ_ID, prompt: 'test' });
+
+        expect(res.status).toBe(200);
+        expect(res.body.data).toEqual(['data:image/png;base64,aaa']);
+    });
+
+    it('PartialSuccessError（一部枚数のみ成功）でも生成は実行されたため imageGenerationCounts に計上する', async () => {
+        generateImageMock.mockReset();
+        generateImageMock.mockRejectedValueOnce(
+            new PartialSuccessError('画像生成に失敗しました: 2枚中1枚のみ成功しました。', 0.5),
+        );
+
+        const res = await request(buildApp())
+            .post('/api/ai/image/generate')
+            .set('Authorization', 'Bearer valid-token')
+            .send({ requestId: REQ_ID, prompt: 'test' });
+
+        expect(res.status).toBe(500);
+        expect(recordImageGenerationKindMock).toHaveBeenCalledWith('u1', false, handle);
+    });
+
+    it('完全失敗（0 枚成功、通常の Error）では imageGenerationCounts に計上しない', async () => {
+        generateImageMock.mockReset();
+        generateImageMock.mockRejectedValueOnce(
+            new Error('画像生成に失敗しました: レスポンスに画像データが含まれていません。'),
+        );
+
+        const res = await request(buildApp())
+            .post('/api/ai/image/generate')
+            .set('Authorization', 'Bearer valid-token')
+            .send({ requestId: REQ_ID, prompt: 'test' });
+
+        expect(res.status).toBe(500);
+        expect(recordImageGenerationKindMock).not.toHaveBeenCalled();
     });
 });

--- a/server/middleware/withUsageQuota.ts
+++ b/server/middleware/withUsageQuota.ts
@@ -92,6 +92,7 @@ export const withUsageQuota = <TData>(
                         message: 'usage:recordQuotaExceeded failed',
                         route: routeKey,
                         uid,
+                        requestId,
                         error: serializeError(recordErr),
                     });
                 }

--- a/server/middleware/withUsageQuota.ts
+++ b/server/middleware/withUsageQuota.ts
@@ -16,6 +16,7 @@ import {
     DuplicateRequestError,
     PartialSuccessError,
     QuotaExceededError,
+    recordQuotaExceeded,
     reserve,
     type ReservationHandle,
 } from '../services/usageService';
@@ -32,7 +33,11 @@ const DEFAULT_TIER: Tier = 'free';
 const isValidRequestId = (value: unknown): value is string =>
     typeof value === 'string' && value.length >= 8 && value.length <= 128;
 
-export type AiHandler<TData> = (req: AuthedRequest) => Promise<TData>;
+// handle: reserve が返した ReservationHandle。AI 呼出後に計測系の best-effort 記録
+// （例: recordImageGenerationKind）を行う handler が、月境界耐性のために commit と
+// 同じ docId アンカーを使えるようにする。使わない handler は第2引数を無視してよい
+// （JS/TS の構造的部分型上、少ない仮引数の関数もこの型に代入できる）。
+export type AiHandler<TData> = (req: AuthedRequest, handle: ReservationHandle) => Promise<TData>;
 
 export const withUsageQuota = <TData>(
     routeKey: AiRouteKey,
@@ -78,6 +83,18 @@ export const withUsageQuota = <TData>(
                 return;
             }
             if (err instanceof QuotaExceededError) {
+                // Issue #232（コンバージョン最適化検討）向けの計測。best-effort のため
+                // 失敗してもログのみに留め、429 レスポンス自体は確実に返す。
+                try {
+                    await recordQuotaExceeded(uid, routeKey);
+                } catch (recordErr) {
+                    logger.error({
+                        message: 'usage:recordQuotaExceeded failed',
+                        route: routeKey,
+                        uid,
+                        error: serializeError(recordErr),
+                    });
+                }
                 res.status(429).json({
                     success: false,
                     error: '今月の AI 利用枠の上限に達しました。来月の更新をお待ちください。',
@@ -96,9 +113,9 @@ export const withUsageQuota = <TData>(
         }
 
         try {
-            const data = await handler(authed);
+            const data = await handler(authed, handle);
             try {
-                await commit(uid, requestId, estimatedCost, handle);
+                await commit(uid, requestId, estimatedCost, handle, routeKey);
             } catch (commitErr) {
                 // commit 失敗時も AI 結果は返す（ユーザーに損なし）。reservation が
                 // 残ると次回以降の上限判定に加算され続け、false positive 429 の経路に
@@ -133,7 +150,7 @@ export const withUsageQuota = <TData>(
                 // usedCost に計上する（cancel で全額なかったことにしない）。
                 const actualCost = Math.round(estimatedCost * handlerErr.successRatio);
                 try {
-                    await commit(uid, requestId, actualCost, handle);
+                    await commit(uid, requestId, actualCost, handle, routeKey);
                 } catch (commitErr) {
                     // commit 自体が失敗した場合、reservation を残すと次回以降の上限判定に
                     // 加算され続ける (成功パスの commit 失敗時と同じ理由)。best-effort で

--- a/server/routes/ai-auth.test.ts
+++ b/server/routes/ai-auth.test.ts
@@ -52,6 +52,8 @@ vi.mock('../services/analysisService', () => ({
 const reserveMock = vi.fn();
 const commitMock = vi.fn();
 const cancelMock = vi.fn();
+const recordQuotaExceededMock = vi.fn();
+const recordImageGenerationKindMock = vi.fn();
 vi.mock('../services/usageService', async (importOriginal) => {
     const actual = await importOriginal<typeof import('../services/usageService')>();
     return {
@@ -59,6 +61,8 @@ vi.mock('../services/usageService', async (importOriginal) => {
         reserve: (...args: unknown[]) => reserveMock(...args),
         commit: (...args: unknown[]) => commitMock(...args),
         cancel: (...args: unknown[]) => cancelMock(...args),
+        recordQuotaExceeded: (...args: unknown[]) => recordQuotaExceededMock(...args),
+        recordImageGenerationKind: (...args: unknown[]) => recordImageGenerationKindMock(...args),
     };
 });
 
@@ -118,6 +122,10 @@ describe('/api/ai/* requires Authorization Bearer ID Token', () => {
         reserveMock.mockReset();
         commitMock.mockReset();
         cancelMock.mockReset();
+        recordQuotaExceededMock.mockReset();
+        recordImageGenerationKindMock.mockReset();
+        recordQuotaExceededMock.mockResolvedValue(undefined);
+        recordImageGenerationKindMock.mockResolvedValue(undefined);
         for (const m of allServiceMocks) m.mockReset();
     });
 
@@ -177,7 +185,7 @@ describe('/api/ai/* requires Authorization Bearer ID Token', () => {
             expect(reserveMock).toHaveBeenCalledWith('u1', REQ_ID, 50, 10000);
             expect(generateNamesMock).toHaveBeenCalledTimes(1);
             // commit/cancel は reserve の返した handle を必ず渡す（月境界耐性の契約）
-            expect(commitMock).toHaveBeenCalledWith('u1', REQ_ID, 50, handle);
+            expect(commitMock).toHaveBeenCalledWith('u1', REQ_ID, 50, handle, 'utility/names');
             expect(cancelMock).not.toHaveBeenCalled();
         });
 
@@ -267,7 +275,7 @@ describe('/api/ai/* requires Authorization Bearer ID Token', () => {
 
             expect(res.status).toBe(200);
             expect(res.body).toEqual({ success: true, data: ['name-1'] });
-            expect(commitMock).toHaveBeenCalledWith('u1', REQ_ID, 50, handle);
+            expect(commitMock).toHaveBeenCalledWith('u1', REQ_ID, 50, handle, 'utility/names');
             // best-effort cancel が試行される
             expect(cancelMock).toHaveBeenCalledWith('u1', REQ_ID, handle);
             consoleErrorSpy.mockRestore();

--- a/server/routes/image.ts
+++ b/server/routes/image.ts
@@ -1,12 +1,42 @@
 import { Router } from 'express';
 import { generateImage } from '../services/imageService';
 import { withUsageQuota } from '../middleware/withUsageQuota';
+import { PartialSuccessError, recordImageGenerationKind } from '../services/usageService';
+import { logger, serializeError } from '../utils/logger';
 
 const router = Router();
 
-router.post('/generate', withUsageQuota('image/generate', async (req) => {
+router.post('/generate', withUsageQuota('image/generate', async (req, handle) => {
     const { prompt } = req.body;
-    return await generateImage(prompt);
+    const isAdditionalGeneration = req.body?.isAdditionalGeneration === true;
+
+    // Issue #232（コンバージョン最適化検討）向けの計測。best-effort のため
+    // 失敗しても画像生成のレスポンス自体には影響させない。
+    const recordKind = async (): Promise<void> => {
+        try {
+            await recordImageGenerationKind(req.user.uid, isAdditionalGeneration, handle);
+        } catch (err) {
+            logger.error({
+                message: 'usage:recordImageGenerationKind failed',
+                uid: req.user.uid,
+                isAdditionalGeneration,
+                error: serializeError(err),
+            });
+        }
+    };
+
+    try {
+        const result = await generateImage(prompt);
+        await recordKind();
+        return result;
+    } catch (err) {
+        // PartialSuccessError（一部枚数のみ成功）も「生成は実行された」ため計測対象に含める。
+        // 完全失敗（0 枚成功、通常の Error）は計測しない。
+        if (err instanceof PartialSuccessError) {
+            await recordKind();
+        }
+        throw err;
+    }
 }));
 
 export default router;

--- a/server/routes/image.ts
+++ b/server/routes/image.ts
@@ -19,6 +19,7 @@ router.post('/generate', withUsageQuota('image/generate', async (req, handle) =>
             logger.error({
                 message: 'usage:recordImageGenerationKind failed',
                 uid: req.user.uid,
+                requestId: req.body?.requestId,
                 isAdditionalGeneration,
                 error: serializeError(err),
             });

--- a/server/services/usageService.test.ts
+++ b/server/services/usageService.test.ts
@@ -5,6 +5,8 @@ import {
     cancel,
     getUsage,
     getUsageDocId,
+    recordQuotaExceeded,
+    recordImageGenerationKind,
     QuotaExceededError,
     DuplicateRequestError,
     ReservationNotFoundError,
@@ -137,6 +139,9 @@ describe('reserve', () => {
                 reservedCost: 0,
                 reservations: {},
                 processedIds: ['req-1'],
+            routeCounts: {},
+            quotaExceededCounts: {},
+            imageGenerationCounts: { initial: 0, additional: 0 },
             } satisfies UsageDoc,
         });
         await expect(reserve('alice', 'req-1', 100, 10000, db)).rejects.toBeInstanceOf(DuplicateRequestError);
@@ -149,6 +154,9 @@ describe('reserve', () => {
                 reservedCost: 500,
                 reservations: { 'r-old': 500 },
                 processedIds: [],
+            routeCounts: {},
+            quotaExceededCounts: {},
+            imageGenerationCounts: { initial: 0, additional: 0 },
             } satisfies UsageDoc,
         });
         await expect(reserve('alice', 'req-1', 600, 10000, db)).rejects.toBeInstanceOf(QuotaExceededError);
@@ -161,6 +169,9 @@ describe('reserve', () => {
                 reservedCost: 500,
                 reservations: { 'r-old': 500 },
                 processedIds: [],
+            routeCounts: {},
+            quotaExceededCounts: {},
+            imageGenerationCounts: { initial: 0, additional: 0 },
             } satisfies UsageDoc,
         });
         await reserve('alice', 'req-1', 500, 10000, db);
@@ -185,7 +196,7 @@ describe('commit', () => {
     it('moves reservedCost to usedCost and removes reservation', async () => {
         const { db, getDoc } = createMockFirestore();
         const handle = await reserve('alice', 'req-1', 200, 10000, db);
-        await commit('alice', 'req-1', 200, handle, db);
+        await commit('alice', 'req-1', 200, handle, undefined, db);
         expect(getDoc('usage/alice_202604')).toMatchObject({
             usedCost: 200,
             reservedCost: 0,
@@ -197,7 +208,7 @@ describe('commit', () => {
     it('actualCost can be less than reservedCost (refund)', async () => {
         const { db, getDoc } = createMockFirestore();
         const handle = await reserve('alice', 'req-1', 300, 10000, db);
-        await commit('alice', 'req-1', 100, handle, db);
+        await commit('alice', 'req-1', 100, handle, undefined, db);
         expect(getDoc('usage/alice_202604')).toMatchObject({
             usedCost: 100,
             reservedCost: 0,
@@ -206,7 +217,34 @@ describe('commit', () => {
 
     it('throws ReservationNotFoundError when commit without reserve', async () => {
         const { db } = createMockFirestore();
-        await expect(commit('alice', 'unknown', 100, undefined, db)).rejects.toBeInstanceOf(ReservationNotFoundError);
+        await expect(commit('alice', 'unknown', 100, undefined, undefined, db)).rejects.toBeInstanceOf(ReservationNotFoundError);
+    });
+
+    it('increments routeCounts[routeKey] when routeKey is provided (Issue #232 計測)', async () => {
+        const { db, getDoc } = createMockFirestore();
+        const handle = await reserve('alice', 'req-1', 1200, 10000, db);
+        await commit('alice', 'req-1', 1200, handle, 'image/generate', db);
+        expect(getDoc('usage/alice_202604')).toMatchObject({
+            routeCounts: { 'image/generate': 1 },
+        });
+    });
+
+    it('accumulates routeCounts across multiple commits of the same routeKey', async () => {
+        const { db, getDoc } = createMockFirestore();
+        const h1 = await reserve('alice', 'req-1', 1200, 10000, db);
+        await commit('alice', 'req-1', 1200, h1, 'image/generate', db);
+        const h2 = await reserve('alice', 'req-2', 1200, 10000, db);
+        await commit('alice', 'req-2', 1200, h2, 'image/generate', db);
+        expect(getDoc('usage/alice_202604')).toMatchObject({
+            routeCounts: { 'image/generate': 2 },
+        });
+    });
+
+    it('does not touch routeCounts when routeKey is omitted (backward compat)', async () => {
+        const { db, getDoc } = createMockFirestore();
+        const handle = await reserve('alice', 'req-1', 200, 10000, db);
+        await commit('alice', 'req-1', 200, handle, undefined, db);
+        expect(getDoc('usage/alice_202604')).toMatchObject({ routeCounts: {} });
     });
 
     it('caps processedIds at MAX_PROCESSED_IDS (drops oldest)', async () => {
@@ -217,9 +255,12 @@ describe('commit', () => {
                 reservedCost: 50,
                 reservations: { 'req-new': 50 },
                 processedIds: initialIds,
+            routeCounts: {},
+            quotaExceededCounts: {},
+            imageGenerationCounts: { initial: 0, additional: 0 },
             } satisfies UsageDoc,
         });
-        await commit('alice', 'req-new', 50, undefined, db);
+        await commit('alice', 'req-new', 50, undefined, undefined, db);
         const doc = getDoc('usage/alice_202604') as Record<string, unknown>;
         const ids = doc.processedIds as string[];
         expect(ids).toHaveLength(200);
@@ -253,6 +294,9 @@ describe('cancel', () => {
                 reservedCost: 0,
                 reservations: {},
                 processedIds: ['req-1'],
+            routeCounts: {},
+            quotaExceededCounts: {},
+            imageGenerationCounts: { initial: 0, additional: 0 },
             } satisfies UsageDoc,
         });
         await cancel('alice', 'req-1', undefined, db);
@@ -267,9 +311,9 @@ describe('reserve → AI succeeds → commit (happy path, no double charge)', ()
     it('full lifecycle leaves only usedCost increment', async () => {
         const { db, getDoc } = createMockFirestore();
         const h1 = await reserve('alice', 'req-1', 200, 10000, db);
-        await commit('alice', 'req-1', 200, h1, db);
+        await commit('alice', 'req-1', 200, h1, undefined, db);
         const h2 = await reserve('alice', 'req-2', 100, 10000, db);
-        await commit('alice', 'req-2', 100, h2, db);
+        await commit('alice', 'req-2', 100, h2, undefined, db);
         expect(getDoc('usage/alice_202604')).toMatchObject({
             usedCost: 300,
             reservedCost: 0,
@@ -301,7 +345,7 @@ describe('UTC month boundary (reserve→AI→commit/cancel cross-month resilienc
         const handle = await reserve('alice', 'req-1', 200, 10000, db);
         // AI 処理中に 5 月に突入
         vi.setSystemTime(new Date('2026-05-01T00:00:01Z'));
-        await commit('alice', 'req-1', 200, handle, db);
+        await commit('alice', 'req-1', 200, handle, undefined, db);
 
         // 5 月 doc は作成されない、4 月 doc が確定済みになる
         expect(getDoc('usage/alice_202605')).toBeUndefined();
@@ -334,7 +378,7 @@ describe('UTC month boundary (reserve→AI→commit/cancel cross-month resilienc
         const { db, getDoc } = createMockFirestore();
         vi.setSystemTime(new Date('2026-04-15T10:00:00Z'));
         await reserve('alice', 'req-1', 200, 10000, db);
-        await commit('alice', 'req-1', 200, undefined, db);
+        await commit('alice', 'req-1', 200, undefined, undefined, db);
         expect(getDoc('usage/alice_202604')).toMatchObject({ usedCost: 200, reservedCost: 0 });
     });
 });
@@ -343,7 +387,15 @@ describe('getUsage', () => {
     it('returns empty doc when not initialized', async () => {
         const { db } = createMockFirestore();
         const usage = await getUsage('alice', db);
-        expect(usage).toEqual({ usedCost: 0, reservedCost: 0, reservations: {}, processedIds: [] });
+        expect(usage).toEqual({
+            usedCost: 0,
+            reservedCost: 0,
+            reservations: {},
+            processedIds: [],
+            routeCounts: {},
+            quotaExceededCounts: {},
+            imageGenerationCounts: { initial: 0, additional: 0 },
+        });
     });
 
     it('returns current state from Firestore', async () => {
@@ -353,6 +405,9 @@ describe('getUsage', () => {
                 reservedCost: 100,
                 reservations: { 'r1': 100 },
                 processedIds: ['done-1'],
+                routeCounts: { 'image/generate': 3 },
+                quotaExceededCounts: { 'image/generate': 1 },
+                imageGenerationCounts: { initial: 2, additional: 1 },
             } satisfies UsageDoc,
         });
         const usage = await getUsage('alice', db);
@@ -361,6 +416,9 @@ describe('getUsage', () => {
             reservedCost: 100,
             reservations: { 'r1': 100 },
             processedIds: ['done-1'],
+            routeCounts: { 'image/generate': 3 },
+            quotaExceededCounts: { 'image/generate': 1 },
+            imageGenerationCounts: { initial: 2, additional: 1 },
         });
     });
 
@@ -401,5 +459,98 @@ describe('getUsage', () => {
         const usage = await getUsage('alice', db);
         expect(usage.usedCost).toBe(0);
         expect(usage.reservedCost).toBe(0);
+    });
+});
+
+describe('recordQuotaExceeded (Issue #232 計測)', () => {
+    it('creates doc and increments quotaExceededCounts[routeKey] on first call', async () => {
+        const { db, getDoc } = createMockFirestore();
+        await recordQuotaExceeded('alice', 'image/generate', db);
+        expect(getDoc('usage/alice_202604')).toMatchObject({
+            quotaExceededCounts: { 'image/generate': 1 },
+        });
+    });
+
+    it('accumulates across multiple calls for the same routeKey', async () => {
+        const { db, getDoc } = createMockFirestore();
+        await recordQuotaExceeded('alice', 'image/generate', db);
+        await recordQuotaExceeded('alice', 'image/generate', db);
+        expect(getDoc('usage/alice_202604')).toMatchObject({
+            quotaExceededCounts: { 'image/generate': 2 },
+        });
+    });
+
+    it('does not affect usedCost/reservedCost of an existing doc', async () => {
+        const { db, getDoc } = createMockFirestore();
+        await reserve('alice', 'req-1', 200, 10000, db);
+        await recordQuotaExceeded('alice', 'image/generate', db);
+        expect(getDoc('usage/alice_202604')).toMatchObject({
+            reservedCost: 200,
+            reservations: { 'req-1': 200 },
+            quotaExceededCounts: { 'image/generate': 1 },
+        });
+    });
+
+    it('tracks separate routeKeys independently', async () => {
+        const { db, getDoc } = createMockFirestore();
+        await recordQuotaExceeded('alice', 'image/generate', db);
+        await recordQuotaExceeded('alice', 'novel/generate', db);
+        expect(getDoc('usage/alice_202604')).toMatchObject({
+            quotaExceededCounts: { 'image/generate': 1, 'novel/generate': 1 },
+        });
+    });
+});
+
+describe('recordImageGenerationKind (Issue #232 計測)', () => {
+    it('increments imageGenerationCounts.initial when isAdditional is false', async () => {
+        const { db, getDoc } = createMockFirestore();
+        await recordImageGenerationKind('alice', false, undefined, db);
+        expect(getDoc('usage/alice_202604')).toMatchObject({
+            imageGenerationCounts: { initial: 1, additional: 0 },
+        });
+    });
+
+    it('increments imageGenerationCounts.additional when isAdditional is true', async () => {
+        const { db, getDoc } = createMockFirestore();
+        await recordImageGenerationKind('alice', true, undefined, db);
+        expect(getDoc('usage/alice_202604')).toMatchObject({
+            imageGenerationCounts: { initial: 0, additional: 1 },
+        });
+    });
+
+    it('accumulates initial and additional independently', async () => {
+        const { db, getDoc } = createMockFirestore();
+        await recordImageGenerationKind('alice', false, undefined, db);
+        await recordImageGenerationKind('alice', true, undefined, db);
+        await recordImageGenerationKind('alice', true, undefined, db);
+        expect(getDoc('usage/alice_202604')).toMatchObject({
+            imageGenerationCounts: { initial: 1, additional: 2 },
+        });
+    });
+
+    it('uses handle.reservedAt as the docId anchor across UTC month boundary (commit と同じ月境界耐性契約)', async () => {
+        // generateImage（AI 呼出）が数秒〜十数秒かかる間に UTC 月が変わっても、
+        // reserve 時点の月 doc に imageGenerationCounts を書き込む。handle を
+        // 使わないと「今」の月 doc に書いてしまい、commit の routeCounts とは
+        // 別の月に計測が分裂する。
+        const { db, getDoc } = createMockFirestore();
+        vi.setSystemTime(new Date('2026-04-30T23:59:59Z'));
+        const handle = await reserve('alice', 'req-1', 1200, 10000, db);
+        vi.setSystemTime(new Date('2026-05-01T00:00:01Z'));
+        await recordImageGenerationKind('alice', false, handle, db);
+
+        expect(getDoc('usage/alice_202605')).toBeUndefined();
+        expect(getDoc('usage/alice_202604')).toMatchObject({
+            imageGenerationCounts: { initial: 1, additional: 0 },
+        });
+    });
+
+    it('falls back to current month when handle is omitted (legacy behavior)', async () => {
+        const { db, getDoc } = createMockFirestore();
+        vi.setSystemTime(new Date('2026-04-15T10:00:00Z'));
+        await recordImageGenerationKind('alice', false, undefined, db);
+        expect(getDoc('usage/alice_202604')).toMatchObject({
+            imageGenerationCounts: { initial: 1, additional: 0 },
+        });
     });
 });

--- a/server/services/usageService.ts
+++ b/server/services/usageService.ts
@@ -277,8 +277,8 @@ export async function getUsage(
 
 // Issue #232（コンバージョン最適化検討）向けの計測専用 best-effort 記録。
 // quota 超過（429）はレスポンスに直結する重要フローのため、記録自体が失敗しても
-// 呼出元 (withUsageQuota) は catch して 429 レスポンスに影響させない設計とする
-// （rules/error-handling.md の「状態復旧 > ログ記録」原則、ここでは応答確定が最優先）。
+// 呼出元 (withUsageQuota) は catch して 429 レスポンス確定を優先し、計測失敗は
+// ログのみに留める（応答確定 > 計測記録の優先順位）。
 export async function recordQuotaExceeded(
     uid: string,
     routeKey: string,
@@ -299,8 +299,9 @@ export async function recordQuotaExceeded(
 }
 
 // Issue #232 向け。画像生成の「初回」と「追加生成ボタン」呼び出しの内訳を計測する
-// best-effort 記録。呼出元 (image route) は成功後に fire し、失敗しても画像生成の
-// レスポンス自体には影響させない。
+// best-effort 記録。呼出元 (image route) は生成成功時、および PartialSuccessError
+// （一部枚数のみ成功）時に fire し、完全失敗（0 枚成功）時は fire しない。失敗しても
+// 画像生成のレスポンス自体には影響させない。
 //
 // handle: generateImage（AI 呼出、数秒〜十数秒かかりうる）の完了後に呼ばれるため、
 // commit と同じく reserve 時の docId を引き継がないと UTC 月境界を跨いだケースで

--- a/server/services/usageService.ts
+++ b/server/services/usageService.ts
@@ -18,6 +18,11 @@ export interface UsageDoc {
     reservedCost: number;
     reservations: Record<string, number>;
     processedIds: string[];
+    // 以下 3 フィールドは Issue #232（コンバージョン最適化検討）向けの計測専用。
+    // 課金判定（usedCost/reservedCost）には一切関与しない。
+    routeCounts: Record<string, number>;
+    quotaExceededCounts: Record<string, number>;
+    imageGenerationCounts: { initial: number; additional: number };
 }
 
 export class QuotaExceededError extends Error {
@@ -76,7 +81,27 @@ const emptyDoc = (): UsageDoc => ({
     reservedCost: 0,
     reservations: {},
     processedIds: [],
+    routeCounts: {},
+    quotaExceededCounts: {},
+    imageGenerationCounts: { initial: 0, additional: 0 },
 });
+
+// 値ごとに number 検証し、不正値（string, NaN, Infinity, 負値）を drop する。
+// reservations の検証ロジック（parseUsageDoc 内）と同じ契約を計測用カウンタにも適用する。
+const sanitizeCountRecord = (raw: unknown): Record<string, number> => {
+    const out: Record<string, number> = {};
+    if (raw && typeof raw === 'object') {
+        for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+            if (typeof value === 'number' && Number.isFinite(value) && value >= 0) {
+                out[key] = value;
+            }
+        }
+    }
+    return out;
+};
+
+const sanitizeNonNegativeInt = (value: unknown): number =>
+    typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : 0;
 
 // snap → UsageDoc 正規化を transaction 経路と非 transaction 経路で共有する純関数。
 // raw データが Firestore で部分破損していても全フィールドが安全な default に
@@ -95,11 +120,19 @@ const parseUsageDoc = (snap: { exists: boolean; data: () => unknown }): UsageDoc
             }
         }
     }
+    const rawImageCounts = raw?.imageGenerationCounts as Partial<UsageDoc['imageGenerationCounts']> | undefined;
+
     return {
         usedCost: typeof raw?.usedCost === 'number' && Number.isFinite(raw.usedCost) ? raw.usedCost : 0,
         reservedCost: typeof raw?.reservedCost === 'number' && Number.isFinite(raw.reservedCost) ? raw.reservedCost : 0,
         reservations: sanitizedReservations,
         processedIds: Array.isArray(raw?.processedIds) ? raw.processedIds.filter((id): id is string => typeof id === 'string') : [],
+        routeCounts: sanitizeCountRecord(raw?.routeCounts),
+        quotaExceededCounts: sanitizeCountRecord(raw?.quotaExceededCounts),
+        imageGenerationCounts: {
+            initial: sanitizeNonNegativeInt(rawImageCounts?.initial),
+            additional: sanitizeNonNegativeInt(rawImageCounts?.additional),
+        },
     };
 };
 
@@ -149,6 +182,9 @@ export async function reserve(
             reservedCost: data.reservedCost + estimatedCost,
             reservations: { ...data.reservations, [requestId]: estimatedCost },
             processedIds: data.processedIds,
+            routeCounts: data.routeCounts,
+            quotaExceededCounts: data.quotaExceededCounts,
+            imageGenerationCounts: data.imageGenerationCounts,
             updatedAt: FieldValue.serverTimestamp(),
         });
     });
@@ -164,11 +200,16 @@ export async function reserve(
 // handle: reserve の戻り値で受け取った ReservationHandle を渡す。これにより
 // reserve→AI→commit の間に UTC 月境界を跨いでも、必ず reserve 時と同じ doc を
 // 操作する。省略時は現在時刻ベースで docId を決定する（互換用）。
+//
+// routeKey: Issue #232（コンバージョン最適化検討）向けの計測専用。渡された場合のみ
+// routeCounts をインクリメントする。省略しても課金ロジック（usedCost/reservedCost）
+// には一切影響しない。
 export async function commit(
     uid: string,
     requestId: string,
     actualCost: number,
     handle: ReservationHandle | undefined = undefined,
+    routeKey: string | undefined = undefined,
     db: Firestore = getFirebaseFirestore(),
 ): Promise<void> {
     if (actualCost < 0) throw new Error('actualCost must be non-negative');
@@ -182,12 +223,16 @@ export async function commit(
         }
         const { [requestId]: _removed, ...remaining } = data.reservations;
         const processedIds = [...data.processedIds, requestId].slice(-MAX_PROCESSED_IDS);
+        const routeCounts = routeKey
+            ? { ...data.routeCounts, [routeKey]: (data.routeCounts[routeKey] ?? 0) + 1 }
+            : data.routeCounts;
 
         tx.update(docRef, {
             usedCost: data.usedCost + actualCost,
             reservedCost: data.reservedCost - reservedAmount,
             reservations: remaining,
             processedIds,
+            routeCounts,
             updatedAt: FieldValue.serverTimestamp(),
         });
     });
@@ -228,4 +273,55 @@ export async function getUsage(
     const docRef = db.collection(COLLECTION).doc(getUsageDocId(uid));
     const snap = await docRef.get();
     return parseUsageDoc(snap);
+}
+
+// Issue #232（コンバージョン最適化検討）向けの計測専用 best-effort 記録。
+// quota 超過（429）はレスポンスに直結する重要フローのため、記録自体が失敗しても
+// 呼出元 (withUsageQuota) は catch して 429 レスポンスに影響させない設計とする
+// （rules/error-handling.md の「状態復旧 > ログ記録」原則、ここでは応答確定が最優先）。
+export async function recordQuotaExceeded(
+    uid: string,
+    routeKey: string,
+    db: Firestore = getFirebaseFirestore(),
+): Promise<void> {
+    const docRef = db.collection(COLLECTION).doc(getUsageDocId(uid));
+    await db.runTransaction(async (tx) => {
+        const data = await readDoc(tx, docRef);
+        tx.set(docRef, {
+            ...data,
+            quotaExceededCounts: {
+                ...data.quotaExceededCounts,
+                [routeKey]: (data.quotaExceededCounts[routeKey] ?? 0) + 1,
+            },
+            updatedAt: FieldValue.serverTimestamp(),
+        });
+    });
+}
+
+// Issue #232 向け。画像生成の「初回」と「追加生成ボタン」呼び出しの内訳を計測する
+// best-effort 記録。呼出元 (image route) は成功後に fire し、失敗しても画像生成の
+// レスポンス自体には影響させない。
+//
+// handle: generateImage（AI 呼出、数秒〜十数秒かかりうる）の完了後に呼ばれるため、
+// commit と同じく reserve 時の docId を引き継がないと UTC 月境界を跨いだケースで
+// 別月の doc に計測が分裂する（commit の月境界耐性と同じ理由、契約を揃える）。
+export async function recordImageGenerationKind(
+    uid: string,
+    isAdditional: boolean,
+    handle: ReservationHandle | undefined = undefined,
+    db: Firestore = getFirebaseFirestore(),
+): Promise<void> {
+    const docRef = db.collection(COLLECTION).doc(getUsageDocId(uid, handle?.reservedAt));
+    const key = isAdditional ? 'additional' : 'initial';
+    await db.runTransaction(async (tx) => {
+        const data = await readDoc(tx, docRef);
+        tx.set(docRef, {
+            ...data,
+            imageGenerationCounts: {
+                ...data.imageGenerationCounts,
+                [key]: data.imageGenerationCounts[key] + 1,
+            },
+            updatedAt: FieldValue.serverTimestamp(),
+        });
+    });
 }


### PR DESCRIPTION
## Summary
Issue #232（画像生成無料枠のコンバージョン最適化）着手の第一歩として、計測基盤のみを実装。可視化・サブ上限導入・コンバージョン導線は別途スコープ。

- `usage/{uid}_{yyyymm}` に `routeCounts` / `quotaExceededCounts` / `imageGenerationCounts` を追加。既存の課金ロジック（`usedCost`/`reservedCost`、reserve/commit/cancelの3phase）は無変更
- `commit()` に `routeKey` を追加し、成功呼び出しをルート別に計測
- quota超過(429)時に `recordQuotaExceeded` をbest-effortで記録
- 画像生成の「初回」「追加生成ボタン」の内訳を計測するため、FE（`ImageGenerationModal` → `imageApi`）から `isAdditionalGeneration` をBEに伝搬
- 月境界跨ぎ・`PartialSuccessError`（一部枚数のみ成功）時の計測欠落は、Evaluator指摘を受けて `ReservationHandle` 伝搬 + PartialSuccess時の記録呼び出しで対応済み

## 既知の限界（分析精度のみ、課金・UXには無影響）
- `recordImageGenerationKind` は `generateImage` 成功直後に独立トランザクションで確定するため、その後の `commit` が失敗し `cancel` にフォールバックした場合（Firestore transaction競合等の稀な異常系）、`imageGenerationCounts` は加算されるが `routeCounts` は加算されず、両カウンタが不整合になりうる。code-review（medium effort）で確認済み・CONFIRMED。実害はコンバージョン分析の統計精度がわずかに下がるのみで、課金・レスポンスには影響しない。triage基準（実バグ/実害/CI破壊/rating≥7）に届かないため、Issue化はせず本コメントで記録。

## Test plan
- [x] `npm run lint`（tsc --noEmit）エラー0件
- [x] `npm run test` 全915テストPASS（新規21件追加）
- [x] Evaluator（別コンテキスト）でAcceptance Criteria全項目PASS確認
- [x] code-review medium effort（8角度 finder + verify）実施、上記既知の限界以外に修正必須の指摘なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)