### PR TITLE
fix(character): 組織「その他」自由入力が所属組織候補に出ない不具合を修正

### DIFF
--- a/components/modals/CharacterForm.tsx
+++ b/components/modals/CharacterForm.tsx
@@ -76,7 +76,9 @@ export const CharacterForm: React.FC<CharacterFormProps> = ({
         if (!allSettings) return [];
         return allSettings.filter(item =>
             item.type === 'world' &&
-            item.fields?.some(f => f.key === '種別' && ['国家', 'ギルド', '秘密結社', '企業'].includes(f.value))
+            // 種別が「その他」で自由入力された場合、値はプリセット文字列ではなく入力テキストそのものに
+            // 置き換わる（WorldForm.tsx）ため、値の一致だけでなく保存時の groupKey（テンプレート由来）でも判定する。
+            item.fields?.some(f => f.key === '種別' && (f.groupKey === 'organization' || ['国家', 'ギルド', '秘密結社', '企業'].includes(f.value)))
         );
     }, [allSettings]);
 


### PR DESCRIPTION
## Summary
- 世界観の「組織」で種別を「その他」にして自由入力すると、値がプリセット文字列ではなく入力テキストそのものに置き換わるため、`CharacterForm.tsx` のプリセット4値（国家/ギルド/秘密結社/企業）とのハードコード一致判定に引っかからず、キャラクターの「所属組織」候補から漏れていた
- 保存時に付与される `groupKey`（テンプレート由来、`handleSaveSetting` まで永続化される）でも判定するよう修正

## Test plan
- [x] `npm run lint`（tsc --noEmit）PASS
- [x] Playwright で再現・修正確認済み: 組織を種別「その他」＋自由入力（例: 傭兵団）で作成 → キャラクター作成モーダルの「所属組織」選択肢に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)