### PR TITLE
fix(dev-portal): マネタイズロードマップ段落の可読性を改善

### DIFF
--- a/public/dev/index.html
+++ b/public/dev/index.html
@@ -1143,13 +1143,12 @@ gantt
 
   <h3 class="h-rule">マネタイズロードマップ（予備検討） <span class="small">/ M5 Pre-research</span></h3>
   <p style="max-width: 65ch;">
-    M5（Tier 2 有料化）着手前の予備調査として、決済基盤各社の一次情報比較を実施（2026-09-06）。
-    サービス規模がまだ小さい段階のため、<strong>まずは事業適格性の審査が不要な標準 Stripe（Billing + Tax）でシンプルに始める方針</strong>（本人確認・銀行口座紐付け等の通常のアカウント有効化は別途必要）。
-    Managed Payments（消費税・請求書処理までまとめて代行する追加オプション、事業形態・地域による利用資格審査あり）は、
-    規模が大きくなってから改めて検討する後回し事項。<strong>着手時期そのものは本田様判断待ちで未定</strong>。
-    詳細は <code>.claude/memory/payment_provider_reference_2026-09.md</code>（決済基盤比較）・
-    <code>.claude/memory/pricing_tier2_reference_2026-06.md</code>（価格設定）を参照。
+    M5（Tier 2 有料化）着手前の予備調査として、決済基盤各社の一次情報比較を実施（2026-09-06）。サービス規模がまだ小さい段階のため、まずは事業適格性の審査が不要な標準 Stripe（Billing + Tax）でシンプルに始める方針とする。Managed Payments（消費税・請求書処理までまとめて代行する追加オプション）は規模拡大後に改めて検討する後回し事項とし、<strong>着手時期そのものは本田様判断待ちで未定</strong>。
   </p>
+
+  <div class="callout">
+    <p><strong>参考資料:</strong> <code>.claude/memory/payment_provider_reference_2026-09.md</code>（決済基盤比較）／ <code>.claude/memory/pricing_tier2_reference_2026-06.md</code>（価格設定）</p>
+  </div>
 
   <div class="diagram" data-fig="Fig. IV-2 / Monetization Roadmap">
     <div class="mermaid">


### PR DESCRIPTION
## Summary
- PR #312 で追加したマネタイズロードマップ紹介文を、実機スクリーンショットでの指摘（太字乱用・長いファイルパスの不自然な折り返し）を受けて整理
- 参考資料へのリンクは既存の `.callout` パーツに分離

## Test plan
- [x] `public/` を静的配信し Playwright MCP で実機確認（コンソールエラー0件、段落6行に収まり callout も崩れなし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017QaLXeEDJQ15HWAPUWszAM