### PR TITLE
docs(handoff): 世界観フォームバグ修正・法務文書クリーンアップ・Footer SNSリンクセッションを記録

### DIFF
--- a/docs/handoff/2026-07-13-dev-portal-image-gen-ux-completion.md
+++ b/docs/handoff/2026-07-13-dev-portal-image-gen-ux-completion.md
@@ -1,0 +1,279 @@
+# Handoff: 2026-07-12/13 画像生成429問題の根本原因解明・UIクールダウン方式へ移行（PR #269）→ Imagen4調査 → 開発者アカウントTier免除実装（PR #275）→ `/dev/`ポータル整備・画像生成モーダルUX改善（PR #278〜#281）まで完了
+
+- Session Date: 2026-07-12 〜 2026-07-13
+- Owner: yasushi-honda
+- Status: ✅ 完了（PR #269〜#281 全てdev+prod反映済み。開発者アカウントのTier 1月間予算免除機構をprod反映しCloud Loggingで間接実機確認、`/dev/`ポータルのドキュメント整備・表示崩れ修正、画像生成モーダルの重複ボタン表示解消まで完了）
+- Previous: [2026-07-12d-icon-devportal-image-error-investigation.md](./2026-07-12d-icon-devportal-image-error-investigation.md)
+
+## セッション要旨
+
+前セッション（2026-07-12前半）で「アプリのバグではない、一時的なクォータ超過」と判定した画像生成429エラーが、その後の実利用で複数回再発。3段階の試行錯誤を経て、UIクールダウン方式（PR #269）に到達し、さらにdev実機検証で429の**真の原因が2系統ある**ことを解明した。
+
+### 429対応の経緯（3段階）
+1. **PR #267**: サーバー側リトライ実装（3秒→8秒）→ prodで再発
+2. **PR #268**: リトライ待機時間延長（10秒→20秒→40秒、合計70秒）→ prodで再発
+3. **PR #269**: 本田様の提案「連続では出来ないことを書いておく方が良い」を受け、リトライを撤去しFE側クールダウンUIに転換。実際のVertex AI quota（`generate_content_image_gen_per_project_per_base_model_global` = 2 req/分/プロジェクト/モデル）をgcloudで確認し、リトライ自体が同じ1分ウィンドウの追加消費になっていた疑いを特定
+
+### PR #269 のlarge tier必須レビューで検出・修正した2件の重大バグ
+- **Codex review-diff P1**: `handleGenerate`が`await onGenerate`完了後にクールダウンを開始していたため、生成中に閉じるボタンでモーダルを閉じてすぐ開き直すと、in-flightリクエストと新規リクエストが重複発行されquotaを倍消費しうる状態だった。クールダウン開始を`await`の前に移動して修正
+- **silent-failure-hunter / comment-analyzer（2系統独立指摘）**: クールダウン時間120秒が、コメント自身が引用する実測回復時間169秒より短いという指摘。本田様確認の上180秒に引き上げ
+
+### dev実機検証で判明した429の「真の原因は2系統」（本セッション最大の発見）
+Codexへのセカンドオピニオン相談で「180秒固定クールダウンは429を防ぐ保証にならない」との指摘を受け、実際に何分間隔なら安全かをdev環境で実測しようとしたところ、想定外の事実が判明した。
+
+1. **アプリ内部のTier 1月間予算（100円/月）の枯渇**: `image/generate`は1回12円のため月8回程度で枯渇する。当初の実測（3分半〜6分半間隔でも429が3連続）はこれが原因で、**Vertex AI側のクォータとは無関係**だった。Firestoreの`usage/{uid}_{yyyymm}`ドキュメントで`quotaExceededCounts.image/generate: 3`と実測回数が完全一致し確定
+2. **Vertex AI側の実際のクォータ**: 上記の発見を受け、本田様の明示承認を得て`server/middleware/withUsageQuota.ts`にdev限定・二重ガード付き（`GCP_PROJECT !== 'novel-writer-prod'`）のTier 1バイパスコードを一時追加し、devに限定デプロイして実測。**2分39秒〜4分47秒の間隔で13回連続成功、1分33秒の間隔では429が発生**という結果を得た。境界は「1分33秒〜2分39秒」の間と推定され、180秒（3分）はこれを安全にカバーする値と確認。検証後、バイパスコードは完全に削除し、devは正規のCI/CDビルド（`4ba1b54`）に復旧済み
+
+## 本セッション merged PR（1件）
+
+| PR | 内容 | 規模 | 種別 |
+|----|------|------|------|
+| #269 | fix(image): 429リトライを撤去しUIクールダウンに置換 | 5 files, +168/-92 | バグ修正（large tier） |
+
+## 同根再発スキャン（§4.6）— ⚠️ 重要な監視事項あり
+
+過去7日のhandoffアーカイブを検索した結果、**2026-07-05のhandoff「model-migration-quota-redesign」で「dev実機で最後の成功から15分以上429が継続」「6回失敗後、約2時間のquota回復待ちで別プロンプトが成功」という観測**が記録されていた。これは本セッションの実測（13回連続成功、境界は1分33秒〜2分39秒）と一見矛盾する。
+
+**上流の真のroot cause仮説（3つ）**:
+1. Vertex AI側のクォータは`gcloud alpha services quota list`の公称値（2 req/分）とは別に、Dynamic Shared Quota（需要に応じて変動する共有容量）の影響を受けており、時間帯・全体負荷によって実際の許容範囲が大きく変動する（Codexのセカンドオピニオンでも同じ仮説が最有力とされた）
+2. 7/5時点の観測は本当にVertex AI側の長時間の制限だった可能性が高い（Tier 1予算枯渇なら「来月まで」絶対回復しない設計のため、2時間で回復した事実と整合しない）
+3. 今回の13回連続成功は「たまたま空いていた時間帯」だった可能性があり、180秒という値の恒久的な安全性を保証するものではない
+
+**もう1件同根が出るとしたらどこか**: prodで複数ユーザーが同時にアクセスする、またはGoogle側のリソースが逼迫する時間帯に、180秒のクールダウンでも429が再発する可能性がある。その場合は「UI側の対策では不十分、サーバー側の共有状態管理（既知の限界としてPR説明文に明記済み）が必要」という結論に至る可能性が高い。
+
+## 対症療法判定（§4.7）
+
+判定基準3（同症状の修正PRが過去30日以内に複数：#266→#267→#268→#269）に該当。ただしCodexセカンドオピニオン内でのWeb Search（Vertex AI公式ドキュメント参照）とgcloud quota実測・Firestore実データ確認・13回のdev実機検証という構造的検証を実施しており、対症療法ではなく根本原因（Tier 1予算枯渇という新発見の経路＋Vertex AI側の変動するDSQ）の特定に至っている。ただし上記の同根再発スキャンで判明した通り、180秒という値自体はVertex AI側の変動要因に対する理論保証ではなく実測ベースの安全マージンである点はPR説明文にも明記済み。
+
+## Issue Net 変化
+
+- Close数: 0件
+- 起票数: 0件
+- Net: 0件（今回の発見はtriage基準の「実害」「再現バグ」には該当せず、PR説明文・本handoffへの記録で対応）
+
+## 2026-07-13 追記: Imagen4調査結果 + PR #269 prod反映完了
+
+### Imagen4調査結果（即着手タスク#1、完了）
+
+`gcloud alpha services quota list --service=aiplatform.googleapis.com`（asia-northeast1実測）で、Imagen4系（fast/standard/ultra全ライン）のクォータは`online_prediction_requests_per_base_model` = **20 req/分**と判明。現行Nano Banana 2 Lite（`generate_content_image_gen_per_project_per_base_model` = 2 req/分）の**10倍**で、数字だけ見れば魅力的だった。
+
+しかし公式ドキュメント（`docs.cloud.google.com/vertex-ai/generative-ai/docs/models/imagen/4-0-{generate,fast-generate,ultra-generate}-001`、およびVertex AI release notes）を個別に直接確認したところ、**Imagen4は`imagen-4.0-{,fast-,ultra-}generate-001`全ラインが2026年3月24日付で公式に廃止発表済み、Discontinuation date 2026年6月30日を経過している**ことが判明（移行推奨先: `gemini-2.5-flash-image`、現行モデルより旧世代）。検索結果に出た`imagen-4.0-generate-preview-06-06`という別バージョンもcurlで確認したところ301リダイレクトで同一の廃止対象ページに転送されるだけで、抜け道は存在しない。
+
+**結論: Imagen4への切替は不採用**。10倍クォータは公式に廃止された製品ラインの数字であり、実生成テスト（速度・成功率比較）は実施する意味がないため見送った。現行のNano Banana 2 Lite + UIクールダウン方式（PR #269、180秒）を継続するのが現時点の最適解と判断（本田様確認済み、「最適解で進めましょう」の指示を受けPR #269 prod反映を実施）。
+
+料金（$0.02〜$0.06/画像という数字）は複数の二次情報源はあったが、公式pricing pageが長大でWebFetchツールがtruncateし一次ソースでの裏取りはできなかった。ただし廃止済みモデルのため実務上の影響はない。
+
+### PR #269 prod反映（条件待ち#1、完了）
+
+本田様の明示指示「最適解で進めましょう。prod反映ができたら」を受け、`gh workflow run deploy-prod.yml --ref main`を実行。
+
+- Workflow run: [29212549257](https://github.com/Yukina1116/novel-writer/actions/runs/29212549257)（test job → deploy job、共に success）
+- 反映確認: `gcloud run services describe novel-writer --project=novel-writer-prod --region=asia-northeast1 --format="value(spec.template.spec.containers[0].image)"` → イメージタグ `1e1b614...`（mainのHEAD、PR #269 + #270まで反映）と一致確認済み
+
+## 次のアクション（3分割）
+
+### 即着手タスク
+
+なし（Imagen4調査は完了・PR #269 prod反映も完了）。
+
+<details>
+<summary>完了済みタスク（参考、折りたたみ）</summary>
+
+| # | タスク | ROI | 想定工数 | 完了条件 | 関連ファイル / コマンド |
+|---|--------|-----|----------|---------|------------------------|
+| 1 | ~~Imagen4モデルでの画像生成クォータ・生成体験を調査し、Nano Banana 2 Lite（現行）と比較~~ ✅完了(2026-07-13) | 本田様から明示指示「imagen4だったらこんなにも不便なのか、確認してください」。現行モデルはTier 1予算(100円/月=8回程度)+Vertex AIクォータ(2 req/分、実測境界1分33秒〜2分39秒)の二重の不便さがある | 30-60分（gcloud quota確認+実際の生成テスト） | Imagen4の`gcloud alpha services quota list`でのクォータ値確認、可能であれば実際に数回生成して体感速度・成功率を比較、現行モデルとのトレードオフ（画質・速度・コスト・クォータ）を本田様に報告 | `gcloud alpha services quota list --service=aiplatform.googleapis.com` |
+
+</details>
+
+### 条件待ち（明示 trigger 付き）
+
+| # | 項目 | trigger（充足条件） | 充足時のタスク | 充足確認方法 |
+|---|------|------------------|--------------|------------|
+| 1 | ~~PR #269（429リトライ撤去+UIクールダウン）のprodへの反映~~ | ✅完了(2026-07-13)。本田様の明示指示「最適解で進めましょう。prod反映ができたら」 | `gh workflow run deploy-prod.yml --ref main`実行、run [29212549257](https://github.com/Yukina1116/novel-writer/actions/runs/29212549257)成功、イメージSHA `1e1b614`一致確認済み | 完了 |
+| 2 | prodで429が再発した場合の調査 | 実際の429再発報告 | 同根再発スキャンで記録した仮説（DSQ変動）を優先的に検証。Cloud Loggingで429本文（`Quota exceeded`か`Resource exhausted, please try again later`か）を確認し、明示クォータ超過か共有容量不足かを判別 | `gcloud logging read` |
+| 3 | Issue #232の次の一手（可視化/サブ上限/コンバージョン導線） | 計測データが一定量蓄積された後の本田様の方針判断 | Issue #232本文の4論点から選択、`/impl-plan`で計画立案 | `gh issue view 232` |
+| 4 | Issue #156/#152/#147/#137 | 各Issue本文記載のtrigger | 各Issue本文参照 | `gh issue view <N>` |
+| 5 | Issue #243 対応候補(b)（安全フィルタ拒否時の専用エラーメッセージ分岐、PR #266で一部実装済み）/(c)（追加検証） | 本田様の優先度判断 | Issue #243本文の対応候補(b)(c)から選択、`/impl-plan`で計画立案 | `gh issue view 243` |
+
+### 却下候補（記録のみ、前セッションから引き継ぎ）
+
+| # | 項目 | 検討経緯 | 着手しない理由 |
+|---|------|---------|---------------|
+| 1 | サーバー側での共有状態管理（Firestore等）によるプロジェクト全体のクォータ制御 | Codex review-diff P1指摘、PR #269の既知の限界に明記済み | 複数タブ/複数ユーザーの合算超過防止には必要だが、現状の利用規模では過剰実装の可能性。本田様の明示指示なし |
+| 2 | `characterService.ts`/`ImageGenerationModal.tsx` の `full body`/`solo`/`simple white background` ハードコード | 前々セッションのExplore agent二次発見 | 「AI立ち絵生成」機能の性質上、意図的な仕様である可能性が高くROI不明確 |
+| 3 | 未成年設定キャラクターのAI立ち絵生成が構造的に失敗する制約 | PR #266で`personGeneration: ALLOW_ALL`に変更し一部緩和済み | 残る制約はGoogle Prohibited Use Policyによる安全フィルタの正常動作であり、AIが「直すべき」と判断すること自体が越権 |
+
+> ⚠️ 「優先順にすすめて」等の包括指示で次セッションが動けるのは即着手タスクのみ（今回は0件、全て条件待ちまたは却下候補）。
+
+## 2026-07-13 追記②: 開発者アカウントTier 1月間予算免除の実装・prod反映完了
+
+### セッション要旨
+
+本田様がprodでAI機能をテストする際、Tier 1月間予算（100円/月=10000sen）を頻繁に使い切ってしまう問題に対し、まず1回限りのGitHub Actions workflowで応急対応し、その後恒久的な「開発者override」機構を実装・prod反映した。
+
+**1回限り対応（PR #273/#274）**: `usage/{uid}_{yyyymm}`ドキュメントのusedCostを手動リセットするworkflowを作成・実行・削除。実行過程でADCアカウント不一致（gcloud CLIは`hy.unimail.11@gmail.com`だがADCは`yasushi.honda@aozora-cg.com`という別アカウント）とFirebase Auth権限不足（`roles/firebaseauth.admin`が別SAにのみ付与）を発見し、本田様の明示承認を得てIAM権限を一時付与→実行→即時取消の手順で対処。usedCost 9100→0のリセットを実測確認。
+
+**恒久対応（PR #275）**: `DEVELOPER_UIDS`環境変数に含まれるuidをTier 1の10倍（`DEVELOPER_OVERRIDE_LIMIT_SEN`=100,000sen=1000円相当）の上限で運用する「開発者override」を実装。Codexへのセカンドオピニオン（plan mode）を経て、Tier概念（課金プラン）とは意図的に分離した設計とした。
+
+### 品質ゲートで検出・修正した重大な設計ミス
+
+`/code-review high`（8角度find+1票verify）で4件CONFIRMED/PLAUSIBLE指摘を検出:
+1. **[CONFIRMED]** 当初`reserve()`の`limit`を`number | undefined`とし`undefined`=完全無制限で設計していたが、暴走ループ・リトライバグ等への歯止めが一切ないと指摘。本田様の判断で「高いが有限の上限」方式に変更し、`reserve()`のシグネチャ変更自体を巻き戻した
+2. **[CONFIRMED]** `deploy-prod.yml`の`flags`内でsecret値が未クォートのまま埋め込まれており、値に空白が入るとデプロイが壊れるリスク → ダブルクォートで囲んで修正
+3. **[CONFIRMED]** override発動が完全にサイレント（ログなし）→ `logger.info`で監査ログを追加
+4. **[PLAUSIBLE]** dev環境（`deploy.yml`）には同じ免除が配線されていない → GOAL.mdに既知のスコープ判断として記録（対応不要、本田様の明示指示なし）
+
+さらに`/review`でPR diffを再確認した際、`developerOverride.ts`冒頭コメントが巻き戻し前の古い設計（"limitをundefinedとして扱う"）のまま残っていた見落としを発見・修正。`codex review-diff`では重大な問題なしとの評価。
+
+### prod反映・実機確認
+
+`gh workflow run deploy-prod.yml`でデプロイ実行、イメージSHA `7e2a19c`（PR #275）→ `1852c99`（PR #276、GOAL.md更新）まで一致確認。`gcloud run services describe`で`DEVELOPER_UIDS`を含む全6環境変数が破壊されずに反映されていることを実機確認（`^;^`区切り文字構文が正常動作）。
+
+### セッション中のトラブルと復旧
+
+GOAL.md更新作業中に`git reset --soft HEAD~1`を誤って`main`ブランチに対して実行し、ローカルの`main`がPR #275マージ前に巻き戻る事故が発生（リモートは無事）。stash退避を経て`git reset --hard origin/main`で安全に復旧。また、GOAL.mdに本田様のFirebase uidを平文で書きそうになった箇所を自動モードのガードレールが検出しブロック、uidを含まない形に修正した。
+
+## 本セッション merged PR（追加5件、計6件）
+
+| PR | 内容 | 規模 | 種別 |
+|----|------|------|------|
+| #271 | docs: Imagen4調査結果とPR #269 prod反映をハンドオフに記録 | 2 files, +37/-11 | ドキュメント |
+| #272 | docs(dev-portal): テスト件数とLast Updatedを実測値に同期 | 1 file, +2/-2 | ドキュメント |
+| #273 | ops: 本番usageリセット用の1回限りworkflowを追加 | 2 files, +105 | 運用ツール（一時） |
+| #274 | ops: 実行完了した本番usageリセットの1回限りworkflowを削除 | 2 files, -105 | 運用ツール（一時、削除） |
+| #275 | feat(usage): 開発者アカウントをTier 1月間予算から免除 | 7 files, +210/-4 | 新機能（large tier） |
+| #276 | docs(goal): PR #275 prod反映完了をGOAL.mdに記録 | 1 file, +6/-4 | ドキュメント |
+
+## デプロイ状況
+
+- dev: `1852c99`（PR #276マージ後の正規CI/CDビルド）に一致、CI（Deploy to Cloud Run）成功確認済み
+- prod: `1852c99`相当（実デプロイは`7e2a19c`＝PR #275時点、GOAL.md更新のPR #276はドキュメントのみのためprod再デプロイ不要）に一致。`DEVELOPER_UIDS`含む全環境変数の実機反映確認済み。**dev/prod完全同期**
+
+## 次のアクション（3分割）
+
+### 即着手タスク
+
+なし（executor領分の作業は全て完了。残る候補は全て外部trigger待ち）。
+
+### 条件待ち（明示 trigger 付き）
+
+| # | 項目 | trigger（充足条件） | 充足時のタスク | 充足確認方法 |
+|---|------|------------------|--------------|------------|
+| 1 | 開発者override機構の実機動作確認（GOAL.md最終タスク） | 本田様ご自身がprodでAI機能（image/generate等）をテストし、クォータ超過エラーが出ないことを確認 | 本田様からの確認結果報告を待つのみ、AI側の追加作業なし | 本田様への確認 |
+| 2 | dev環境（`deploy.yml`）へのDEVELOPER_UIDS配線 | dev環境でも同様のTier1予算枯渇が発生した場合の本田様指示 | `deploy.yml`に同様の環境変数配線を追加、`/impl-plan`軽量モードで計画 | 本田様への確認、または`gh workflow run`可否の指示 |
+| 3 | 別プロジェクト（aozora-sns-auto/apps/admin-web）の残留devサーバー（PID 52872）停止 | 本田様の停止指示（並行実行中の別セッションの可能性があるため） | `~/.claude/scripts/cleanup-node.sh --kill`または該当プロセスを個別kill | `ps -p 52872` |
+| 4 | prodで429が再発した場合の調査 | 実際の429再発報告 | 同根再発スキャンで記録した仮説（DSQ変動）を優先的に検証。Cloud Loggingで429本文を確認 | `gcloud logging read` |
+| 5 | Issue #232の次の一手（可視化/サブ上限/コンバージョン導線） | 計測データが一定量蓄積された後の本田様の方針判断 | Issue #232本文の4論点から選択、`/impl-plan`で計画立案 | `gh issue view 232` |
+| 6 | Issue #156/#152/#147/#137 | 各Issue本文記載のtrigger | 各Issue本文参照 | `gh issue view <N>` |
+| 7 | Issue #243 対応候補(b)/(c) | 本田様の優先度判断 | Issue #243本文参照、`/impl-plan`で計画立案 | `gh issue view 243` |
+
+### 却下候補（記録のみ）
+
+| # | 項目 | 検討経緯 | 着手しない理由 |
+|---|------|---------|---------------|
+| 1 | サーバー側での共有状態管理（Firestore等）によるプロジェクト全体のクォータ制御 | Codex review-diff P1指摘、PR #269の既知の限界に明記済み | 複数タブ/複数ユーザーの合算超過防止には必要だが、現状の利用規模では過剰実装の可能性。本田様の明示指示なし |
+| 2 | `characterService.ts`/`ImageGenerationModal.tsx` の `full body`/`solo`/`simple white background` ハードコード | 前々セッションのExplore agent二次発見 | 「AI立ち絵生成」機能の性質上、意図的な仕様である可能性が高くROI不明確 |
+| 3 | 未成年設定キャラクターのAI立ち絵生成が構造的に失敗する制約 | PR #266で`personGeneration: ALLOW_ALL`に変更し一部緩和済み | 残る制約はGoogle Prohibited Use Policyによる安全フィルタの正常動作であり、AIが「直すべき」と判断すること自体が越権 |
+| 4 | dev環境への開発者override先行実装 | 本セッションでprodのみ実装 | ROI不明確（devでの予算枯渇は未報告）、本田様の明示指示なし。条件待ち#2として保持 |
+
+## 再開可能性判定
+
+✅ **再開可能** - ドキュメントから開発再開できます。即着手タスク0件、全て条件待ち（本田様の確認・指示待ち）。
+
+## 最終結論
+
+✅ **セッション終了可** — 残作業ゼロ、Git clean、dev/prod完全同期済み
+
+- OPEN PR: 0件（#271〜#276 全てマージ・ブランチ削除済み）
+- active Issue: 5件（すべてdecision-maker明示指示待ちまたはtrigger待ち、Net 0）
+- Git: clean（`main`ブランチ、`origin/main`と同期済み、`1852c99`）
+- 即着手タスク: 0件 / 条件待ち: 7件 / 却下候補: 4件
+- 同根再発スキャン（§4.6）: 過去7日アーカイブ0件ヒット。「Tier 1」というキーワードが過去handoffにヒットしたのはM6暗号化バックアップ機能の同名異義語のみで、真の同根なし。PR #273/#274→#275は同一問題への段階対応（応急→恒久）であり、悪い意味での同根再発ではない
+- 対症療法判定（§4.7）: 該当なし。retry/fallback等の表面的対処ではなく、Codexセカンドオピニオン+`/code-review high`構造的検証を経た根本対応（Tier概念と分離した運用上例外の新規実装）
+- 残留プロセス: 1件検出（別プロジェクト `aozora-sns-auto/apps/admin-web` の pnpm dev、PID 52872、⚠️本チェックは現在のプロジェクトに限らないマシン全体のチェック。並行実行中の別セッションの可能性があるため停止は条件待ち#3に留める）
+- テスト: `npm run lint` PASS、`npm run test` 945/945 PASS
+- 既知の blocker: なし（残タスクは全て本田様の確認・判断待ちで、AI側のblockerではない）
+
+## 2026-07-13 追記③: 開発者Tier免除の間接実機確認 + `/dev/`ポータル整備 + 画像生成モーダルUX改善
+
+### セッション要旨
+
+本田様がdev環境（`novel-writer-ramnh3ulya-an.a.run.app/dev/`）でAI立ち絵生成を実機テストしたスクリーンショットを提示。当初「開発者Tier免除の確認」として提示されたが、実際に写っていたのはPR #269のFE側クールダウンUI（Tier免除とは無関係の別機構）だった。そこでprod環境のCloud Loggingを直接確認したところ、`usage:developer-override applied`ログが4件記録されており（対象uidに対し `image/generate` / `character/image-prompt`、limit=100000 sen）、GOAL.mdの最終タスクの**間接証拠**を得た（本田様ご自身の明示確認はまだ得られていないため`[ ]`は維持）。
+
+この過程で誤りも1件あった: URLがdev環境かprod環境か未確認のまま「prod実機確認完了」と断定しかけたが、`gcloud run services describe`で両環境のURLを個別に照合し、スクショはdev環境（override未配線）、Cloud Loggingの証跡はprod環境という食い違いに気づき訂正した。
+
+### `/dev/`ポータル整備（PR #278、#280）
+
+本田様の承諾を得て、上記クールダウンUIのスクリーンショットを実例として`/dev/`ポータルの「② AI 生成 — withUsageQuota 3-phase」セクションに追加（`public/dev/images/image-generation-cooldown.jpg`、270KB→124KBにリサイズ）。あわせて、これまでドキュメント化されていなかった`DEVELOPER_UIDS`環境変数を環境変数テーブルに追記。さらに、着手可能タスクの棚卸し中にテスト件数表示のズレ（ヘッダー933件・進捗カード920件、実測945件）を発見し実測値に同期（PR #280）。
+
+### `/dev/`ポータル表示崩れ修正（PR #279、2段階）
+
+本田様がdev環境実機で「主要ファイル」カードの文字はみ出しを発見・報告。1回目の修正（`.card h4`にのみ`overflow-wrap`付与）では不十分で、本文`<p>`内の`TERMS_VERSION_MISMATCH`のような長いコード識別子がなお隣カードにはみ出す再発が発生。`overflow-wrap`は継承プロパティであるため`.card`自体に指定し直し、子要素（h4/p/kicker）全てをカバーする形で解消した。原因は CSS Grid アイテム(`.card`)のデフォルト `min-width: auto` により、空白なしの長い文字列がカード幅を押し広げていたこと。
+
+### 画像生成モーダルの重複ボタン表示修正（PR #281）
+
+本田様が「同じボタンが2つ重複して冗長」と実機スクショで報告。調査の結果、簡易生成モードの「画像を生成」ボタン（新規生成、既存結果を破棄）が`generatedImages`の状態に関わらず常時表示される実装になっており、画像生成後は右パネルの「追加でN枚生成する」ボタン（既存に追加）と機能の異なる2つのボタンが並び、クールダウン中はどちらも同一ラベルになって見分けがつかなくなっていた。ユーザーの要望「シンプルな実装で」を受け、`generatedImages.length === 0`のときのみ左ボタンを表示する条件分岐を追加。既存の static pin テストパターン（`readFileSync` + regex）に合わせた回帰防止テストも追加し、条件分岐を一時的に外してテストがFAILすることを確認した上でコミットした。
+
+動作確認は一時的に `useRequiresAuth` を `canUseAi: true` 固定、`generatedImages` 初期値にダミー画像2枚を入れてPlaywrightで実表示を確認し、確認後は全てのデバッグ用変更を元に戻してからコミットした（本来のソース変更のみが残っていることをdiffで確認済み）。
+
+修正後、ユーザーから「再生成ボタンが出せない」という別の問い合わせがあったが、これは既存機能「修正して再生成」（魔法の杖アイコン）の話で、生成された画像をクリックして選択すると表示される仕組みだった（今回の修正とは無関係、使い方説明で解決）。
+
+## 本セッション merged PR（4件）
+
+| PR | 内容 | 規模 | 種別 |
+|----|------|------|------|
+| #278 | docs(dev-portal): AI立ち絵生成クールダウンの実機キャプチャとDEVELOPER_UIDS追記 | 2 files, +12/-0 | ドキュメント |
+| #279 | fix(dev-portal): カード本文中の長いコード文字列も折り返し対象に含める（1回目#278直後の追加コミット含め計2コミット） | 1 file, +4/-4 | バグ修正 |
+| #280 | docs(dev-portal): テスト件数表示を実測値(945)に同期 | 1 file, +2/-2 | ドキュメント |
+| #281 | fix(image-gen): 画像生成モーダルの新規/追加生成ボタン重複表示を解消（回帰テスト追加含む） | 2 files, +40/-13 | バグ修正 |
+
+## 次のアクション（3分割）
+
+### 即着手タスク
+
+なし（executor領分の作業は全て完了。残る候補は全て外部trigger待ち）。
+
+### 条件待ち（明示 trigger 付き）
+
+| # | 項目 | trigger（充足条件） | 充足時のタスク | 充足確認方法 |
+|---|------|------------------|--------------|------------|
+| 1 | 開発者override機構の実機動作確認（GOAL.md最終タスク） | 本田様ご自身がprodでAI機能（image/generate等）をテストし、クォータ超過エラーが出ないことを確認・報告 | 確認結果報告を待つのみ、AI側の追加作業なし。prod Cloud Loggingでの間接証拠は取得済み | 本田様への確認 |
+| 2 | dev環境（`deploy.yml`）へのDEVELOPER_UIDS配線 | dev環境でも同様のTier1予算枯渇が発生した場合の本田様指示 | `deploy.yml`に同様の環境変数配線を追加、`/impl-plan`軽量モードで計画 | 本田様への確認、または`gh workflow run`可否の指示 |
+| 3 | 別プロジェクト（sanwa-houkai-app/web）の残留devサーバー停止 | 本田様の停止指示（並行実行中の別セッションの可能性があるため） | `~/.claude/scripts/cleanup-node.sh --kill`または該当プロセスを個別kill | `pgrep -fl "next dev"` |
+| 4 | Issue #232の次の一手（可視化/サブ上限/コンバージョン導線） | 計測データが一定量蓄積された後の本田様の方針判断 | Issue #232本文の4論点から選択、`/impl-plan`で計画立案 | `gh issue view 232` |
+| 5 | Issue #156/#152/#147/#137 | 各Issue本文記載のtrigger | 各Issue本文参照 | `gh issue view <N>` |
+
+### 却下候補（記録のみ）
+
+| # | 項目 | 検討経緯 | 着手しない理由 |
+|---|------|---------|---------------|
+| 1 | サーバー側での共有状態管理（Firestore等）によるプロジェクト全体のクォータ制御 | Codex review-diff P1指摘、PR #269の既知の限界に明記済み | 複数タブ/複数ユーザーの合算超過防止には必要だが、現状の利用規模では過剰実装の可能性。本田様の明示指示なし |
+| 2 | `characterService.ts`/`ImageGenerationModal.tsx` の `full body`/`solo`/`simple white background` ハードコード | 前々セッションのExplore agent二次発見 | 「AI立ち絵生成」機能の性質上、意図的な仕様である可能性が高くROI不明確 |
+| 3 | 未成年設定キャラクターのAI立ち絵生成が構造的に失敗する制約 | PR #266で`personGeneration: ALLOW_ALL`に変更し一部緩和済み | 残る制約はGoogle Prohibited Use Policyによる安全フィルタの正常動作であり、AIが「直すべき」と判断すること自体が越権 |
+| 4 | dev環境への開発者override先行実装 | 前セッションでprodのみ実装 | ROI不明確（devでの予算枯渇は未報告）、本田様の明示指示なし。条件待ち#2として保持 |
+
+## 同根再発スキャン（§4.6）
+
+本セッションのfix系PR2件（#279 CSS表示崩れ、#281 Reactボタン重複）は、いずれも「`/dev/`ポータル/画像生成モーダルのUI」という表層は似るが、原因は完全に別系統（CSS Grid `min-width`継承問題 vs `generatedImages`状態に基づく条件分岐漏れ）で共有ファイル・共有ユーティリティなし。過去7日のhandoffアーカイブにも同根キーワードのヒットなし。同根再発には該当しない。
+
+## 対症療法判定（§4.7）
+
+PR #279・#281ともに、症状の遮断（retry/fallback等）ではなく実際にPlaywrightで表示を再現し原因箇所を特定した恒久修正。PR #281は既存 static pin パターンに沿った回帰防止テストも追加し、条件を外すとテストが失敗することまで確認済み。対症療法には該当しない。
+
+## 再開可能性判定
+
+✅ **再開可能** - ドキュメントから開発再開できます。即着手タスク0件、全て条件待ち（本田様の確認・指示待ち）。
+
+## 最終結論
+
+✅ **セッション終了可** — 残作業ゼロ、Git clean、CI成功
+
+- OPEN PR: 0件（#278〜#281 全てマージ・ブランチ削除済み）
+- active Issue: 5件（すべてdecision-maker明示指示待ちまたはtrigger待ち、Net 0）
+- Git: clean（`main`ブランチ、`origin/main`と同期済み、`b1613f4`）
+- 即着手タスク: 0件 / 条件待ち: 5件 / 却下候補: 4件
+- 同根再発スキャン（§4.6）: 該当なし（上記参照）
+- 対症療法判定（§4.7）: 該当なし（上記参照）
+- 残留プロセス: 1件検出（別プロジェクト `sanwa-houkai-app/web` の Next.js dev、PID 69117、⚠️本チェックは現在のプロジェクトに限らないマシン全体のチェック。並行実行中の別セッションの可能性があるため停止は条件待ち#3に留める）
+- テスト: `npm run lint` PASS、`npm run test` 946/946 PASS
+- 既知の blocker: なし（残タスクは全て本田様の確認・判断待ちで、AI側のblockerではない）

--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -1,279 +1,133 @@
-# Handoff: 2026-07-12/13 画像生成429問題の根本原因解明・UIクールダウン方式へ移行（PR #269）→ Imagen4調査 → 開発者アカウントTier免除実装（PR #275）→ `/dev/`ポータル整備・画像生成モーダルUX改善（PR #278〜#281）まで完了
+# Handoff: 2026-07-23 世界観フォームバグ修正・法務文書クリーンアップ・Footer SNSリンク追加→prod反映まで完了
 
-- Session Date: 2026-07-12 〜 2026-07-13
+- Session Date: 2026-07-23
 - Owner: yasushi-honda
-- Status: ✅ 完了（PR #269〜#281 全てdev+prod反映済み。開発者アカウントのTier 1月間予算免除機構をprod反映しCloud Loggingで間接実機確認、`/dev/`ポータルのドキュメント整備・表示崩れ修正、画像生成モーダルの重複ボタン表示解消まで完了）
-- Previous: [2026-07-12d-icon-devportal-image-error-investigation.md](./2026-07-12d-icon-devportal-image-error-investigation.md)
+- Status: ✅ 完了（PR #283〜#288 全てdev+prod反映済み、Playwright実機確認済み）
+- Previous: [2026-07-13-dev-portal-image-gen-ux-completion.md](./2026-07-13-dev-portal-image-gen-ux-completion.md)
 
 ## セッション要旨
 
-前セッション（2026-07-12前半）で「アプリのバグではない、一時的なクォータ超過」と判定した画像生成429エラーが、その後の実利用で複数回再発。3段階の試行錯誤を経て、UIクールダウン方式（PR #269）に到達し、さらにdev実機検証で429の**真の原因が2系統ある**ことを解明した。
+ユーザー報告の画像スクショ2枚（世界観フォームで「魔法・技術」テンプレート選択→保存→編集し直すと「重要アイテム」グループに誤って表示される）を起点に調査し、根本原因を特定して修正（PR #283）。続けて法務文書（利用規約・プライバシーポリシー・特定商取引法表記）の露出バグ・内容整理をユーザーとの複数往復の対話で段階的に実施（PR #284〜285, #287, #288）。並行してFooterへのX（SNS）アカウントリンク追加（PR #286）を`/code-review`＋6エージェント並列レビューを経て実施。最後にdev確認後、`novel-writer-prod`への手動デプロイ（`deploy-prod.yml` workflow_dispatch）を実行し、実機確認まで完了した。
 
-### 429対応の経緯（3段階）
-1. **PR #267**: サーバー側リトライ実装（3秒→8秒）→ prodで再発
-2. **PR #268**: リトライ待機時間延長（10秒→20秒→40秒、合計70秒）→ prodで再発
-3. **PR #269**: 本田様の提案「連続では出来ないことを書いておく方が良い」を受け、リトライを撤去しFE側クールダウンUIに転換。実際のVertex AI quota（`generate_content_image_gen_per_project_per_base_model_global` = 2 req/分/プロジェクト/モデル）をgcloudで確認し、リトライ自体が同じ1分ウィンドウの追加消費になっていた疑いを特定
+## PR #283: 世界観フォームのテンプレート間キー重複バグ修正
 
-### PR #269 のlarge tier必須レビューで検出・修正した2件の重大バグ
-- **Codex review-diff P1**: `handleGenerate`が`await onGenerate`完了後にクールダウンを開始していたため、生成中に閉じるボタンでモーダルを閉じてすぐ開き直すと、in-flightリクエストと新規リクエストが重複発行されquotaを倍消費しうる状態だった。クールダウン開始を`await`の前に移動して修正
-- **silent-failure-hunter / comment-analyzer（2系統独立指摘）**: クールダウン時間120秒が、コメント自身が引用する実測回復時間169秒より短いという指摘。本田様確認の上180秒に引き上げ
+### 根本原因
+`components/modals/WorldForm.tsx` の全テンプレート（場所・組織・魔法/技術・歴史上の出来事・重要アイテム）が共通で「種別」というフィールドキーを持つため、`field.key` だけでテンプレートを逆引きする `fieldKeyToTemplateMap`（保存データ再読込用）と `renderFieldInput` 内の検索が、キー名の重複により常に最後（または最初）に定義されたテンプレートを誤って返していた。同時に select の選択肢（options）も別テンプレートのものが表示される追加バグを実機確認で発見。
 
-### dev実機検証で判明した429の「真の原因は2系統」（本セッション最大の発見）
-Codexへのセカンドオピニオン相談で「180秒固定クールダウンは429を防ぐ保証にならない」との指摘を受け、実際に何分間隔なら安全かをdev環境で実測しようとしたところ、想定外の事実が判明した。
+### 修正内容
+- `types.ts`: `SettingItem.fields` に `groupKey?`/`groupName?` を追加
+- `WorldForm.tsx`: 保存データに `groupKey`/`groupName` を保持し、編集時はそれを正として復元（レガシーデータはフォールバックで従来ロジック維持）。select の選択肢も `field.groupKey` に紐づく所属テンプレートから優先検索するよう修正
+- **セルフレビューで発見した追加の回帰**: 上記修正により `isDirty` 判定の baseline（`initialStateString`）が `itemToEdit` の生データから計算されており、`populateState` が内部で補完する `groupKey` を反映していなかった。`groupKey` 未保存のレガシーデータを編集で開くと、未編集でも「未保存の変更」ダイアログが誤表示される回帰があったため、`populateState` を補完済みデータを返す関数に変更して解消
 
-1. **アプリ内部のTier 1月間予算（100円/月）の枯渇**: `image/generate`は1回12円のため月8回程度で枯渇する。当初の実測（3分半〜6分半間隔でも429が3連続）はこれが原因で、**Vertex AI側のクォータとは無関係**だった。Firestoreの`usage/{uid}_{yyyymm}`ドキュメントで`quotaExceededCounts.image/generate: 3`と実測回数が完全一致し確定
-2. **Vertex AI側の実際のクォータ**: 上記の発見を受け、本田様の明示承認を得て`server/middleware/withUsageQuota.ts`にdev限定・二重ガード付き（`GCP_PROJECT !== 'novel-writer-prod'`）のTier 1バイパスコードを一時追加し、devに限定デプロイして実測。**2分39秒〜4分47秒の間隔で13回連続成功、1分33秒の間隔では429が発生**という結果を得た。境界は「1分33秒〜2分39秒」の間と推定され、180秒（3分）はこれを安全にカバーする値と確認。検証後、バイパスコードは完全に削除し、devは正規のCI/CDビルド（`4ba1b54`）に復旧済み
+### 検証
+lint/test 946件PASS。Playwright実機確認: 単体テンプレート適用・複数テンプレート同時適用・IndexedDB直接注入したレガシーデータの3パターンで保存→再編集の往復を確認。
 
-## 本セッション merged PR（1件）
+## PR #284: 利用規約のTODOコメント表記露出を修正
 
-| PR | 内容 | 規模 | 種別 |
-|----|------|------|------|
-| #269 | fix(image): 429リトライを撤去しUIクールダウンに置換 | 5 files, +168/-92 | バグ修正（large tier） |
+`terms-of-service.md` 9行目の警告文中、`` `<!-- TODO -->` `` とバッククォートで囲まれた記述が marked によりインラインコードとしてエスケープ表示され、DOMPurify のコメントノード除去をすり抜けて開発者向け内部表記がそのままエンドユーザー向けページに露出していた。バッククォートを外し自然文に変更。`public/legal`（正本）・`docs/legal`（履歴参照用）の両方に反映。
 
-## 同根再発スキャン（§4.6）— ⚠️ 重要な監視事項あり
+## PR #285 / #287 / #288: 法務文書の内容整理（ユーザーとの複数往復で段階的に実施）
 
-過去7日のhandoffアーカイブを検索した結果、**2026-07-05のhandoff「model-migration-quota-redesign」で「dev実機で最後の成功から15分以上429が継続」「6回失敗後、約2時間のquota回復待ちで別プロンプトが成功」という観測**が記録されていた。これは本セッションの実測（13回連続成功、境界は1分33秒〜2分39秒）と一見矛盾する。
+decision-maker から prod 実機（`https://novel-writer-df263ic6wa-an.a.run.app`）を見た上で複数回の追加指摘を受け、都度対応:
 
-**上流の真のroot cause仮説（3つ）**:
-1. Vertex AI側のクォータは`gcloud alpha services quota list`の公称値（2 req/分）とは別に、Dynamic Shared Quota（需要に応じて変動する共有容量）の影響を受けており、時間帯・全体負荷によって実際の許容範囲が大きく変動する（Codexのセカンドオピニオンでも同じ仮説が最有力とされた）
-2. 7/5時点の観測は本当にVertex AI側の長時間の制限だった可能性が高い（Tier 1予算枯渇なら「来月まで」絶対回復しない設計のため、2時間で回復した事実と整合しない）
-3. 今回の13回連続成功は「たまたま空いていた時間帯」だった可能性があり、180秒という値の恒久的な安全性を保証するものではない
+1. **PR #285**: 「小説らいたー ver16」→「小説らいたー（α版）」に統一。Tier 0/1/2 という開発者向け内部呼称に加え、decision-maker 指定のプラン名（メモパッドプラン/ノートプラン/＋ブックプラン）を用語定義セクションで対応関係明示のうえ導入
+2. **PR #287**（decision-maker からの追加指摘): 用語定義の「メモパッドプラン（Tier 0）」等のTier番号併記を削除（社内識別子でありユーザーには不要）。「gemini-3.1-flash-lite, Nano Banana 2 Lite」「(Imagen)」等の具体的AIモデル名を「Google Cloud の生成AIサービス（Vertex AI）」程度の抽象度に統一（モデル変更のたびに規約改定が必要になるのは非効率、という一般的な業界慣行に基づく判断）。コスト情報（月額100円相当等）は実質的な利用条件のため維持。前回PR #285で`docs/legal/tokushou.md`への反映が漏れていたため同時に同期
+3. **PR #288**（decision-maker からのさらなる追加指摘): 見出し「利用規約 (Terms of Service)」等の英語併記、警告文「重要 (LEGAL_REVIEW_REQUIRED)」の英語識別子併記、バージョン行「（M7-α stub、未確定）」の開発用マイルストーンコードを削除。`LEGAL_REVIEW_REQUIRED` はファイル冒頭のHTMLコメント `<!-- LEGAL_REVIEW_REQUIRED -->`（画面非表示）で grep 可能マーカーとしての機能を維持しているため、画面表示部分の併記のみ安全に削除できると判断
 
-**もう1件同根が出るとしたらどこか**: prodで複数ユーザーが同時にアクセスする、またはGoogle側のリソースが逼迫する時間帯に、180秒のクールダウンでも429が再発する可能性がある。その場合は「UI側の対策では不十分、サーバー側の共有状態管理（既知の限界としてPR説明文に明記済み）が必要」という結論に至る可能性が高い。
+いずれも3文書（terms-of-service / privacy-policy / tokushou）× 2箇所（public/legal 正本・docs/legal 履歴参照用）= 6ファイルに反映。
+
+## PR #286: FooterへのX(SNS)リンク追加
+
+### 設計判断
+`LEGAL_DOCS`（既存、法的文書3件・same-origin URLのみを契約テストで pin）に外部SNSリンクを混ぜず、別定数 `SOCIAL_LINKS` を `legalDocs.ts` に新設。`LegalLinkList` に任意の `extraLinks` prop を追加し `Footer.tsx` からのみ渡すことで、`TermsConsentModal`（同意ダイアログ、SNSリンク不要）への影響を排除。
+
+### レビュー経緯
+CLAUDE.md規約によりmedium tier該当（5ファイル、+56/-4行）のため `/code-review` をユーザーに依頼しつつ、並行して pr-review-toolkit の6エージェント（code-reviewer / code-simplifier / comment-analyzer / pr-test-analyzer / silent-failure-hunter / type-design-analyzer）を並列起動。3件がサービスエラー（API接続切断・stall）で失敗したため、ユーザー確認の上プロンプトを簡潔化して再実行し全6件完了。
+
+- **採用した指摘**（pr-test-analyzer、重要度6-7）: `extraLinks = []` のデフォルト値と `[...LEGAL_DOCS, ...extraLinks]` の結合順序がテスト未保護だった。将来これが誤って削除・必須化されると `TermsConsentModal`（利用規約同意ゲート、全未同意ユーザーをブロックする重要画面）で `TypeError: undefined is not iterable` によるレンダリングクラッシュに直結する具体的リスクがあったため、`LegalLinkList.test.ts` を新規作成しpin
+- **見送った指摘**: type-design-analyzerの `LegalDoc → LinkItem` 型リネーム提案（他エージェントは現状維持推奨で意見が割れたため見送り）、comment-analyzerのコメント文言修正提案
+- **`/code-review` 本体からの指摘（採用）**: 「X」という1文字のリンクテキストのみではスクリーンリーダーで外部SNSリンクと伝わらない（WCAG 2.4.4 Link Purpose）。`LegalDoc` に `ariaLabel?: string` を追加し `aria-label="X（旧Twitter）"` を設定して対応
+
+## GitHub API障害への対応（PR #283マージ時）
+
+PR #283のsquash mergeが "Head branch is out of date" で繰り返し失敗。調査の結果、GitHub公式ステータスページで同時刻に "Latency issues across a number of services"（Webhooks/Issues degraded, Actions partial outage）インシデントを確認。git refレベルでは最新だがGitHub内部のPRメタデータ更新が遅延していたと判断し、Monitor（30分タイムアウト）で待機。約1時間後に自然解消しマージ成功。この間、ユーザーから「別の角度から考えられませんか」と指摘を受け、キャッシュ問題・push宛先ズレ等の代替仮説も実測で検証し排除した。
+
+## prodデプロイ
+
+ユーザーから「devがOKならprodにあげましょう」との指示を受け、dev環境（`novel-writer-ramnh3ulya-an.a.run.app`）で全変更を実機確認後、`gh workflow run deploy-prod.yml --ref main` で `novel-writer-prod` へ手動デプロイ実行。
+
+**教訓（重要）**: 当初 `gcloud run services describe --format="value(spec.template.spec.containers[0].image)"` の一致のみで「反映完了」と誤判定した。このフィールドは「指定spec」であり、実際にトラフィックを受けているrevisionとは限らない。正しくは `status.traffic` で100%を得ているrevisionを特定し、そのrevisionの `spec.containers[0].image` を確認する必要がある。今回は新revisionがReadyになるまでのタイムラグで一度誤判定し、ユーザーからの追加確認依頼を受けて訂正した。dev/prod双方で最終的にはこの正しい方法で確認し、Playwrightで実機確認（3法務文書ページの表記・Footer Xリンクとaria-label）も完了。
+
+## ドキュメント整合性
+
+| 項目 | 状態 | 備考 |
+|------|------|------|
+| CLAUDE.md ↔ 実装 | ✅ | 変更なし（法務文書・UI機能追加のみ、CLAUDE.md記載事項に影響なし） |
+| GOAL.md ↔ 今セッション作業 | ✅ | 今セッションはGOAL.mdのミッション（開発者override機構）と無関係の別作業のため変更なし |
+| E2Eテスト件数 | ✅ | 946→955件（新規9件: legalDocs.test.ts 2件, Footer.test.ts 3件, LegalLinkList.test.ts 2件, aria-label関連2件） |
+| リンク切れ | ✅ | tokushou.md→privacy-policy.md の相対リンクは今回差分に含まれず健全 |
+| ADR整合性 | ⏭️ | 該当する技術判断（アーキテクチャレベル）なし、ADR作成不要 |
+
+## Git状態
+
+| 項目 | 状態 |
+|------|------|
+| 未コミット変更 | なし |
+| 未プッシュコミット | なし（`origin/main` と同期済み、`ff3a344`） |
+| CI/CD | ✅成功（dev自動デプロイ×6回、prod手動デプロイ1回、全てsuccess） |
+
+## 品質ゲート
+
+| 項目 | 状態 |
+|------|------|
+| `/code-review` 実行 | ✅実行済み（PR #286、1件の指摘反映（aria-label追加）） |
+| 6エージェント並列レビュー | ✅実行済み（PR #286、3件failed→再実行で完了、1件の指摘反映（テスト追加）） |
+| 構造的整合性チェック | ✅確認済み（型変更 `SettingItem.fields` の全呼び出し元確認済み） |
+
+## 次のアクション（3分割）
+
+### 即着手タスク
+即着手タスクなし
+
+### 条件待ち（明示trigger付き）
+
+| # | 項目 | trigger | 充足時のタスク | 充足確認方法 |
+|---|------|---------|--------------|------------|
+| 1 | [GOAL.md] 開発者override実機確認の最終クローズ | 本田様ご自身がprodでAI機能を呼び出し「エラーが出なかった」と明示確認 | GOAL.mdの該当チェックボックスを`[x]`にし完了記録 | 本田様への確認 |
+| 2 | 既存Issue #232/#156/#152/#147/#137 | 各Issue本文記載のtrigger、または本田様の優先度指示 | 各Issue本文参照 | `gh issue view <番号>` |
+
+### 却下候補（記録のみ）
+却下候補なし（今セッションは全て具体的な指摘・要望への対応で完結）
+
+## 同根再発スキャン（§4.6）
+
+本セッションのfix系PR2件（#283 世界観フォーム、#284 legal TODOコメント露出）は完全に別コンポーネント（`WorldForm.tsx` のJS/TSロジック vs `public/legal/*.md` + `legal.js` のMarkdownレンダリング挙動）で根本原因も異なり、共有ファイル・共有ユーティリティなし。過去7日のhandoff archiveにも同根キーワードのヒットなし（archiveディレクトリ自体が存在しない）。同根再発には該当しない。
 
 ## 対症療法判定（§4.7）
 
-判定基準3（同症状の修正PRが過去30日以内に複数：#266→#267→#268→#269）に該当。ただしCodexセカンドオピニオン内でのWeb Search（Vertex AI公式ドキュメント参照）とgcloud quota実測・Firestore実データ確認・13回のdev実機検証という構造的検証を実施しており、対症療法ではなく根本原因（Tier 1予算枯渇という新発見の経路＋Vertex AI側の変動するDSQ）の特定に至っている。ただし上記の同根再発スキャンで判明した通り、180秒という値自体はVertex AI側の変動要因に対する理論保証ではなく実測ベースの安全マージンである点はPR説明文にも明記済み。
+PR #283・#284ともに、リトライ/fallback等の症状遮断ではなく、実際にコードを読み構造的原因（キー名重複、marked/DOMPurifyのエスケープ挙動）を特定した恒久修正。PR #283はセルフレビューで追加の回帰（isDirty baseline不整合）を発見し実機再現検証まで実施。対症療法には該当しない。
+
+## 再開可能性判定
+
+✅ **再開可能** - ドキュメントから開発再開できます。即着手タスク0件、全て条件待ち（本田様の確認・指示待ち）。
 
 ## Issue Net 変化
 
 - Close数: 0件
 - 起票数: 0件
-- Net: 0件（今回の発見はtriage基準の「実害」「再現バグ」には該当せず、PR説明文・本handoffへの記録で対応）
-
-## 2026-07-13 追記: Imagen4調査結果 + PR #269 prod反映完了
-
-### Imagen4調査結果（即着手タスク#1、完了）
-
-`gcloud alpha services quota list --service=aiplatform.googleapis.com`（asia-northeast1実測）で、Imagen4系（fast/standard/ultra全ライン）のクォータは`online_prediction_requests_per_base_model` = **20 req/分**と判明。現行Nano Banana 2 Lite（`generate_content_image_gen_per_project_per_base_model` = 2 req/分）の**10倍**で、数字だけ見れば魅力的だった。
-
-しかし公式ドキュメント（`docs.cloud.google.com/vertex-ai/generative-ai/docs/models/imagen/4-0-{generate,fast-generate,ultra-generate}-001`、およびVertex AI release notes）を個別に直接確認したところ、**Imagen4は`imagen-4.0-{,fast-,ultra-}generate-001`全ラインが2026年3月24日付で公式に廃止発表済み、Discontinuation date 2026年6月30日を経過している**ことが判明（移行推奨先: `gemini-2.5-flash-image`、現行モデルより旧世代）。検索結果に出た`imagen-4.0-generate-preview-06-06`という別バージョンもcurlで確認したところ301リダイレクトで同一の廃止対象ページに転送されるだけで、抜け道は存在しない。
-
-**結論: Imagen4への切替は不採用**。10倍クォータは公式に廃止された製品ラインの数字であり、実生成テスト（速度・成功率比較）は実施する意味がないため見送った。現行のNano Banana 2 Lite + UIクールダウン方式（PR #269、180秒）を継続するのが現時点の最適解と判断（本田様確認済み、「最適解で進めましょう」の指示を受けPR #269 prod反映を実施）。
-
-料金（$0.02〜$0.06/画像という数字）は複数の二次情報源はあったが、公式pricing pageが長大でWebFetchツールがtruncateし一次ソースでの裏取りはできなかった。ただし廃止済みモデルのため実務上の影響はない。
-
-### PR #269 prod反映（条件待ち#1、完了）
-
-本田様の明示指示「最適解で進めましょう。prod反映ができたら」を受け、`gh workflow run deploy-prod.yml --ref main`を実行。
-
-- Workflow run: [29212549257](https://github.com/Yukina1116/novel-writer/actions/runs/29212549257)（test job → deploy job、共に success）
-- 反映確認: `gcloud run services describe novel-writer --project=novel-writer-prod --region=asia-northeast1 --format="value(spec.template.spec.containers[0].image)"` → イメージタグ `1e1b614...`（mainのHEAD、PR #269 + #270まで反映）と一致確認済み
-
-## 次のアクション（3分割）
-
-### 即着手タスク
-
-なし（Imagen4調査は完了・PR #269 prod反映も完了）。
-
-<details>
-<summary>完了済みタスク（参考、折りたたみ）</summary>
-
-| # | タスク | ROI | 想定工数 | 完了条件 | 関連ファイル / コマンド |
-|---|--------|-----|----------|---------|------------------------|
-| 1 | ~~Imagen4モデルでの画像生成クォータ・生成体験を調査し、Nano Banana 2 Lite（現行）と比較~~ ✅完了(2026-07-13) | 本田様から明示指示「imagen4だったらこんなにも不便なのか、確認してください」。現行モデルはTier 1予算(100円/月=8回程度)+Vertex AIクォータ(2 req/分、実測境界1分33秒〜2分39秒)の二重の不便さがある | 30-60分（gcloud quota確認+実際の生成テスト） | Imagen4の`gcloud alpha services quota list`でのクォータ値確認、可能であれば実際に数回生成して体感速度・成功率を比較、現行モデルとのトレードオフ（画質・速度・コスト・クォータ）を本田様に報告 | `gcloud alpha services quota list --service=aiplatform.googleapis.com` |
-
-</details>
-
-### 条件待ち（明示 trigger 付き）
-
-| # | 項目 | trigger（充足条件） | 充足時のタスク | 充足確認方法 |
-|---|------|------------------|--------------|------------|
-| 1 | ~~PR #269（429リトライ撤去+UIクールダウン）のprodへの反映~~ | ✅完了(2026-07-13)。本田様の明示指示「最適解で進めましょう。prod反映ができたら」 | `gh workflow run deploy-prod.yml --ref main`実行、run [29212549257](https://github.com/Yukina1116/novel-writer/actions/runs/29212549257)成功、イメージSHA `1e1b614`一致確認済み | 完了 |
-| 2 | prodで429が再発した場合の調査 | 実際の429再発報告 | 同根再発スキャンで記録した仮説（DSQ変動）を優先的に検証。Cloud Loggingで429本文（`Quota exceeded`か`Resource exhausted, please try again later`か）を確認し、明示クォータ超過か共有容量不足かを判別 | `gcloud logging read` |
-| 3 | Issue #232の次の一手（可視化/サブ上限/コンバージョン導線） | 計測データが一定量蓄積された後の本田様の方針判断 | Issue #232本文の4論点から選択、`/impl-plan`で計画立案 | `gh issue view 232` |
-| 4 | Issue #156/#152/#147/#137 | 各Issue本文記載のtrigger | 各Issue本文参照 | `gh issue view <N>` |
-| 5 | Issue #243 対応候補(b)（安全フィルタ拒否時の専用エラーメッセージ分岐、PR #266で一部実装済み）/(c)（追加検証） | 本田様の優先度判断 | Issue #243本文の対応候補(b)(c)から選択、`/impl-plan`で計画立案 | `gh issue view 243` |
-
-### 却下候補（記録のみ、前セッションから引き継ぎ）
-
-| # | 項目 | 検討経緯 | 着手しない理由 |
-|---|------|---------|---------------|
-| 1 | サーバー側での共有状態管理（Firestore等）によるプロジェクト全体のクォータ制御 | Codex review-diff P1指摘、PR #269の既知の限界に明記済み | 複数タブ/複数ユーザーの合算超過防止には必要だが、現状の利用規模では過剰実装の可能性。本田様の明示指示なし |
-| 2 | `characterService.ts`/`ImageGenerationModal.tsx` の `full body`/`solo`/`simple white background` ハードコード | 前々セッションのExplore agent二次発見 | 「AI立ち絵生成」機能の性質上、意図的な仕様である可能性が高くROI不明確 |
-| 3 | 未成年設定キャラクターのAI立ち絵生成が構造的に失敗する制約 | PR #266で`personGeneration: ALLOW_ALL`に変更し一部緩和済み | 残る制約はGoogle Prohibited Use Policyによる安全フィルタの正常動作であり、AIが「直すべき」と判断すること自体が越権 |
-
-> ⚠️ 「優先順にすすめて」等の包括指示で次セッションが動けるのは即着手タスクのみ（今回は0件、全て条件待ちまたは却下候補）。
-
-## 2026-07-13 追記②: 開発者アカウントTier 1月間予算免除の実装・prod反映完了
-
-### セッション要旨
-
-本田様がprodでAI機能をテストする際、Tier 1月間予算（100円/月=10000sen）を頻繁に使い切ってしまう問題に対し、まず1回限りのGitHub Actions workflowで応急対応し、その後恒久的な「開発者override」機構を実装・prod反映した。
-
-**1回限り対応（PR #273/#274）**: `usage/{uid}_{yyyymm}`ドキュメントのusedCostを手動リセットするworkflowを作成・実行・削除。実行過程でADCアカウント不一致（gcloud CLIは`hy.unimail.11@gmail.com`だがADCは`yasushi.honda@aozora-cg.com`という別アカウント）とFirebase Auth権限不足（`roles/firebaseauth.admin`が別SAにのみ付与）を発見し、本田様の明示承認を得てIAM権限を一時付与→実行→即時取消の手順で対処。usedCost 9100→0のリセットを実測確認。
-
-**恒久対応（PR #275）**: `DEVELOPER_UIDS`環境変数に含まれるuidをTier 1の10倍（`DEVELOPER_OVERRIDE_LIMIT_SEN`=100,000sen=1000円相当）の上限で運用する「開発者override」を実装。Codexへのセカンドオピニオン（plan mode）を経て、Tier概念（課金プラン）とは意図的に分離した設計とした。
-
-### 品質ゲートで検出・修正した重大な設計ミス
-
-`/code-review high`（8角度find+1票verify）で4件CONFIRMED/PLAUSIBLE指摘を検出:
-1. **[CONFIRMED]** 当初`reserve()`の`limit`を`number | undefined`とし`undefined`=完全無制限で設計していたが、暴走ループ・リトライバグ等への歯止めが一切ないと指摘。本田様の判断で「高いが有限の上限」方式に変更し、`reserve()`のシグネチャ変更自体を巻き戻した
-2. **[CONFIRMED]** `deploy-prod.yml`の`flags`内でsecret値が未クォートのまま埋め込まれており、値に空白が入るとデプロイが壊れるリスク → ダブルクォートで囲んで修正
-3. **[CONFIRMED]** override発動が完全にサイレント（ログなし）→ `logger.info`で監査ログを追加
-4. **[PLAUSIBLE]** dev環境（`deploy.yml`）には同じ免除が配線されていない → GOAL.mdに既知のスコープ判断として記録（対応不要、本田様の明示指示なし）
-
-さらに`/review`でPR diffを再確認した際、`developerOverride.ts`冒頭コメントが巻き戻し前の古い設計（"limitをundefinedとして扱う"）のまま残っていた見落としを発見・修正。`codex review-diff`では重大な問題なしとの評価。
-
-### prod反映・実機確認
-
-`gh workflow run deploy-prod.yml`でデプロイ実行、イメージSHA `7e2a19c`（PR #275）→ `1852c99`（PR #276、GOAL.md更新）まで一致確認。`gcloud run services describe`で`DEVELOPER_UIDS`を含む全6環境変数が破壊されずに反映されていることを実機確認（`^;^`区切り文字構文が正常動作）。
-
-### セッション中のトラブルと復旧
-
-GOAL.md更新作業中に`git reset --soft HEAD~1`を誤って`main`ブランチに対して実行し、ローカルの`main`がPR #275マージ前に巻き戻る事故が発生（リモートは無事）。stash退避を経て`git reset --hard origin/main`で安全に復旧。また、GOAL.mdに本田様のFirebase uidを平文で書きそうになった箇所を自動モードのガードレールが検出しブロック、uidを含まない形に修正した。
-
-## 本セッション merged PR（追加5件、計6件）
-
-| PR | 内容 | 規模 | 種別 |
-|----|------|------|------|
-| #271 | docs: Imagen4調査結果とPR #269 prod反映をハンドオフに記録 | 2 files, +37/-11 | ドキュメント |
-| #272 | docs(dev-portal): テスト件数とLast Updatedを実測値に同期 | 1 file, +2/-2 | ドキュメント |
-| #273 | ops: 本番usageリセット用の1回限りworkflowを追加 | 2 files, +105 | 運用ツール（一時） |
-| #274 | ops: 実行完了した本番usageリセットの1回限りworkflowを削除 | 2 files, -105 | 運用ツール（一時、削除） |
-| #275 | feat(usage): 開発者アカウントをTier 1月間予算から免除 | 7 files, +210/-4 | 新機能（large tier） |
-| #276 | docs(goal): PR #275 prod反映完了をGOAL.mdに記録 | 1 file, +6/-4 | ドキュメント |
-
-## デプロイ状況
-
-- dev: `1852c99`（PR #276マージ後の正規CI/CDビルド）に一致、CI（Deploy to Cloud Run）成功確認済み
-- prod: `1852c99`相当（実デプロイは`7e2a19c`＝PR #275時点、GOAL.md更新のPR #276はドキュメントのみのためprod再デプロイ不要）に一致。`DEVELOPER_UIDS`含む全環境変数の実機反映確認済み。**dev/prod完全同期**
-
-## 次のアクション（3分割）
-
-### 即着手タスク
-
-なし（executor領分の作業は全て完了。残る候補は全て外部trigger待ち）。
-
-### 条件待ち（明示 trigger 付き）
-
-| # | 項目 | trigger（充足条件） | 充足時のタスク | 充足確認方法 |
-|---|------|------------------|--------------|------------|
-| 1 | 開発者override機構の実機動作確認（GOAL.md最終タスク） | 本田様ご自身がprodでAI機能（image/generate等）をテストし、クォータ超過エラーが出ないことを確認 | 本田様からの確認結果報告を待つのみ、AI側の追加作業なし | 本田様への確認 |
-| 2 | dev環境（`deploy.yml`）へのDEVELOPER_UIDS配線 | dev環境でも同様のTier1予算枯渇が発生した場合の本田様指示 | `deploy.yml`に同様の環境変数配線を追加、`/impl-plan`軽量モードで計画 | 本田様への確認、または`gh workflow run`可否の指示 |
-| 3 | 別プロジェクト（aozora-sns-auto/apps/admin-web）の残留devサーバー（PID 52872）停止 | 本田様の停止指示（並行実行中の別セッションの可能性があるため） | `~/.claude/scripts/cleanup-node.sh --kill`または該当プロセスを個別kill | `ps -p 52872` |
-| 4 | prodで429が再発した場合の調査 | 実際の429再発報告 | 同根再発スキャンで記録した仮説（DSQ変動）を優先的に検証。Cloud Loggingで429本文を確認 | `gcloud logging read` |
-| 5 | Issue #232の次の一手（可視化/サブ上限/コンバージョン導線） | 計測データが一定量蓄積された後の本田様の方針判断 | Issue #232本文の4論点から選択、`/impl-plan`で計画立案 | `gh issue view 232` |
-| 6 | Issue #156/#152/#147/#137 | 各Issue本文記載のtrigger | 各Issue本文参照 | `gh issue view <N>` |
-| 7 | Issue #243 対応候補(b)/(c) | 本田様の優先度判断 | Issue #243本文参照、`/impl-plan`で計画立案 | `gh issue view 243` |
-
-### 却下候補（記録のみ）
-
-| # | 項目 | 検討経緯 | 着手しない理由 |
-|---|------|---------|---------------|
-| 1 | サーバー側での共有状態管理（Firestore等）によるプロジェクト全体のクォータ制御 | Codex review-diff P1指摘、PR #269の既知の限界に明記済み | 複数タブ/複数ユーザーの合算超過防止には必要だが、現状の利用規模では過剰実装の可能性。本田様の明示指示なし |
-| 2 | `characterService.ts`/`ImageGenerationModal.tsx` の `full body`/`solo`/`simple white background` ハードコード | 前々セッションのExplore agent二次発見 | 「AI立ち絵生成」機能の性質上、意図的な仕様である可能性が高くROI不明確 |
-| 3 | 未成年設定キャラクターのAI立ち絵生成が構造的に失敗する制約 | PR #266で`personGeneration: ALLOW_ALL`に変更し一部緩和済み | 残る制約はGoogle Prohibited Use Policyによる安全フィルタの正常動作であり、AIが「直すべき」と判断すること自体が越権 |
-| 4 | dev環境への開発者override先行実装 | 本セッションでprodのみ実装 | ROI不明確（devでの予算枯渇は未報告）、本田様の明示指示なし。条件待ち#2として保持 |
-
-## 再開可能性判定
-
-✅ **再開可能** - ドキュメントから開発再開できます。即着手タスク0件、全て条件待ち（本田様の確認・指示待ち）。
+- Net: 0件（今セッションはIssue起票・closeなし）
 
 ## 最終結論
 
-✅ **セッション終了可** — 残作業ゼロ、Git clean、dev/prod完全同期済み
+✅ **セッション終了可** — 残作業ゼロ、Git clean、CI成功（dev/prod両方）
 
-- OPEN PR: 0件（#271〜#276 全てマージ・ブランチ削除済み）
-- active Issue: 5件（すべてdecision-maker明示指示待ちまたはtrigger待ち、Net 0）
-- Git: clean（`main`ブランチ、`origin/main`と同期済み、`1852c99`）
-- 即着手タスク: 0件 / 条件待ち: 7件 / 却下候補: 4件
-- 同根再発スキャン（§4.6）: 過去7日アーカイブ0件ヒット。「Tier 1」というキーワードが過去handoffにヒットしたのはM6暗号化バックアップ機能の同名異義語のみで、真の同根なし。PR #273/#274→#275は同一問題への段階対応（応急→恒久）であり、悪い意味での同根再発ではない
-- 対症療法判定（§4.7）: 該当なし。retry/fallback等の表面的対処ではなく、Codexセカンドオピニオン+`/code-review high`構造的検証を経た根本対応（Tier概念と分離した運用上例外の新規実装）
-- 残留プロセス: 1件検出（別プロジェクト `aozora-sns-auto/apps/admin-web` の pnpm dev、PID 52872、⚠️本チェックは現在のプロジェクトに限らないマシン全体のチェック。並行実行中の別セッションの可能性があるため停止は条件待ち#3に留める）
-- テスト: `npm run lint` PASS、`npm run test` 945/945 PASS
-- 既知の blocker: なし（残タスクは全て本田様の確認・判断待ちで、AI側のblockerではない）
-
-## 2026-07-13 追記③: 開発者Tier免除の間接実機確認 + `/dev/`ポータル整備 + 画像生成モーダルUX改善
-
-### セッション要旨
-
-本田様がdev環境（`novel-writer-ramnh3ulya-an.a.run.app/dev/`）でAI立ち絵生成を実機テストしたスクリーンショットを提示。当初「開発者Tier免除の確認」として提示されたが、実際に写っていたのはPR #269のFE側クールダウンUI（Tier免除とは無関係の別機構）だった。そこでprod環境のCloud Loggingを直接確認したところ、`usage:developer-override applied`ログが4件記録されており（対象uidに対し `image/generate` / `character/image-prompt`、limit=100000 sen）、GOAL.mdの最終タスクの**間接証拠**を得た（本田様ご自身の明示確認はまだ得られていないため`[ ]`は維持）。
-
-この過程で誤りも1件あった: URLがdev環境かprod環境か未確認のまま「prod実機確認完了」と断定しかけたが、`gcloud run services describe`で両環境のURLを個別に照合し、スクショはdev環境（override未配線）、Cloud Loggingの証跡はprod環境という食い違いに気づき訂正した。
-
-### `/dev/`ポータル整備（PR #278、#280）
-
-本田様の承諾を得て、上記クールダウンUIのスクリーンショットを実例として`/dev/`ポータルの「② AI 生成 — withUsageQuota 3-phase」セクションに追加（`public/dev/images/image-generation-cooldown.jpg`、270KB→124KBにリサイズ）。あわせて、これまでドキュメント化されていなかった`DEVELOPER_UIDS`環境変数を環境変数テーブルに追記。さらに、着手可能タスクの棚卸し中にテスト件数表示のズレ（ヘッダー933件・進捗カード920件、実測945件）を発見し実測値に同期（PR #280）。
-
-### `/dev/`ポータル表示崩れ修正（PR #279、2段階）
-
-本田様がdev環境実機で「主要ファイル」カードの文字はみ出しを発見・報告。1回目の修正（`.card h4`にのみ`overflow-wrap`付与）では不十分で、本文`<p>`内の`TERMS_VERSION_MISMATCH`のような長いコード識別子がなお隣カードにはみ出す再発が発生。`overflow-wrap`は継承プロパティであるため`.card`自体に指定し直し、子要素（h4/p/kicker）全てをカバーする形で解消した。原因は CSS Grid アイテム(`.card`)のデフォルト `min-width: auto` により、空白なしの長い文字列がカード幅を押し広げていたこと。
-
-### 画像生成モーダルの重複ボタン表示修正（PR #281）
-
-本田様が「同じボタンが2つ重複して冗長」と実機スクショで報告。調査の結果、簡易生成モードの「画像を生成」ボタン（新規生成、既存結果を破棄）が`generatedImages`の状態に関わらず常時表示される実装になっており、画像生成後は右パネルの「追加でN枚生成する」ボタン（既存に追加）と機能の異なる2つのボタンが並び、クールダウン中はどちらも同一ラベルになって見分けがつかなくなっていた。ユーザーの要望「シンプルな実装で」を受け、`generatedImages.length === 0`のときのみ左ボタンを表示する条件分岐を追加。既存の static pin テストパターン（`readFileSync` + regex）に合わせた回帰防止テストも追加し、条件分岐を一時的に外してテストがFAILすることを確認した上でコミットした。
-
-動作確認は一時的に `useRequiresAuth` を `canUseAi: true` 固定、`generatedImages` 初期値にダミー画像2枚を入れてPlaywrightで実表示を確認し、確認後は全てのデバッグ用変更を元に戻してからコミットした（本来のソース変更のみが残っていることをdiffで確認済み）。
-
-修正後、ユーザーから「再生成ボタンが出せない」という別の問い合わせがあったが、これは既存機能「修正して再生成」（魔法の杖アイコン）の話で、生成された画像をクリックして選択すると表示される仕組みだった（今回の修正とは無関係、使い方説明で解決）。
-
-## 本セッション merged PR（4件）
-
-| PR | 内容 | 規模 | 種別 |
-|----|------|------|------|
-| #278 | docs(dev-portal): AI立ち絵生成クールダウンの実機キャプチャとDEVELOPER_UIDS追記 | 2 files, +12/-0 | ドキュメント |
-| #279 | fix(dev-portal): カード本文中の長いコード文字列も折り返し対象に含める（1回目#278直後の追加コミット含め計2コミット） | 1 file, +4/-4 | バグ修正 |
-| #280 | docs(dev-portal): テスト件数表示を実測値(945)に同期 | 1 file, +2/-2 | ドキュメント |
-| #281 | fix(image-gen): 画像生成モーダルの新規/追加生成ボタン重複表示を解消（回帰テスト追加含む） | 2 files, +40/-13 | バグ修正 |
-
-## 次のアクション（3分割）
-
-### 即着手タスク
-
-なし（executor領分の作業は全て完了。残る候補は全て外部trigger待ち）。
-
-### 条件待ち（明示 trigger 付き）
-
-| # | 項目 | trigger（充足条件） | 充足時のタスク | 充足確認方法 |
-|---|------|------------------|--------------|------------|
-| 1 | 開発者override機構の実機動作確認（GOAL.md最終タスク） | 本田様ご自身がprodでAI機能（image/generate等）をテストし、クォータ超過エラーが出ないことを確認・報告 | 確認結果報告を待つのみ、AI側の追加作業なし。prod Cloud Loggingでの間接証拠は取得済み | 本田様への確認 |
-| 2 | dev環境（`deploy.yml`）へのDEVELOPER_UIDS配線 | dev環境でも同様のTier1予算枯渇が発生した場合の本田様指示 | `deploy.yml`に同様の環境変数配線を追加、`/impl-plan`軽量モードで計画 | 本田様への確認、または`gh workflow run`可否の指示 |
-| 3 | 別プロジェクト（sanwa-houkai-app/web）の残留devサーバー停止 | 本田様の停止指示（並行実行中の別セッションの可能性があるため） | `~/.claude/scripts/cleanup-node.sh --kill`または該当プロセスを個別kill | `pgrep -fl "next dev"` |
-| 4 | Issue #232の次の一手（可視化/サブ上限/コンバージョン導線） | 計測データが一定量蓄積された後の本田様の方針判断 | Issue #232本文の4論点から選択、`/impl-plan`で計画立案 | `gh issue view 232` |
-| 5 | Issue #156/#152/#147/#137 | 各Issue本文記載のtrigger | 各Issue本文参照 | `gh issue view <N>` |
-
-### 却下候補（記録のみ）
-
-| # | 項目 | 検討経緯 | 着手しない理由 |
-|---|------|---------|---------------|
-| 1 | サーバー側での共有状態管理（Firestore等）によるプロジェクト全体のクォータ制御 | Codex review-diff P1指摘、PR #269の既知の限界に明記済み | 複数タブ/複数ユーザーの合算超過防止には必要だが、現状の利用規模では過剰実装の可能性。本田様の明示指示なし |
-| 2 | `characterService.ts`/`ImageGenerationModal.tsx` の `full body`/`solo`/`simple white background` ハードコード | 前々セッションのExplore agent二次発見 | 「AI立ち絵生成」機能の性質上、意図的な仕様である可能性が高くROI不明確 |
-| 3 | 未成年設定キャラクターのAI立ち絵生成が構造的に失敗する制約 | PR #266で`personGeneration: ALLOW_ALL`に変更し一部緩和済み | 残る制約はGoogle Prohibited Use Policyによる安全フィルタの正常動作であり、AIが「直すべき」と判断すること自体が越権 |
-| 4 | dev環境への開発者override先行実装 | 前セッションでprodのみ実装 | ROI不明確（devでの予算枯渇は未報告）、本田様の明示指示なし。条件待ち#2として保持 |
-
-## 同根再発スキャン（§4.6）
-
-本セッションのfix系PR2件（#279 CSS表示崩れ、#281 Reactボタン重複）は、いずれも「`/dev/`ポータル/画像生成モーダルのUI」という表層は似るが、原因は完全に別系統（CSS Grid `min-width`継承問題 vs `generatedImages`状態に基づく条件分岐漏れ）で共有ファイル・共有ユーティリティなし。過去7日のhandoffアーカイブにも同根キーワードのヒットなし。同根再発には該当しない。
-
-## 対症療法判定（§4.7）
-
-PR #279・#281ともに、症状の遮断（retry/fallback等）ではなく実際にPlaywrightで表示を再現し原因箇所を特定した恒久修正。PR #281は既存 static pin パターンに沿った回帰防止テストも追加し、条件を外すとテストが失敗することまで確認済み。対症療法には該当しない。
-
-## 再開可能性判定
-
-✅ **再開可能** - ドキュメントから開発再開できます。即着手タスク0件、全て条件待ち（本田様の確認・指示待ち）。
-
-## 最終結論
-
-✅ **セッション終了可** — 残作業ゼロ、Git clean、CI成功
-
-- OPEN PR: 0件（#278〜#281 全てマージ・ブランチ削除済み）
-- active Issue: 5件（すべてdecision-maker明示指示待ちまたはtrigger待ち、Net 0）
-- Git: clean（`main`ブランチ、`origin/main`と同期済み、`b1613f4`）
-- 即着手タスク: 0件 / 条件待ち: 5件 / 却下候補: 4件
+- OPEN PR: 0件（#283〜#288 全てマージ・ブランチ削除済み）
+- active Issue: 5件（すべて前セッションから継続、decision-maker明示指示待ちまたはtrigger待ち、Net 0）
+- Git: clean（`main`ブランチ、`origin/main`と同期済み、`ff3a344`）
+- 即着手タスク: 0件 / 条件待ち: 2件 / 却下候補: 0件
 - 同根再発スキャン（§4.6）: 該当なし（上記参照）
 - 対症療法判定（§4.7）: 該当なし（上記参照）
-- 残留プロセス: 1件検出（別プロジェクト `sanwa-houkai-app/web` の Next.js dev、PID 69117、⚠️本チェックは現在のプロジェクトに限らないマシン全体のチェック。並行実行中の別セッションの可能性があるため停止は条件待ち#3に留める）
-- テスト: `npm run lint` PASS、`npm run test` 946/946 PASS
+- 残留プロセス: なし
+- テスト: `npm run lint` PASS、`npm run test` 955/955 PASS
+- prod実機確認: 完了（Playwright、法務文書3ページ・Footer Xリンク＋aria-label）
 - 既知の blocker: なし（残タスクは全て本田様の確認・判断待ちで、AI側のblockerではない）


### PR DESCRIPTION
## Summary
- 2026-07-23セッション（PR #283〜#288、世界観フォームのテンプレートキー重複バグ修正・法務文書クリーンアップ・FooterへのXリンク追加、dev/prod両反映）のハンドオフ記録
- 前回セッション記録（2026-07-12/13、PR #269〜#281）は `docs/handoff/2026-07-13-dev-portal-image-gen-ux-completion.md` に個別ファイルとしてアーカイブ

## Test plan
- [x] ハンドオフファイルサイズチェック: 14069バイト（60KB閾値未満）、最長行818文字（1500文字閾値未満）
- [x] docs-onlyの変更のためlint/testは影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)