### PR TITLE
ops: 本番usageリセット用の1回限りworkflowを追加

### DIFF
--- a/.github/workflows/prod-usage-reset-oneoff.yml
+++ b/.github/workflows/prod-usage-reset-oneoff.yml
@@ -1,0 +1,48 @@
+name: "[ONE-OFF] prod usage reset"
+
+# 1回限りの本番 usage リセットツール。
+# 実行対象アカウントの今月分 usage/{uid}_{yyyymm} の usedCost / reservedCost /
+# reservations のみ 0 にリセットする（scripts/prod-usage-reset-oneoff.ts 参照）。
+# workflow_dispatch のみ、本田様の番号単位明示認可必須。
+# 実行後は本 workflow ファイルと scripts/prod-usage-reset-oneoff.ts を削除する
+# (1回限りツールをリポジトリに残さない)。
+
+on:
+  workflow_dispatch:
+    inputs:
+      email:
+        description: 'リセット対象アカウントのメールアドレス'
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  reset:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - id: auth
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: projects/1026420855688/locations/global/workloadIdentityPools/github-pool/providers/github-provider
+          service_account: github-deploy@novel-writer-prod.iam.gserviceaccount.com
+
+      - name: Reset usage
+        env:
+          GCLOUD_PROJECT: novel-writer-prod
+        run: npx tsx scripts/prod-usage-reset-oneoff.ts "${{ inputs.email }}"

--- a/scripts/prod-usage-reset-oneoff.ts
+++ b/scripts/prod-usage-reset-oneoff.ts
@@ -1,0 +1,57 @@
+/**
+ * 1回限りの本番 usage リセットツール。
+ *
+ * 実行: GCLOUD_PROJECT=novel-writer-prod npx tsx scripts/prod-usage-reset-oneoff.ts <email>
+ * (.github/workflows/prod-usage-reset-oneoff.yml から WIF 経由で実行する想定)
+ *
+ * 対象アカウントの今月分 usage/{uid}_{yyyymm} の usedCost / reservedCost /
+ * reservations のみ 0 にリセットする。processedIds / routeCounts /
+ * quotaExceededCounts / imageGenerationCounts (Issue #232 計測用) は保持する。
+ *
+ * 実行前後の値を必ず標準出力に記録し、GitHub Actions のログを監査証跡とする。
+ */
+
+import { getFirebaseAuth, getFirebaseFirestore } from '../server/firebaseAdmin.js';
+import { getUsageDocId } from '../server/services/usageService.js';
+
+async function run(): Promise<void> {
+  const email = process.argv[2];
+  if (!email) {
+    throw new Error('Usage: tsx scripts/prod-usage-reset-oneoff.ts <email>');
+  }
+  if (process.env.GCLOUD_PROJECT !== 'novel-writer-prod') {
+    throw new Error(
+      `GCLOUD_PROJECT must be 'novel-writer-prod' (got: ${process.env.GCLOUD_PROJECT ?? 'unset'})`
+    );
+  }
+
+  const user = await getFirebaseAuth().getUserByEmail(email);
+  console.log(`[target] email=${email} uid=${user.uid}`);
+
+  const docId = getUsageDocId(user.uid);
+  const ref = getFirebaseFirestore().collection('usage').doc(docId);
+
+  const before = await ref.get();
+  if (!before.exists) {
+    console.log(`[before] usage/${docId} does not exist — nothing to reset.`);
+    return;
+  }
+  console.log(`[before] usage/${docId} =`, JSON.stringify(before.data()));
+
+  await ref.update({
+    usedCost: 0,
+    reservedCost: 0,
+    reservations: {},
+  });
+
+  const after = await ref.get();
+  console.log(`[after]  usage/${docId} =`, JSON.stringify(after.data()));
+}
+
+run().then(
+  () => process.exit(0),
+  (err: unknown) => {
+    console.error('FAIL:', err);
+    process.exit(1);
+  }
+);


### PR DESCRIPTION
## Summary
- prodでテスト中にTier 1月間予算(100円/月)を使い切ったため、本田様の明示承認を得て一時的なusageリセット手段を追加
- `usage/{uid}_{yyyymm}` の `usedCost` / `reservedCost` / `reservations` のみ0にリセット（`processedIds`/`routeCounts`/`quotaExceededCounts`/`imageGenerationCounts`計測データは保持）
- workflow_dispatch専用、email input必須、実行前後の値をログに残す（監査証跡）
- **実行後は本PRのファイルを削除するフォローアップPRを出す**（1回限りツールをリポジトリに残さない）

## 前提となったIAM変更（本田様の明示承認済み）
`github-deploy@novel-writer-prod.iam.gserviceaccount.com` に `roles/firebaseauth.admin` を一時付与済み（`getUserByEmail`に必要）。本ワークフロー実行完了後、削除フォローアップPRとあわせて取り消す。

## Test plan
- [x] `npm run lint` PASS（型チェックのみ、実行はworkflow_dispatchで本田様確認の上で実施）
- [ ] マージ後、`gh workflow run` で実行し、ログのbefore/afterでリセットを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)