### PR TITLE
docs(dev-portal): テスト件数表示を実測値(945)に同期

### DIFF
--- a/public/dev/index.html
+++ b/public/dev/index.html
@@ -713,7 +713,7 @@ footer a:hover{ color: var(--ink); border-bottom-color: var(--ink); }
         <b>v0.0.0 (Phase 5 / 公開中)</b>
         Last updated · 2026-07-13<br />
         Branch · main / clean<br />
-        Tests · 933 / 933 PASS
+        Tests · 945 / 945 PASS
         <div class="env-links" role="group" aria-label="環境を開く">
           <a class="env-btn" id="env-dev" href="https://novel-writer-ramnh3ulya-an.a.run.app/" target="_blank" rel="noopener">開発 (dev)<span class="ext" aria-hidden="true">↗</span></a>
           <a class="env-btn" id="env-prod" href="https://novel-writer-df263ic6wa-an.a.run.app/" target="_blank" rel="noopener">本番 (prod)<span class="ext" aria-hidden="true">↗</span></a>
@@ -783,7 +783,7 @@ footer a:hover{ color: var(--ink); border-bottom-color: var(--ink); }
     </div>
     <div class="card">
       <p class="kicker">テスト</p>
-      <h4>920 / 920 PASS</h4>
+      <h4>945 / 945 PASS</h4>
       <p>vitest 全グリーン。tsc --noEmit 0 errors。CI は Deploy to Cloud Run 成功。</p>
     </div>
     <div class="card">


### PR DESCRIPTION
## Summary
- `/dev/` ポータルのヘッダー(933)とマイルストーン進捗カード(920)のテスト件数表示が、実際の `npm run test` 結果(945 passed)からずれていたため実測値に同期

## 背景
着手可能タスクの棚卸し中に発見。CLAUDE.md記載の運用（テスト件数は固定文字列でgrep書き換え）が直近の更新で漏れていたと見られる。

## Test plan
- [x] `npm run test -- --run` で実測値 945 passed を確認
- [x] doc-onlyの変更のため `/code-review` はスコープ外

🤖 Generated with [Claude Code](https://claude.com/claude-code)