### PR TITLE
docs(handoff): 同根バグ（EventForm）修正クローズセッションを記録

### DIFF
--- a/docs/handoff/2026-07-26-legal-cleanup-round2-character-affiliation-fix.md
+++ b/docs/handoff/2026-07-26-legal-cleanup-round2-character-affiliation-fix.md
@@ -1,0 +1,144 @@
+# Handoff: 2026-07-26 法務文書クリーンアップ第2弾（Vertex AI改称・内部識別子除去・明示同意フロー整合）+ キャラクター所属組織バグ修正
+
+- Session Date: 2026-07-26
+- Owner: yasushi-honda
+- Status: ✅ 完了（PR #299/#300/#301 マージ・dev/prod両方デプロイ確認済み）。⚠️ ただし §同根再発スキャン で未修正の同根バグ1件を検出、次アクション参照
+- Previous: [2026-07-24-legal-cleanup-ai-disclaimer-removal.md](./2026-07-24-legal-cleanup-ai-disclaimer-removal.md)
+
+## セッション要旨
+
+decision-makerが`https://novel-writer-df263ic6wa-an.a.run.app/legal/terms-of-service.html`・`privacy-policy.html`を実際に開いてスクリーンショット付きで詳細指摘。3件のPRで法務文書の内容修正 + キャラクター機能の不具合修正を行い、dev環境で実機検証後、prodへ手動デプロイした。
+
+## PR #299: 名称改称・未実装機能記述の除去、明示同意フローとの整合
+
+- **Vertex AI → Gemini Enterprise Agent Platform**: 2026年5月に公式改称（`cloud.google.com/vertex-ai`が`cloud.google.com/products/gemini-enterprise-agent-platform`にリダイレクトし、ページタイトル`"Gemini Enterprise Agent Platform (formerly Vertex AI)"`で一次ソース確認済み）
+- **＋ブックプラン / 2.4暗号化バックアップ節を全削除**: 「E2EEでクラウドにバックアップ」は実際には設計されていない機能（実際のM6暗号化バックアップはローカルファイルのExport/Import、自動クラウド同期ではない）だったため、decision-maker指摘により削除
+- **内部識別子の除去**: `email`/`uid`/`displayName`/`usage/{uid_yyyymm}`等のbacktick表記、`termsVersion`表記を除去し平文化。利用履歴の保存自体は実在（`usageService.ts`のTier1月100円上限管理）することを確認した上で文言のみ平文化
+- **Firebase Auth / DOMPurify等の実装技術名を除去**: §1.1アカウント情報取得の narrative、§6セキュリティ節から除去（§4.1委託先開示テーブルでのFirebase Auth/Firestore表記はPR #295の先例通り委託先開示として妥当なため維持）
+- **死んだ外部リンク削除**: `vertex-ai/docs/general/data-governance`が404であることを確認し削除
+- **空の箇条書き修正**: 禁止事項7番（TODOコメントのみで空表示）、改訂履歴の空bullet、§3.2末尾の空bulletを削除・非表示コメント化
+- **§1.1適用の書き換え**: 「利用した時点でみなし同意」という記述が、既に実装済みの明示同意モーダル（`TermsConsentModal.tsx`、ログイン時「同意して開始」ボタン）と矛盾していたため、「ログイン時は明示同意／未ログイン利用時はみなし同意」に書き分け
+- **TERMS_VERSION（`server/services/termsConfig.ts`）はbumpしない**: decision-maker判断（既存ユーザーの権利義務変更ではなく誤記是正が中心のため、既存ログイン済みユーザーへの再同意モーダル強制表示は不要と判断）
+
+## PR #300: キャラクター「所属組織」に「その他」自由入力の組織が出ない不具合を修正
+
+**症状**: 世界観の「組織」で種別を「その他」にして自由入力（例:「傭兵団」）すると、キャラクター作成モーダルの「所属組織」プルダウンにその組織が表示されない。
+
+**根本原因**: `components/modals/CharacterForm.tsx`の`organizationOptions`が、種別フィールドの値を`['国家','ギルド','秘密結社','企業']`とのハードコード一致で判定していた。しかし`WorldForm.tsx`側の実装では、「その他」を選び自由入力すると値がプリセット文字列ではなく**入力テキストそのものに置き換わる**ため、ハードコード一致に引っかからず候補から漏れていた。
+
+**修正**: 保存時に付与され`handleSaveSetting`まで永続化される`groupKey`（テンプレート由来識別子）でも判定するようOR条件を追加。既存のプリセット値一致判定は後方互換のため維持。
+
+**検証**: ローカル・dev環境（実際のCloud Run URL）の両方でPlaywrightにより再現→修正確認（組織を種別「その他」+自由入力で作成→キャラクターの所属組織プルダウンに表示されることを確認）。`npm run lint`（tsc --noEmit）PASS。
+
+## PR #301: 末尾の内部開発フェーズ表記（M7-α stub）を削除
+
+dev環境実機確認中にdecision-makerが「2026-04-28: M7-α stub 作成（未確定）」という改訂履歴の表示を発見し、「結局これなに？もしも必須でなければ表示させないでおきましょう」と指摘。社内の開発マイルストーン名+ドラフト状態を示す内部メモで一般ユーザーに意味が伝わらず、必須の法定記載事項でもないため4ファイルから削除。
+
+## デプロイ検証
+
+- **dev環境**（`novel-writer-ramnh3ulya-an.a.run.app`）: 各PRマージ後、`push→main`で`deploy.yml`が自動デプロイ。`gh run watch`で成功確認 + `gcloud run services describe`でイメージSHAがmain HEADと一致することを確認 + `curl`で実際のmd配信内容を直接確認（旧表記が0件）
+- **prod環境**（`novel-writer-df263ic6wa-an.a.run.app`）: decision-maker明示指示「客観的ゴール達成根拠を元に問題なければprodに反映」を受け、`gh workflow run "Deploy to Cloud Run (prod)"`（workflow_dispatch）で手動デプロイ。デプロイ後、イメージSHAが`main`HEAD（`e20cb23`）と完全一致することを`gcloud run services describe`で確認 + `curl`で法務文書の実配信内容を直接確認（バージョン行/＋ブックプラン/M7-α表記/Firebase Auth経由/内部識別子/死んだリンクいずれも0件）
+- キャラクター所属組織バグ修正について、prod上での実データ作成による再確認は行っていない（dev環境と全く同一のコミット・ビルドのため、実プロダクションデータを汚さない判断）
+
+## ドキュメント整合性
+
+| 項目 | 状態 | 備考 |
+|------|------|------|
+| GOAL.md ↔ 今セッション作業 | ✅ | 今セッションはGOAL.mdのミッション（開発者override機構、依然本田様実機確認待ちで変更なし）と無関係の別作業のため更新不要 |
+| CLAUDE.md ↔ 実装 | ✅ | 法務文書の内容修正のみでアーキテクチャ変更なし、更新不要 |
+| docs/legal ↔ public/legal | ✅ | 3PRとも両方同時更新、内容完全一致を確認 |
+
+## Git状態
+
+| 項目 | 状態 |
+|------|------|
+| 未コミット変更 | なし |
+| 未プッシュコミット | なし（`origin/main`と同期済み、`e20cb23`） |
+| CI/CD | ✅成功（dev自動デプロイ3回 + prod手動デプロイ1回、すべて成功） |
+
+## 品質ゲート
+
+| 項目 | 状態 |
+|------|------|
+| `/code-review` 実行 | 未実行。PR #299はdocs-large tier（4 files/152行）、PR #300はsmall tier（1 file/4行）、PR #301はtrivial tier（4 files/24行）— hookの tier判定でいずれも`/review-pr`6エージェント並列は過剰と判定され、手動チェックリストreview + broken link grep確認で代替（PR #299作成直後に`/code-review low`実行をdecision-makerに依頼したが、devへの反映を優先する判断で未実行のまま進行） |
+| Playwright実機検証 | ✅実施（PR #300、ローカル+dev環境で再現→修正確認の2回） |
+
+## 次のアクション（3分割）
+
+### 即着手タスクなし
+
+### 条件待ち（明示trigger付き）
+
+| # | 項目 | trigger | 充足時のタスク | 充足確認方法 |
+|---|------|---------|--------------|------------|
+| 1 | **`components/modals/EventForm.tsx`の同根バグ修正**（§同根再発スキャン参照、下記詳細） | decision-makerの修正指示 | PR #300と同じ修正パターン（`groupKey === 'organization'`判定の追加）を`EventForm.tsx:47-59`の`locationOptions`に適用 | `git diff`で該当箇所の現状確認 |
+| 2 | `/code-review low`（PR #299対象、既にマージ済みのため事後レビューとして実行） | decision-makerの実行判断 | 指摘があれば追加修正PRを作成 | 未実行のまま |
+| 3 | [GOAL.md] 開発者override実機確認の最終クローズ | 本田様ご自身がprodでAI機能を呼び出し「エラーが出なかった」と明示確認 | GOAL.mdの該当チェックボックスを`[x]`にし完了記録 | 本田様への確認 |
+| 4 | Issue #232/#152/#147/#137 | 各Issue本文記載のtrigger、または本田様の優先度指示 | 各Issue本文参照 | `gh issue view <番号>` |
+
+### 却下候補（記録のみ）
+
+なし（前セッションの却下候補3件はdecision-maker明示却下済みで変更なし、参照: `2026-07-24-legal-cleanup-ai-disclaimer-removal.md`）
+
+## 同根再発スキャン（§4.6、必須実施）
+
+本セッションにPR #300（`fix:`プレフィックス）が含まれるため詳細スキャンを実施。**1件の未修正・同根バグを検出した**（STOP対象）。
+
+**検出内容**: `components/modals/EventForm.tsx:47-59`の`locationOptions`（タイムラインイベントの「場所」プルダウン候補生成ロジック）が、PR #300で修正した`CharacterForm.tsx`の`organizationOptions`と全く同じ「種別プリセット値ハードコード判定」パターンを持つ:
+
+```js
+const organizationTypes = ['国家', 'ギルド', '秘密結社', '企業'];
+const organizationIds = new Set(
+    allSettings.filter(item => item.type === 'world' &&
+        item.fields?.some(f => f.key === '種別' && organizationTypes.includes(f.value))
+    ).map(item => item.id)
+);
+return allSettings.filter(item => item.type === 'world' && !organizationIds.has(item.id));
+```
+
+**症状の向き**: `CharacterForm.tsx`とは逆方向のバグ。組織を種別「その他」+自由入力で作成すると`organizationTypes`に一致せず`organizationIds`に含まれないため、**タイムラインイベントの「場所」プルダウンに組織が誤って表示される**（本来は場所ではないため除外されるべき）。
+
+**根本原因仮説（3件）**:
+1. `CharacterForm.tsx`と`EventForm.tsx`は組織/非組織判定ロジックを共通ヘルパー化せず独立実装しており、同じ誤った前提（種別値はプリセット文字列のみ）が2箇所にコピー的に実装された
+2. `groupKey`によるテンプレート追跡機構（`WorldForm.tsx`→`handleSaveSetting`まで永続化）はデータモデルの後付け拡張で、既存の種別値ハードコード判定を持つ全消費箇所への遡及的な置き換えが行われなかった
+3. 「その他」自由入力時に値がプリセット文字列から入力テキストへ完全に置き換わるという`WorldForm.tsx`の挙動が非自明で、この挙動を知らないまま複数箇所で同じ前提のコードが書かれた
+
+**再発しうる経路**: 今回のgrepスキャンでは`EventForm.tsx`以外に同パターンは検出されなかった（`PlotBoardModal.tsx`等は文言参照のみでロジック不在）。ただし今後、世界観テンプレート種別（場所/組織/魔法技術/歴史上の出来事/重要アイテム）を種別値で判定する新規コードが追加されるたびに、同じ「その他」自由入力の値置き換え問題が再発しうる。
+
+**対応**: 「条件待ち」#1として記録。decision-maker指示がない限りAI側から修正に着手しない（守り＝検出まで、修正はdecision-maker領分）。
+
+## 対症療法判定（§4.7）
+
+PR #300について判定。4基準いずれにも該当せず、対症療法ではなく根本原因修正と判定:
+1. retry/fallback等の症状遮断ではなく、`groupKey`という構造的識別子を使った根本原因修正
+2. 「なぜ今起きたか」の調査済み（`WorldForm.tsx`の値置き換え挙動をコードリーディングで特定、Playwright再現で確証）
+3. 過去30日以内の同症状PRなし
+4. 修正後の動作確認はローカル+dev環境の実ブラウザ操作（Playwright）で実施、単体テスト/smokeのみではない
+
+## Issue Net 変化
+
+- Close数: 0件
+- 起票数: 0件
+- Net: 0件（本セッションはIssue追跡と無関係な法務文書コンテンツ整備+直接修正のため、Net 0は中立であり進捗ゼロの警告には該当しない。EventForm.tsxの同根バグも、triage基準を満たすかdecision-maker判断待ちのためIssue化せず「条件待ち」に記録）
+
+## 残留プロセスチェック
+
+✅ 残留プロセスなし（本プロジェクトのdev serverは確認後に停止済み、マシン全体のNode残留プロセスも検出されず）
+
+## 再開可能性判定
+
+✅ **再開可能** - ドキュメントから開発再開できます。即着手タスク0件、全て条件待ち（うち1件は未修正の同根バグ）。
+
+## 最終結論
+
+⚠️ **セッション終了前に要対応が1件あるが、対応済みタスクとしてはセッション終了可** — 本セッションの作業自体（法務文書修正3PR+バグ修正1PR、dev/prod反映）は完了・クリーンだが、§4.6同根再発スキャンで`EventForm.tsx`に未修正の同根バグを検出したため、次セッションへの引き継ぎ事項として明示する
+
+- OPEN PR: 0件（#299/#300/#301すべてマージ・ブランチ削除済み）
+- active Issue: 4件（#232/#152/#147/#137、すべてdecision-maker明示指示待ちまたはtrigger待ち）
+- Git: clean（`main`ブランチ、`origin/main`と同期済み、`e20cb23`）
+- 即着手タスク: 0件 / 条件待ち: 4件（新規: EventForm.tsx同根バグ修正、/code-review low事後実行） / 却下候補: 0件
+- 同根再発スキャン（§4.6）: **1件検出**（`EventForm.tsx:47-59`、条件待ち#1として記録、decision-maker指示待ち）
+- 対症療法判定（§4.7）: 該当なし（PR #300は根本原因修正と判定）
+- 残留プロセス: なし
+- テスト: `npm run lint` PASS（3PRとも）。既存のvitestスイートに変更なし（対象コードパスはserver/middleware・routesの契約テスト対象外のReactコンポーネントのため、Playwright実機検証で代替）
+- 既知のblocker: なし（EventForm.tsx修正は技術的には即実行可能だが、decision-makerの修正指示待ちとして意図的に保留）

--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -1,67 +1,50 @@
-# Handoff: 2026-07-26 法務文書クリーンアップ第2弾（Vertex AI改称・内部識別子除去・明示同意フロー整合）+ キャラクター所属組織バグ修正
+# Handoff: 2026-07-26b 同根バグ（EventForm）修正クローズ
 
 - Session Date: 2026-07-26
 - Owner: yasushi-honda
-- Status: ✅ 完了（PR #299/#300/#301 マージ・dev/prod両方デプロイ確認済み）。⚠️ ただし §同根再発スキャン で未修正の同根バグ1件を検出、次アクション参照
-- Previous: [2026-07-24-legal-cleanup-ai-disclaimer-removal.md](./2026-07-24-legal-cleanup-ai-disclaimer-removal.md)
+- Status: ✅ 完了（PR #303 マージ・dev/prod両方デプロイ確認済み）。前回handoff（PR #302）で検出した同根バグを解消
+- Previous: [2026-07-26-legal-cleanup-round2-character-affiliation-fix.md](./2026-07-26-legal-cleanup-round2-character-affiliation-fix.md)
 
 ## セッション要旨
 
-decision-makerが`https://novel-writer-df263ic6wa-an.a.run.app/legal/terms-of-service.html`・`privacy-policy.html`を実際に開いてスクリーンショット付きで詳細指摘。3件のPRで法務文書の内容修正 + キャラクター機能の不具合修正を行い、dev環境で実機検証後、prodへ手動デプロイした。
+前回handoff（PR #302）の§4.6同根再発スキャンで検出した`EventForm.tsx`の未修正バグについて、decision-makerがAskUserQuestionで「今すぐ同じパターンで修正する」を選択したため、本セッション継続内で対応・検証・dev/prod両反映まで完了した。
 
-## PR #299: 名称改称・未実装機能記述の除去、明示同意フローとの整合
+## PR #303: 組織「その他」自由入力がイベントの場所候補に誤って出る不具合を修正
 
-- **Vertex AI → Gemini Enterprise Agent Platform**: 2026年5月に公式改称（`cloud.google.com/vertex-ai`が`cloud.google.com/products/gemini-enterprise-agent-platform`にリダイレクトし、ページタイトル`"Gemini Enterprise Agent Platform (formerly Vertex AI)"`で一次ソース確認済み）
-- **＋ブックプラン / 2.4暗号化バックアップ節を全削除**: 「E2EEでクラウドにバックアップ」は実際には設計されていない機能（実際のM6暗号化バックアップはローカルファイルのExport/Import、自動クラウド同期ではない）だったため、decision-maker指摘により削除
-- **内部識別子の除去**: `email`/`uid`/`displayName`/`usage/{uid_yyyymm}`等のbacktick表記、`termsVersion`表記を除去し平文化。利用履歴の保存自体は実在（`usageService.ts`のTier1月100円上限管理）することを確認した上で文言のみ平文化
-- **Firebase Auth / DOMPurify等の実装技術名を除去**: §1.1アカウント情報取得の narrative、§6セキュリティ節から除去（§4.1委託先開示テーブルでのFirebase Auth/Firestore表記はPR #295の先例通り委託先開示として妥当なため維持）
-- **死んだ外部リンク削除**: `vertex-ai/docs/general/data-governance`が404であることを確認し削除
-- **空の箇条書き修正**: 禁止事項7番（TODOコメントのみで空表示）、改訂履歴の空bullet、§3.2末尾の空bulletを削除・非表示コメント化
-- **§1.1適用の書き換え**: 「利用した時点でみなし同意」という記述が、既に実装済みの明示同意モーダル（`TermsConsentModal.tsx`、ログイン時「同意して開始」ボタン）と矛盾していたため、「ログイン時は明示同意／未ログイン利用時はみなし同意」に書き分け
-- **TERMS_VERSION（`server/services/termsConfig.ts`）はbumpしない**: decision-maker判断（既存ユーザーの権利義務変更ではなく誤記是正が中心のため、既存ログイン済みユーザーへの再同意モーダル強制表示は不要と判断）
+**症状**: 世界観の「組織」を種別「その他」で自由入力すると、そのタイムラインイベントの「発生場所」プルダウン候補に誤って表示される（本来は場所ではないため除外されるべき）。
 
-## PR #300: キャラクター「所属組織」に「その他」自由入力の組織が出ない不具合を修正
+**根本原因**: `components/modals/EventForm.tsx`の`locationOptions`が、`CharacterForm.tsx`（PR #300で修正済み）と全く同じ「種別プリセット値ハードコード判定」パターンを持っていた。組織を除外する側の`organizationIds`集合の判定が`['国家','ギルド','秘密結社','企業']`とのハードコード一致のみで、「その他」自由入力時にプリセット文字列ではなく入力テキストそのものに置き換わる`WorldForm.tsx`の挙動に対応していなかった。症状の向きはPR #300とは逆（除外されるべきものが漏れて表示される）だが、根本原因は同一。
 
-**症状**: 世界観の「組織」で種別を「その他」にして自由入力（例:「傭兵団」）すると、キャラクター作成モーダルの「所属組織」プルダウンにその組織が表示されない。
+**修正**: PR #300と全く同じパターン（`groupKey === 'organization'`判定のOR追加）を適用。
 
-**根本原因**: `components/modals/CharacterForm.tsx`の`organizationOptions`が、種別フィールドの値を`['国家','ギルド','秘密結社','企業']`とのハードコード一致で判定していた。しかし`WorldForm.tsx`側の実装では、「その他」を選び自由入力すると値がプリセット文字列ではなく**入力テキストそのものに置き換わる**ため、ハードコード一致に引っかからず候補から漏れていた。
-
-**修正**: 保存時に付与され`handleSaveSetting`まで永続化される`groupKey`（テンプレート由来識別子）でも判定するようOR条件を追加。既存のプリセット値一致判定は後方互換のため維持。
-
-**検証**: ローカル・dev環境（実際のCloud Run URL）の両方でPlaywrightにより再現→修正確認（組織を種別「その他」+自由入力で作成→キャラクターの所属組織プルダウンに表示されることを確認）。`npm run lint`（tsc --noEmit）PASS。
-
-## PR #301: 末尾の内部開発フェーズ表記（M7-α stub）を削除
-
-dev環境実機確認中にdecision-makerが「2026-04-28: M7-α stub 作成（未確定）」という改訂履歴の表示を発見し、「結局これなに？もしも必須でなければ表示させないでおきましょう」と指摘。社内の開発マイルストーン名+ドラフト状態を示す内部メモで一般ユーザーに意味が伝わらず、必須の法定記載事項でもないため4ファイルから削除。
+**検証**: ローカルPlaywrightで再現→修正確認。「組織」（種別その他+自由入力「傭兵団」）を作成→イベントの発生場所候補から除外されることを確認。対照として「場所」（種別デフォルト「都市」）も作成→こちらは正しく候補に表示されることを確認（過剰除外していないことも確認）。`npm run lint`（tsc --noEmit）PASS。
 
 ## デプロイ検証
 
-- **dev環境**（`novel-writer-ramnh3ulya-an.a.run.app`）: 各PRマージ後、`push→main`で`deploy.yml`が自動デプロイ。`gh run watch`で成功確認 + `gcloud run services describe`でイメージSHAがmain HEADと一致することを確認 + `curl`で実際のmd配信内容を直接確認（旧表記が0件）
-- **prod環境**（`novel-writer-df263ic6wa-an.a.run.app`）: decision-maker明示指示「客観的ゴール達成根拠を元に問題なければprodに反映」を受け、`gh workflow run "Deploy to Cloud Run (prod)"`（workflow_dispatch）で手動デプロイ。デプロイ後、イメージSHAが`main`HEAD（`e20cb23`）と完全一致することを`gcloud run services describe`で確認 + `curl`で法務文書の実配信内容を直接確認（バージョン行/＋ブックプラン/M7-α表記/Firebase Auth経由/内部識別子/死んだリンクいずれも0件）
-- キャラクター所属組織バグ修正について、prod上での実データ作成による再確認は行っていない（dev環境と全く同一のコミット・ビルドのため、実プロダクションデータを汚さない判断）
+- **dev環境**: `push→main`で`deploy.yml`自動デプロイ、`gh run watch`で成功確認
+- **prod環境**: decision-maker明示指示「今すぐprodに反映する」を受け、`gh workflow run "Deploy to Cloud Run (prod)"`で手動デプロイ、`gcloud run services describe`でイメージSHAが`main`HEAD（`9266028`）と完全一致することを確認
 
 ## ドキュメント整合性
 
 | 項目 | 状態 | 備考 |
 |------|------|------|
 | GOAL.md ↔ 今セッション作業 | ✅ | 今セッションはGOAL.mdのミッション（開発者override機構、依然本田様実機確認待ちで変更なし）と無関係の別作業のため更新不要 |
-| CLAUDE.md ↔ 実装 | ✅ | 法務文書の内容修正のみでアーキテクチャ変更なし、更新不要 |
-| docs/legal ↔ public/legal | ✅ | 3PRとも両方同時更新、内容完全一致を確認 |
+| CLAUDE.md ↔ 実装 | ✅ | ロジック修正のみでアーキテクチャ変更なし、更新不要 |
 
 ## Git状態
 
 | 項目 | 状態 |
 |------|------|
 | 未コミット変更 | なし |
-| 未プッシュコミット | なし（`origin/main`と同期済み、`e20cb23`） |
-| CI/CD | ✅成功（dev自動デプロイ3回 + prod手動デプロイ1回、すべて成功） |
+| 未プッシュコミット | なし（`origin/main`と同期済み、`9266028`） |
+| CI/CD | ✅成功（dev自動デプロイ1回 + prod手動デプロイ1回） |
 
 ## 品質ゲート
 
 | 項目 | 状態 |
 |------|------|
-| `/code-review` 実行 | 未実行。PR #299はdocs-large tier（4 files/152行）、PR #300はsmall tier（1 file/4行）、PR #301はtrivial tier（4 files/24行）— hookの tier判定でいずれも`/review-pr`6エージェント並列は過剰と判定され、手動チェックリストreview + broken link grep確認で代替（PR #299作成直後に`/code-review low`実行をdecision-makerに依頼したが、devへの反映を優先する判断で未実行のまま進行） |
-| Playwright実機検証 | ✅実施（PR #300、ローカル+dev環境で再現→修正確認の2回） |
+| `/code-review` 実行 | 未実行。small tier（1 file/6行）のためhook判定で手動チェックリストreview可、decision-maker承認を得てマージ |
+| Playwright実機検証 | ✅実施（ローカルで再現→修正確認、組織除外+場所包含の両方をpositive/negative両面で確認） |
 
 ## 次のアクション（3分割）
 
@@ -71,74 +54,46 @@ dev環境実機確認中にdecision-makerが「2026-04-28: M7-α stub 作成（�
 
 | # | 項目 | trigger | 充足時のタスク | 充足確認方法 |
 |---|------|---------|--------------|------------|
-| 1 | **`components/modals/EventForm.tsx`の同根バグ修正**（§同根再発スキャン参照、下記詳細） | decision-makerの修正指示 | PR #300と同じ修正パターン（`groupKey === 'organization'`判定の追加）を`EventForm.tsx:47-59`の`locationOptions`に適用 | `git diff`で該当箇所の現状確認 |
-| 2 | `/code-review low`（PR #299対象、既にマージ済みのため事後レビューとして実行） | decision-makerの実行判断 | 指摘があれば追加修正PRを作成 | 未実行のまま |
-| 3 | [GOAL.md] 開発者override実機確認の最終クローズ | 本田様ご自身がprodでAI機能を呼び出し「エラーが出なかった」と明示確認 | GOAL.mdの該当チェックボックスを`[x]`にし完了記録 | 本田様への確認 |
-| 4 | Issue #232/#152/#147/#137 | 各Issue本文記載のtrigger、または本田様の優先度指示 | 各Issue本文参照 | `gh issue view <番号>` |
+| 1 | [GOAL.md] 開発者override実機確認の最終クローズ | 本田様ご自身がprodでAI機能を呼び出し「エラーが出なかった」と明示確認 | GOAL.mdの該当チェックボックスを`[x]`にし完了記録 | 本田様への確認 |
+| 2 | `/code-review low`（PR #299対象、事後レビュー） | decision-makerの実行判断 | 指摘があれば追加修正PRを作成 | 未実行のまま（前回handoffから持ち越し） |
+| 3 | Issue #232/#152/#147/#137 | 各Issue本文記載のtrigger、または本田様の優先度指示 | 各Issue本文参照 | `gh issue view <番号>` |
 
 ### 却下候補（記録のみ）
 
-なし（前セッションの却下候補3件はdecision-maker明示却下済みで変更なし、参照: `2026-07-24-legal-cleanup-ai-disclaimer-removal.md`）
+なし
 
 ## 同根再発スキャン（§4.6、必須実施）
 
-本セッションにPR #300（`fix:`プレフィックス）が含まれるため詳細スキャンを実施。**1件の未修正・同根バグを検出した**（STOP対象）。
-
-**検出内容**: `components/modals/EventForm.tsx:47-59`の`locationOptions`（タイムラインイベントの「場所」プルダウン候補生成ロジック）が、PR #300で修正した`CharacterForm.tsx`の`organizationOptions`と全く同じ「種別プリセット値ハードコード判定」パターンを持つ:
-
-```js
-const organizationTypes = ['国家', 'ギルド', '秘密結社', '企業'];
-const organizationIds = new Set(
-    allSettings.filter(item => item.type === 'world' &&
-        item.fields?.some(f => f.key === '種別' && organizationTypes.includes(f.value))
-    ).map(item => item.id)
-);
-return allSettings.filter(item => item.type === 'world' && !organizationIds.has(item.id));
-```
-
-**症状の向き**: `CharacterForm.tsx`とは逆方向のバグ。組織を種別「その他」+自由入力で作成すると`organizationTypes`に一致せず`organizationIds`に含まれないため、**タイムラインイベントの「場所」プルダウンに組織が誤って表示される**（本来は場所ではないため除外されるべき）。
-
-**根本原因仮説（3件）**:
-1. `CharacterForm.tsx`と`EventForm.tsx`は組織/非組織判定ロジックを共通ヘルパー化せず独立実装しており、同じ誤った前提（種別値はプリセット文字列のみ）が2箇所にコピー的に実装された
-2. `groupKey`によるテンプレート追跡機構（`WorldForm.tsx`→`handleSaveSetting`まで永続化）はデータモデルの後付け拡張で、既存の種別値ハードコード判定を持つ全消費箇所への遡及的な置き換えが行われなかった
-3. 「その他」自由入力時に値がプリセット文字列から入力テキストへ完全に置き換わるという`WorldForm.tsx`の挙動が非自明で、この挙動を知らないまま複数箇所で同じ前提のコードが書かれた
-
-**再発しうる経路**: 今回のgrepスキャンでは`EventForm.tsx`以外に同パターンは検出されなかった（`PlotBoardModal.tsx`等は文言参照のみでロジック不在）。ただし今後、世界観テンプレート種別（場所/組織/魔法技術/歴史上の出来事/重要アイテム）を種別値で判定する新規コードが追加されるたびに、同じ「その他」自由入力の値置き換え問題が再発しうる。
-
-**対応**: 「条件待ち」#1として記録。decision-maker指示がない限りAI側から修正に着手しない（守り＝検出まで、修正はdecision-maker領分）。
+本セッションにPR #303（`fix:`プレフィックス）が含まれるため実施。**前回handoff（PR #302）で検出した同根バグ（`EventForm.tsx`）は本PRで解消済み**。追加の同根候補を再スキャンした結果、`CharacterForm.tsx`・`EventForm.tsx`以外に同パターン（種別値ハードコード判定）は検出されず（`organizationTypes`/`groupKey === 'organization'`でのgrep再実施、2ファイルのみヒットしいずれも修正済み）。新規の同根候補は0件。
 
 ## 対症療法判定（§4.7）
 
-PR #300について判定。4基準いずれにも該当せず、対症療法ではなく根本原因修正と判定:
-1. retry/fallback等の症状遮断ではなく、`groupKey`という構造的識別子を使った根本原因修正
-2. 「なぜ今起きたか」の調査済み（`WorldForm.tsx`の値置き換え挙動をコードリーディングで特定、Playwright再現で確証）
-3. 過去30日以内の同症状PRなし
-4. 修正後の動作確認はローカル+dev環境の実ブラウザ操作（Playwright）で実施、単体テスト/smokeのみではない
+PR #303について判定。4基準いずれにも該当せず、根本原因修正と判定（PR #300と同一理由: retry/fallback等ではなく構造的識別子による修正、根本原因調査済み、過去30日以内の同症状PRなし、実ブラウザ操作での動作確認実施）。
 
 ## Issue Net 変化
 
 - Close数: 0件
 - 起票数: 0件
-- Net: 0件（本セッションはIssue追跡と無関係な法務文書コンテンツ整備+直接修正のため、Net 0は中立であり進捗ゼロの警告には該当しない。EventForm.tsxの同根バグも、triage基準を満たすかdecision-maker判断待ちのためIssue化せず「条件待ち」に記録）
+- Net: 0件（EventForm.tsxの同根バグは前回handoffで検出時点からIssue化せず直接修正のため、Issue Netには影響なし）
 
 ## 残留プロセスチェック
 
-✅ 残留プロセスなし（本プロジェクトのdev serverは確認後に停止済み、マシン全体のNode残留プロセスも検出されず）
+✅ 残留プロセスなし
 
 ## 再開可能性判定
 
-✅ **再開可能** - ドキュメントから開発再開できます。即着手タスク0件、全て条件待ち（うち1件は未修正の同根バグ）。
+✅ **再開可能** - ドキュメントから開発再開できます。即着手タスク0件、全て条件待ち。
 
 ## 最終結論
 
-⚠️ **セッション終了前に要対応が1件あるが、対応済みタスクとしてはセッション終了可** — 本セッションの作業自体（法務文書修正3PR+バグ修正1PR、dev/prod反映）は完了・クリーンだが、§4.6同根再発スキャンで`EventForm.tsx`に未修正の同根バグを検出したため、次セッションへの引き継ぎ事項として明示する
+✅ **セッション終了可** — 前回handoff（PR #302）で検出した同根バグを含め、本セッションの全作業が完了・クリーン
 
-- OPEN PR: 0件（#299/#300/#301すべてマージ・ブランチ削除済み）
+- OPEN PR: 0件（#303マージ・ブランチ削除済み）
 - active Issue: 4件（#232/#152/#147/#137、すべてdecision-maker明示指示待ちまたはtrigger待ち）
-- Git: clean（`main`ブランチ、`origin/main`と同期済み、`e20cb23`）
-- 即着手タスク: 0件 / 条件待ち: 4件（新規: EventForm.tsx同根バグ修正、/code-review low事後実行） / 却下候補: 0件
-- 同根再発スキャン（§4.6）: **1件検出**（`EventForm.tsx:47-59`、条件待ち#1として記録、decision-maker指示待ち）
-- 対症療法判定（§4.7）: 該当なし（PR #300は根本原因修正と判定）
+- Git: clean（`main`ブランチ、`origin/main`と同期済み、`9266028`）
+- 即着手タスク: 0件 / 条件待ち: 3件 / 却下候補: 0件
+- 同根再発スキャン（§4.6）: 前回検出分は解消、新規0件
+- 対症療法判定（§4.7）: 該当なし
 - 残留プロセス: なし
-- テスト: `npm run lint` PASS（3PRとも）。既存のvitestスイートに変更なし（対象コードパスはserver/middleware・routesの契約テスト対象外のReactコンポーネントのため、Playwright実機検証で代替）
-- 既知のblocker: なし（EventForm.tsx修正は技術的には即実行可能だが、decision-makerの修正指示待ちとして意図的に保留）
+- テスト: `npm run lint` PASS
+- 既知のblocker: なし（残タスクは全てdecision-makerの確認・判断待ち）


### PR DESCRIPTION
## Summary
- PR #303（EventForm.tsxの組織「その他」自由入力バグ修正、前回handoff #302 の同根再発スキャンで検出）のdev/prod反映完了を記録
- 前回handoff内容を `docs/handoff/2026-07-26-legal-cleanup-round2-character-affiliation-fix.md` にアーカイブ

## Test plan
- [x] handoffファイルサイズ・最長行チェック（14KB台、記法ドリフトなし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)