### PR TITLE
fix(dev-portal): カード本文中の長いコード識別子の折り返し漏れを修正

### DIFF
--- a/public/dev/index.html
+++ b/public/dev/index.html
@@ -301,6 +301,8 @@ h3.h-rule .small{
   padding: var(--space-md);
   position: relative;
   min-width: 0;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 .card::before{
   content: "";
@@ -314,8 +316,6 @@ h3.h-rule .small{
   font-family: var(--font-display);
   font-weight: 600;
   font-size: 1.2rem;
-  overflow-wrap: anywhere;
-  word-break: break-word;
 }
 .card .kicker{
   font-family: var(--font-mono);


### PR DESCRIPTION
## Summary
- PR #278 で `.card h4` にのみ `overflow-wrap` を付けたため、本文 `<p>` 内の `TERMS_VERSION_MISMATCH` のような長いコード識別子が未対応のまま隣カードにはみ出していた
- `overflow-wrap` は継承プロパティのため `.card` 自体に指定し直し、子要素（h4/p/kicker）全てをカバー

## 背景
本田様がdev環境実機（`/dev/#p-dev`）で再度崩れを確認・報告。「SERVER ENTRY」〜「MODALS」の8枚の主要ファイルカードのうち、「SHARED CODES」カードの本文 `TERMS_VERSION_MISMATCH` がはみ出していた。

## Test plan
- [x] `python3 -m http.server` で静的配信し、Playwright MCPで確認
  - [x] 「VII. 開発者情報」タブの全8カードで文字はみ出しがないことを確認
  - [x] 「I. 概要」タブのマイルストーン進捗カードにも崩れがないことを確認
  - [x] DOM走査で `scrollWidth > clientWidth` の要素がゼロであることを確認
- [x] doc-onlyの変更のため `/code-review` はスコープ外（CLAUDE.md記載の運用に準拠）

🤖 Generated with [Claude Code](https://claude.com/claude-code)