### PR TITLE
fix(scope): アプリ本体のfaviconフォールバック追加(#308)を取り消し

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,8 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>小説らいたー</title>
     <link rel="icon" type="image/svg+xml" href="/branding/favicon.svg">
-    <link rel="icon" type="image/png" sizes="32x32" href="/branding/favicon-32.png">
-    <link rel="apple-touch-icon" href="/branding/apple-touch-icon.png">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Kiwi+Maru&family=M+PLUS+Rounded+1c:wght@400;700&family=Noto+Sans+JP:wght@400;700&family=Noto+Serif+JP:wght@400;700&family=Sawarabi+Mincho&family=Yuji+Syuku&display=swap" rel="stylesheet">


### PR DESCRIPTION
## Summary
- #308（アプリ本体`index.html`へのPNG/apple-touch-iconフォールバック追加）はスコープ誤り
- 今回のユーザーオーダーは「ドキュメントをまとめたWebページ（`/dev/`配下の開発者ポータル）」へのfavicon追加であり、アプリ本体には元々`favicon.svg`が設定・配信済みで変更は不要だった
- `index.html`から今回追加した2行（PNG / apple-touch-icon の`<link>`）のみを削除
- PNGアセット自体（`public/branding/favicon-32.png` / `apple-touch-icon.png`）は#309で`/dev/index.html`・`/dev/sns.html`が引き続き参照しているため削除しない

## Test plan
- [x] `grep`で`/dev/index.html`・`/dev/sns.html`が引き続き該当PNGを参照していることを確認
- [x] `git diff --stat`で`index.html`のみ2行削除、他ファイルへの影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q3xjtVWk2YSQBZAmkCroeL