### PR TITLE
fix(image-gen): 画像生成モーダルの新規/追加生成ボタン重複表示を解消

### DIFF
--- a/components/ImageGenerationModal.handlers.test.ts
+++ b/components/ImageGenerationModal.handlers.test.ts
@@ -102,3 +102,15 @@ describe('ImageGenerationModal クールダウンとバジー状態の分離 (20
         expect(finalPromptBlock![0]).toMatch(/if \(isCoolingDown\) \{\s*\n\s*setChatHistory\(prev => \[\.\.\.prev, \{[\s\S]*?\}\]\);\s*\n\s*\} else \{\s*\n\s*await handleGenerate\(finalPrompt\);\s*\n\s*\}/);
     });
 });
+
+describe('ImageGenerationModal 簡易生成モードの新規/追加生成ボタン重複表示 (PR #281 static pin)', () => {
+    const source = readFileSync(resolve(__dirname, 'ImageGenerationModal.tsx'), 'utf-8');
+
+    it('簡易生成モードの「画像を生成」ボタンは generatedImages.length === 0 のときのみ描画する（本田様がdev環境実機で発見: 画像生成後も常時表示されると、右パネルの「追加でN枚生成する」ボタンと機能が重複して見え、クールダウン中は両方が同一ラベルになり冗長だった）', () => {
+        // mode === 'simple' 分岐 (else ブロック) 全体を抽出し、その中で「画像を生成」ボタンが
+        // generatedImages.length === 0 の条件でラップされていることを確認する。
+        const simpleModeMatch = source.match(/\} else \{ \/\/ mode === 'simple'[\s\S]*?\n {8}\}\n {4}\};/);
+        expect(simpleModeMatch).toBeTruthy();
+        expect(simpleModeMatch![0]).toMatch(/\{generatedImages\.length === 0 && \(\s*\n[\s\S]*?画像を生成[\s\S]*?\n\s*\)\}/);
+    });
+});

--- a/components/ImageGenerationModal.tsx
+++ b/components/ImageGenerationModal.tsx
@@ -279,19 +279,21 @@ export const ImageGenerationModal = ({ isOpen, onClose, onGenerate, onGeneratePr
                     <div className="bg-gray-900/50 rounded-lg p-3 overflow-y-auto mb-4 text-xs text-gray-400 flex-grow">
                         <p className="whitespace-pre-wrap">{characterDescription || '設定が入力されていません。'}</p>
                     </div>
-                    <div className="mt-auto pt-4">
-                        <button
-                            onClick={() => {
-                                const prompt = `masterpiece, best quality, full body, solo, adult, simple white background, no text, no letters, ${characterDescription.replace(/[\n\r:]+/g, ', ')}`;
-                                handleGenerate(prompt);
-                            }}
-                            disabled={!canUseAi || isBusy || isCoolingDown || !characterDescription.trim()}
-                            title={!canUseAi ? aiBlockedReason : cooldownTitle}
-                            className="w-full flex items-center justify-center gap-2 px-4 py-2 bg-cyan-600 text-sm rounded-md hover:bg-cyan-500 transition text-white disabled:bg-gray-600 disabled:cursor-not-allowed"
-                        >
-                            <Icons.MoonIcon /> {isCoolingDown ? cooldownButtonLabel : '画像を生成'}
-                        </button>
-                    </div>
+                    {generatedImages.length === 0 && (
+                        <div className="mt-auto pt-4">
+                            <button
+                                onClick={() => {
+                                    const prompt = `masterpiece, best quality, full body, solo, adult, simple white background, no text, no letters, ${characterDescription.replace(/[\n\r:]+/g, ', ')}`;
+                                    handleGenerate(prompt);
+                                }}
+                                disabled={!canUseAi || isBusy || isCoolingDown || !characterDescription.trim()}
+                                title={!canUseAi ? aiBlockedReason : cooldownTitle}
+                                className="w-full flex items-center justify-center gap-2 px-4 py-2 bg-cyan-600 text-sm rounded-md hover:bg-cyan-500 transition text-white disabled:bg-gray-600 disabled:cursor-not-allowed"
+                            >
+                                <Icons.MoonIcon /> {isCoolingDown ? cooldownButtonLabel : '画像を生成'}
+                            </button>
+                        </div>
+                    )}
                 </div>
             );
         }


### PR DESCRIPTION
## Summary
- AI立ち絵生成モーダルで、画像を1回でも生成した後は左パネルの「画像を生成」（新規生成、既存結果を破棄）ボタンを非表示にし、右パネルの「追加でN枚生成する」（既存に追加）ボタンのみを表示するよう変更

## 背景
本田様がdev環境実機で、クールダウン中に左右で同一ラベル「あと◯秒お待ちください」のボタンが2つ表示され冗長だと報告。実際には機能の異なる2つのボタン（新規生成 vs 追加生成）だったが、`generatedImages` の状態に関わらず左の新規生成ボタンが常時表示される実装だったため、生成後は両方が同時に見える状態になっていた。

やり直したい場合の導線としては、モーダルを開き直せば `generatedImages` がリセットされ再度「画像を生成」ボタンが出るため、別途「最初からやり直す」ボタンは追加せずシンプルな実装とした（本田様との相談の上でシンプル案を採用）。

## Test plan
- [x] `npm run lint` (tsc --noEmit) エラーなし
- [x] `npm run test -- --run` 945/945 PASS
- [x] Playwright + 一時的なデバッグ変更（`useRequiresAuth` を一時的に `canUseAi: true` 固定、`generatedImages` 初期値にダミー画像2枚）でモーダルの実表示を確認
  - [x] 画像生成前: 左に「画像を生成」ボタンのみ表示
  - [x] 画像生成後(ダミー2枚): 左のボタンが非表示、右に「追加で2枚生成する」ボタンのみ表示
  - [x] 追加生成クリック後のクールダウン中: 右のボタンのみ「あと◯秒お待ちください」表示、左に重複ボタンなし
  - [x] 確認後、デバッグ用の一時変更は全て元に戻し、本来の修正のみが残っていることを diff で確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)