### PR TITLE
fix(world-form): テンプレート間の「種別」キー重複によるグループ誤分類を修正

### DIFF
--- a/components/modals/WorldForm.tsx
+++ b/components/modals/WorldForm.tsx
@@ -148,7 +148,11 @@ export const WorldForm: React.FC<WorldFormProps> = ({
         };
     }, []);
 
-    const populateState = (data) => {
+    // 戻り値は補完済み（groupKey/groupName確定後）のfieldsを含むデータ。
+    // isDirty比較のbaseline（initialStateString）はこれを使う必要がある。
+    // itemToEdit生データ（レガシーデータはgroupKey未保存）をそのままbaselineにすると、
+    // 補完後の実state（fields）と食い違い、未編集でもisDirty=trueになってしまう。
+    const populateState = (data): Partial<SettingItem> => {
         const safeData = data || initialEmptyWorldState;
         setName(safeData.name || '');
         setLongDescription(safeData.longDescription || '');
@@ -156,6 +160,7 @@ export const WorldForm: React.FC<WorldFormProps> = ({
         setExportDescription(safeData.exportDescription || '');
         setMapImageUrl(safeData.mapImageUrl || '');
 
+        let normalizedFields: Field[] = [];
         if (safeData.fields) {
             const initialFields = (safeData.fields || []).map(f => {
                 // groupKeyが保存済みならそれを正とする（複数テンプレートで同名キー「種別」等が
@@ -176,6 +181,7 @@ export const WorldForm: React.FC<WorldFormProps> = ({
                 };
             });
             setFields(initialFields);
+            normalizedFields = initialFields;
 
             const initialExpanded = initialFields.reduce((acc, field) => {
                 acc[field.groupKey] = true;
@@ -186,6 +192,8 @@ export const WorldForm: React.FC<WorldFormProps> = ({
             setFields([]);
             setExpandedGroups({});
         }
+
+        return { ...safeData, fields: normalizedFields };
     };
 
     useEffect(() => {
@@ -219,13 +227,13 @@ export const WorldForm: React.FC<WorldFormProps> = ({
             const hasDataToEdit = itemToEdit && (itemToEdit.id || Object.keys(itemToEdit).length > 0);
             
             if (hasDataToEdit) {
-                populateState(itemToEdit);
+                const populatedData = populateState(itemToEdit);
                 useStore.getState().setFormData('world', itemToEdit);
-                setInitialStateString(JSON.stringify(getNormalizedData(itemToEdit)));
+                setInitialStateString(JSON.stringify(getNormalizedData(populatedData)));
             } else {
                 resetFormData('world'); // ストアにある前回の残骸を消す
-                populateState(initialEmptyWorldState);
-                setInitialStateString(JSON.stringify(getNormalizedData(initialEmptyWorldState)));
+                const populatedData = populateState(initialEmptyWorldState);
+                setInitialStateString(JSON.stringify(getNormalizedData(populatedData)));
             }
             
             setEditedFields(new Set());

--- a/components/modals/WorldForm.tsx
+++ b/components/modals/WorldForm.tsx
@@ -137,7 +137,9 @@ export const WorldForm: React.FC<WorldFormProps> = ({
             name: data?.name || '',
             fields: (data?.fields || []).map((f: any) => ({
                 key: f.key || '',
-                value: f.value || ''
+                value: f.value || '',
+                groupKey: f.groupKey || '',
+                groupName: f.groupName || ''
             })),
             longDescription: data?.longDescription || '',
             memo: data?.memo || '',
@@ -156,9 +158,18 @@ export const WorldForm: React.FC<WorldFormProps> = ({
 
         if (safeData.fields) {
             const initialFields = (safeData.fields || []).map(f => {
+                // groupKeyが保存済みならそれを正とする（複数テンプレートで同名キー「種別」等が
+                // 重複するため、キー名だけからのテンプレート逆引きは一意に定まらない）
+                if (f.groupKey) {
+                    return {
+                        ...f,
+                        id: uuidv4(),
+                        groupName: f.groupName || fieldKeyToTemplateMap.get(f.key)?.name || 'カスタム項目'
+                    };
+                }
                 const templateInfo = fieldKeyToTemplateMap.get(f.key);
-                return { 
-                    ...f, 
+                return {
+                    ...f,
                     id: uuidv4(),
                     groupKey: templateInfo?.key || 'custom',
                     groupName: templateInfo?.name || 'カスタム項目'
@@ -345,8 +356,10 @@ export const WorldForm: React.FC<WorldFormProps> = ({
     const buttonClass = (colorClass: string) => `${colorClass} text-white rounded-md transition btn-pressable flex items-center justify-center gap-2 ${isMobile ? 'p-3 text-base w-full' : 'px-4 py-2 text-sm'}`;
 
     const renderFieldInput = (field: Field) => {
-        const allTemplateFields = Object.values(worldTemplates).flatMap(t => t.fields);
-        const templateField = allTemplateFields.find(f => f.key === field.key);
+        // 複数テンプレートで同名キー（例：「種別」）が重複するため、まず所属テンプレート内で検索する
+        const ownTemplate = worldTemplates[field.groupKey as keyof typeof worldTemplates];
+        const templateField = ownTemplate?.fields.find(f => f.key === field.key)
+            ?? Object.values(worldTemplates).flatMap(t => t.fields).find(f => f.key === field.key);
 
         if (templateField && templateField.type === 'select') {
             const isCustom = !templateField.options.includes(field.value);

--- a/types.ts
+++ b/types.ts
@@ -74,7 +74,7 @@ export interface SettingItem {
     };
     
     // World specific
-    fields?: { key: string, value: string }[];
+    fields?: { key: string, value: string, groupKey?: string, groupName?: string }[];
     mapImageUrl?: string;
 }
 


### PR DESCRIPTION
## Summary
- 世界観フォームで「魔法・技術」テンプレート等を選択して保存すると、再度編集を開いた際に「重要アイテム」グループへ誤分類される不具合を修正
- 全テンプレート共通の「種別」フィールドキーがテンプレート逆引きロジックで衝突していたのが原因（`fieldKeyToTemplateMap` は後勝ち、`renderFieldInput` 側の検索は先勝ちで、select の選択肢も別テンプレートのものが表示される追加バグも実機確認で発覚）
- 保存データに `groupKey`/`groupName` を保持し、編集時はそれを正として復元するよう修正（レガシーデータは従来ロジックへフォールバック）
- **セルフレビューで発見した追加の回帰**: 上記修正により `isDirty` 判定の baseline（`initialStateString`）と実際の state（`fields`）で `groupKey` が食い違い、`groupKey` 未保存のレガシーデータを編集で開くと未編集でも「未保存の変更」ダイアログが出てしまう問題があった。`populateState` を補完済みデータを返す関数に変更し解消（2コミット目）

## Test plan
- [x] `npm run lint`（tsc --noEmit）PASS
- [x] `npm run test`（946 tests）PASS
- [x] Playwright実機確認: 「魔法・技術」単体、「場所」+「重要アイテム」同時適用の両パターンで、保存→再度編集を開いても正しいグループ・正しい選択肢（例: 魔法/科学技術/超能力/その他）で復元されることを確認
- [x] Playwright実機確認: IndexedDBに `groupKey` 未保存のレガシー形式データを直接注入し、編集モーダルを開いて何も変更せずキャンセルしても「未保存の変更」ダイアログが出ないことを確認（回帰なし）
- [x] テスト用に作成したデータはすべてクリーンアップ済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)