### PR TITLE
feat(footer): フッターにX(SNS)アカウントリンクを追加

### DIFF
--- a/components/Footer.test.ts
+++ b/components/Footer.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// Footer は SOCIAL_LINKS (X 等の外部 SNS) を LegalLinkList の extraLinks として渡す契約を pin。
+// TermsConsentModal (同意ダイアログ) は同じ LegalLinkList を使うが SNS リンクは不要なため、
+// extraLinks を渡さない (デフォルト空配列) ことも合わせて防御する。
+
+describe('Footer social link wiring', () => {
+    const footerSource = readFileSync(resolve(__dirname, 'Footer.tsx'), 'utf-8');
+    const termsConsentModalSource = readFileSync(
+        resolve(__dirname, 'modals/TermsConsentModal.tsx'),
+        'utf-8',
+    );
+
+    it('imports SOCIAL_LINKS from legalDocs', () => {
+        expect(footerSource).toMatch(/import \{ SOCIAL_LINKS \} from ['"]\.\.\/legalDocs['"]/);
+    });
+
+    it('passes SOCIAL_LINKS as extraLinks to LegalLinkList', () => {
+        expect(footerSource).toMatch(/extraLinks=\{SOCIAL_LINKS\}/);
+    });
+
+    it('TermsConsentModal does not pass extraLinks (no SNS link in consent dialog)', () => {
+        expect(termsConsentModalSource).not.toMatch(/extraLinks/);
+    });
+});

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { LegalLinkList } from './LegalLinkList';
+import { SOCIAL_LINKS } from '../legalDocs';
 
 export const Footer: React.FC = () => {
     return (
@@ -7,6 +8,7 @@ export const Footer: React.FC = () => {
             <LegalLinkList
                 containerClassName="flex flex-wrap gap-x-4 gap-y-1 justify-center text-xs text-gray-600 dark:text-gray-400"
                 linkClassName="hover:text-indigo-600 dark:hover:text-indigo-400 hover:underline"
+                extraLinks={SOCIAL_LINKS}
             />
         </footer>
     );

--- a/components/LegalLinkList.test.ts
+++ b/components/LegalLinkList.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// LegalLinkList の extraLinks はデフォルト空配列であることを pin する。
+// TermsConsentModal は extraLinks を渡さずこのデフォルトに依存しているため、
+// デフォルト値が誤って削除/必須化されると [...LEGAL_DOCS, ...undefined] となり
+// スプレッド構文が TypeError で落ちる。同意ゲート画面のクラッシュに直結するため
+// 静的 grep で防御する（このプロジェクトのコンポーネントテスト規約に準拠）。
+
+describe('LegalLinkList contract', () => {
+    const source = readFileSync(resolve(__dirname, 'LegalLinkList.tsx'), 'utf-8');
+
+    it('defaults extraLinks to an empty array', () => {
+        expect(source).toMatch(/extraLinks\s*=\s*\[\]/);
+    });
+
+    it('concatenates LEGAL_DOCS before extraLinks (legal docs first, SNS links after)', () => {
+        expect(source).toMatch(/\[\.\.\.LEGAL_DOCS,\s*\.\.\.extraLinks\]/);
+    });
+});

--- a/components/LegalLinkList.test.ts
+++ b/components/LegalLinkList.test.ts
@@ -18,4 +18,8 @@ describe('LegalLinkList contract', () => {
     it('concatenates LEGAL_DOCS before extraLinks (legal docs first, SNS links after)', () => {
         expect(source).toMatch(/\[\.\.\.LEGAL_DOCS,\s*\.\.\.extraLinks\]/);
     });
+
+    it('renders aria-label from doc.ariaLabel (WCAG 2.4.4 Link Purpose)', () => {
+        expect(source).toMatch(/aria-label=\{doc\.ariaLabel\}/);
+    });
 });

--- a/components/LegalLinkList.tsx
+++ b/components/LegalLinkList.tsx
@@ -1,14 +1,15 @@
 import React from 'react';
-import { LEGAL_DOCS } from '../legalDocs';
+import { LEGAL_DOCS, LegalDoc } from '../legalDocs';
 
 interface Props {
     containerClassName: string;
     linkClassName: string;
+    extraLinks?: ReadonlyArray<LegalDoc>;
 }
 
-export const LegalLinkList: React.FC<Props> = ({ containerClassName, linkClassName }) => (
+export const LegalLinkList: React.FC<Props> = ({ containerClassName, linkClassName, extraLinks = [] }) => (
     <ul className={containerClassName}>
-        {LEGAL_DOCS.map(doc => (
+        {[...LEGAL_DOCS, ...extraLinks].map(doc => (
             <li key={doc.url}>
                 <a
                     href={doc.url}

--- a/components/LegalLinkList.tsx
+++ b/components/LegalLinkList.tsx
@@ -15,6 +15,7 @@ export const LegalLinkList: React.FC<Props> = ({ containerClassName, linkClassNa
                     href={doc.url}
                     target="_blank"
                     rel="noopener noreferrer"
+                    aria-label={doc.ariaLabel}
                     className={linkClassName}
                 >
                     {doc.label}

--- a/legalDocs.test.ts
+++ b/legalDocs.test.ts
@@ -48,4 +48,11 @@ describe('SOCIAL_LINKS', () => {
             expect(legalUrls.has(link.url)).toBe(false);
         }
     });
+
+    it('every entry has a descriptive ariaLabel (WCAG 2.4.4 Link Purpose)', () => {
+        // 'X' のような短いラベルだけでは、外部SNSリンクであることがスクリーンリーダーで伝わらないため必須。
+        for (const link of SOCIAL_LINKS) {
+            expect(link.ariaLabel?.length ?? 0).toBeGreaterThan(0);
+        }
+    });
 });

--- a/legalDocs.test.ts
+++ b/legalDocs.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { LEGAL_DOCS } from './legalDocs';
+import { LEGAL_DOCS, SOCIAL_LINKS } from './legalDocs';
 
 // PR-D-2: legalDocs.ts は静的定数で、Footer / TermsConsentModal が link 先として参照する。
 // AC-7 (footer 3 link 表示) の前提条件として URL 形状と件数を pin する。
@@ -31,5 +31,21 @@ describe('LEGAL_DOCS', () => {
     it('labels are unique (avoid duplicate footer entries)', () => {
         const labels = LEGAL_DOCS.map(doc => doc.label);
         expect(new Set(labels).size).toBe(labels.length);
+    });
+});
+
+describe('SOCIAL_LINKS', () => {
+    it('every entry has a non-empty label and an https URL', () => {
+        for (const link of SOCIAL_LINKS) {
+            expect(link.label.length).toBeGreaterThan(0);
+            expect(link.url).toMatch(/^https:\/\//);
+        }
+    });
+
+    it('does not overlap with LEGAL_DOCS urls', () => {
+        const legalUrls = new Set(LEGAL_DOCS.map(doc => doc.url));
+        for (const link of SOCIAL_LINKS) {
+            expect(legalUrls.has(link.url)).toBe(false);
+        }
     });
 });

--- a/legalDocs.ts
+++ b/legalDocs.ts
@@ -9,6 +9,7 @@
 export interface LegalDoc {
     label: string;
     url: string;
+    ariaLabel?: string;
 }
 
 export const LEGAL_DOCS: ReadonlyArray<LegalDoc> = [
@@ -20,5 +21,5 @@ export const LEGAL_DOCS: ReadonlyArray<LegalDoc> = [
 // Footer にのみ表示する外部 SNS リンク。LEGAL_DOCS とは意味が異なる
 // (法的文書ではない、same-origin でもない) ため別定数として保持する。
 export const SOCIAL_LINKS: ReadonlyArray<LegalDoc> = [
-    { label: 'X', url: 'https://x.com/novelwriter_app' },
+    { label: 'X', url: 'https://x.com/novelwriter_app', ariaLabel: 'X（旧Twitter）' },
 ];

--- a/legalDocs.ts
+++ b/legalDocs.ts
@@ -16,3 +16,9 @@ export const LEGAL_DOCS: ReadonlyArray<LegalDoc> = [
     { label: 'プライバシーポリシー', url: '/legal/privacy-policy.html' },
     { label: '特定商取引法に基づく表記', url: '/legal/tokushou.html' },
 ];
+
+// Footer にのみ表示する外部 SNS リンク。LEGAL_DOCS とは意味が異なる
+// (法的文書ではない、same-origin でもない) ため別定数として保持する。
+export const SOCIAL_LINKS: ReadonlyArray<LegalDoc> = [
+    { label: 'X', url: 'https://x.com/novelwriter_app' },
+];


### PR DESCRIPTION
## Summary
- フッター（「利用規約 / プライバシーポリシー / 特定商取引法に基づく表記」の並び）に X（旧Twitter）公式アカウントリンクを追加
- `LEGAL_DOCS` は「same-origin の法的文書3件」であることを契約テストで pin しているため、そこに外部SNSリンクを混ぜず、別定数 `SOCIAL_LINKS` を `legalDocs.ts` に新設
- `LegalLinkList` に任意の `extraLinks` prop を追加し、`Footer.tsx` からのみ渡すことで、`TermsConsentModal`（同意ダイアログ、SNSリンク不要）への影響を排除

## Test plan
- [x] `npm run lint`（tsc --noEmit）PASS
- [x] `npm run test`（951 tests、新規7件追加）PASS
- [x] Playwright実機確認: Footerに4リンク（利用規約/プライバシーポリシー/特定商取引法に基づく表記/X）が正しいURLで表示されることを確認。`TermsConsentModal` 側の `LegalLinkList` 呼び出しに `extraLinks` が渡っていない（SNSリンクが出ない）ことをソース確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)