### PR TITLE
fix(knowledge): タグ未保存とカテゴリ▼の反応不良を修正

### DIFF
--- a/components/KnowledgeModal.tagCommit.test.ts
+++ b/components/KnowledgeModal.tagCommit.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// バグ修正: タグ入力欄に Enter/カンマを押さず文字を残したまま保存すると、
+// その未コミットのタグが tags state に一度も入らずサイレントに消えていた
+// (再度開くとタグ欄・一覧のタグ表示のいずれも空白になる)。
+// 修正: handleSubmit で tagInput の残留分も tags にマージしてから onSave する。
+// 本テストは「送信時に tagInput を無視して tags をそのまま渡す」旧構造への退行を pin する。
+//
+// 併せてカテゴリ入力の list/datalist (ホバーで▼が出るがクリックしても無反応の
+// ネイティブ picker indicator) を削除した修正の退行も pin する。
+
+describe('KnowledgeModal タグ未コミット問題 (bug fix)', () => {
+    const source = readFileSync(resolve(__dirname, 'KnowledgeModal.tsx'), 'utf-8');
+
+    const handleSubmitMatch = source.match(/const handleSubmit[\s\S]*?(?=const handleKeyDown)/);
+
+    it('handleSubmit が定義されている', () => {
+        expect(handleSubmitMatch).toBeTruthy();
+    });
+
+    it('handleSubmit が tagInput.trim() を確定させてから onSave に渡す', () => {
+        expect(handleSubmitMatch![0]).toMatch(/tagInput\.trim\(\)/);
+        expect(handleSubmitMatch![0]).toMatch(/onSave\(\s*\{[^}]*tags:\s*finalTags/);
+    });
+
+    it('旧バグパターン: tagInput を無視して tags をそのまま onSave に渡す直線パターンが存在しない', () => {
+        const oldPattern = /onSave\(\s*\{\s*\.\.\.itemToEdit,\s*name,\s*content,\s*category,\s*tags\s*\}/;
+        expect(source).not.toMatch(oldPattern);
+    });
+
+    it('カテゴリ入力に list/datalist (クリック無反応の▼) が存在しない', () => {
+        expect(source).not.toMatch(/list=["']category-suggestions["']/);
+        expect(source).not.toMatch(/<datalist/);
+    });
+});

--- a/components/KnowledgeModal.tsx
+++ b/components/KnowledgeModal.tsx
@@ -60,12 +60,6 @@ export const KnowledgeModal: React.FC<{
         return JSON.stringify(currentState) !== initialStateString;
     }, [name, content, category, tags, initialStateString]);
 
-    const existingCategories = useMemo(() => {
-        if (!allKnowledge) return ['未分類'];
-        const categories = new Set(allKnowledge.map(k => k.category || '未分類'));
-        return Array.from(categories);
-    }, [allKnowledge]);
-
     const handleTagInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
         if (e.key === 'Enter' || e.key === ',') {
             e.preventDefault();
@@ -90,7 +84,11 @@ export const KnowledgeModal: React.FC<{
     const handleSubmit = (e: React.FormEvent) => {
         e.preventDefault();
         if (!name.trim()) return;
-        onSave({ ...itemToEdit, name, content, category, tags }, 'knowledge');
+        // Enter/カンマを押さずタグ入力欄に文字が残ったまま保存すると、そのタグが
+        // 未コミットのまま消えてしまうため、送信時にも確定させる。
+        const pendingTag = tagInput.trim();
+        const finalTags = pendingTag && !tags.includes(pendingTag) ? [...tags, pendingTag] : tags;
+        onSave({ ...itemToEdit, name, content, category, tags: finalTags }, 'knowledge');
     };
     
     const handleKeyDown = (e: React.KeyboardEvent<HTMLFormElement>) => {
@@ -184,12 +182,8 @@ export const KnowledgeModal: React.FC<{
                                     type="text"
                                     value={category}
                                     onChange={e => { setCategory(e.target.value); markEdited('category'); }}
-                                    list="category-suggestions"
                                     className={inputClass}
                                 />
-                                <datalist id="category-suggestions">
-                                    {existingCategories.map(cat => <option key={cat} value={cat} />)}
-                                </datalist>
                             </div>
                             <div>
                                 {renderLabel("タグ (Enterで追加)", "tags")}


### PR DESCRIPTION
## Summary
- ナレッジベースのタグ入力欄で Enter/カンマを押さずに保存すると、入力済みのタグがコミットされないまま消える不具合を修正。送信時 (`handleSubmit`) にも未確定の `tagInput` を `tags` へマージするよう変更。
- カテゴリ入力欄の `list`/`datalist` によるネイティブ▼インジケーター(ホバーで出現・クリック無反応)を除去。`::-webkit-calendar-picker-indicator` によるCSS非表示を試したが、text+list input では効かないことを実機検証で確認したため、`list`/`datalist` 自体を削除する方式を採用。

## Test plan
- [x] `npm run lint` (tsc --noEmit) PASS
- [x] `npm run test` (vitest) 65 files / 955 tests 全PASS
- [x] Playwright で実機確認:
  - 修正前: タグを入力しEnterを押さず保存 → 再度開くとタグ欄が空白、一覧のタグ表示も空 (再現)
  - 修正後: 同操作でタグが正しくコミットされ、モーダル再オープン時・一覧・タグフィルターバーいずれにも反映
  - カテゴリ欄: 修正前はホバーで▼が出現しクリックしても無反応。修正後は▼が表示されなくなり、既存カテゴリの変更・保存・再読込も問題なく動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)