### PR TITLE
fix(event): 組織「その他」自由入力がイベントの場所候補に誤って出る不具合を修正

### DIFF
--- a/components/modals/EventForm.tsx
+++ b/components/modals/EventForm.tsx
@@ -49,9 +49,11 @@ export const EventForm: React.FC<EventFormProps> = ({ event, onSave, onCancel, l
         const organizationTypes = ['国家', 'ギルド', '秘密結社', '企業'];
         const organizationIds = new Set(
             allSettings
-                .filter(item => 
+                .filter(item =>
                     item.type === 'world' &&
-                    item.fields?.some(f => f.key === '種別' && organizationTypes.includes(f.value))
+                    // 種別が「その他」で自由入力された場合、値はプリセット文字列ではなく入力テキストそのものに
+                    // 置き換わる（WorldForm.tsx）ため、値の一致だけでなく保存時の groupKey（テンプレート由来）でも判定する。
+                    item.fields?.some(f => f.key === '種別' && (f.groupKey === 'organization' || organizationTypes.includes(f.value)))
                 )
                 .map(item => item.id)
         );


### PR DESCRIPTION
## Summary
PR #300（CharacterForm.tsx）と同根の不具合を修正（handoff #302 の同根再発スキャンで検出）。

- 世界観の「組織」で種別を「その他」にして自由入力すると、値がプリセット文字列ではなく入力テキストそのものに置き換わるため、`EventForm.tsx` の組織判定（プリセット4値とのハードコード一致）に引っかからず、本来は「場所」候補から除外されるべき組織がタイムラインイベントの発生場所候補に誤って表示されていた
- 保存時に付与される `groupKey`（テンプレート由来）でも判定するよう修正（PR #300と同一パターン）

## Test plan
- [x] `npm run lint`（tsc --noEmit）PASS
- [x] Playwright で再現・修正確認: 組織を種別「その他」で作成→イベントの発生場所候補から除外されることを確認、場所タイプの項目は引き続き候補に表示されることも確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)