### PR TITLE
fix(dev-portal): 開発者ポータル2ページにfaviconを追加

### DIFF
--- a/public/dev/index.html
+++ b/public/dev/index.html
@@ -6,6 +6,9 @@
 <meta name="robots" content="noindex,nofollow" />
 <title>小説らいたー — Developer Atlas</title>
 <meta name="description" content="novel-writer プロジェクトの開発者向けポータル。アーキテクチャ俯瞰・目視チェックリスト・簡易マニュアル。" />
+<link rel="icon" type="image/svg+xml" href="/branding/favicon.svg">
+<link rel="icon" type="image/png" sizes="32x32" href="/branding/favicon-32.png">
+<link rel="apple-touch-icon" href="/branding/apple-touch-icon.png">
 
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/public/dev/sns.html
+++ b/public/dev/sns.html
@@ -6,6 +6,9 @@
 <meta name="robots" content="noindex,nofollow" />
 <title>小説らいたー — SNS投稿キット</title>
 <meta name="description" content="novel-writer の SNS 投稿準備素材。アプリ概要・主要機能スクリーンショット・投稿文言ドラフトを1ページにまとめたもの。" />
+<link rel="icon" type="image/svg+xml" href="/branding/favicon.svg">
+<link rel="icon" type="image/png" sizes="32x32" href="/branding/favicon-32.png">
+<link rel="apple-touch-icon" href="/branding/apple-touch-icon.png">
 
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />


### PR DESCRIPTION
## Summary
- `public/dev/index.html`（Developer Atlas）・`public/dev/sns.html`（SNS投稿キット）は、SPA本体の`index.html`とは別の独立した静的HTMLで、favicon指定を一切継承していなかった（ブラウザ既定アイコンが表示される状態）
- 両ページの`<head>`に、#308で追加済みのブランドアセット（`/branding/favicon.svg` + PNG(32x32)/apple-touch-icon(180x180)フォールバック）へのリンクを追加

## Test plan
- [x] ローカル静的配信（`public/`起点）で `dev/index.html`・`dev/sns.html` が200 OK、`/branding/favicon.svg`等の参照先も200 OKで到達可能なことを確認
- [x] Playwrightで`dev/index.html`を読み込み、ネットワークリクエストで`/branding/favicon.svg`が実際に取得されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q3xjtVWk2YSQBZAmkCroeL